### PR TITLE
Add UnhandledMethodHandler for receiver-side fallback dispatch

### DIFF
--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -288,6 +288,10 @@ public final class com/monkopedia/ksrpc/Transformer$DefaultImpls {
 	public static fun unpackError (Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
 }
 
+public abstract interface class com/monkopedia/ksrpc/UnhandledMethodHandler {
+	public abstract fun onUnhandled (Ljava/lang/String;Lcom/monkopedia/ksrpc/channels/CallData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract class com/monkopedia/ksrpc/channels/CallData {
 	public static final field Companion Lcom/monkopedia/ksrpc/channels/CallData$Companion;
 	public abstract fun isBinary ()Z

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -90,10 +90,6 @@ abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc/KsrpcEnvironment { // 
     }
 }
 
-abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc/UnhandledMethodHandler { // com.monkopedia.ksrpc/UnhandledMethodHandler|null[0]
-    abstract suspend fun onUnhandled(kotlin/String, com.monkopedia.ksrpc.channels/CallData<#A>): com.monkopedia.ksrpc.channels/CallData<#A> // com.monkopedia.ksrpc/UnhandledMethodHandler.onUnhandled|onUnhandled(kotlin.String;com.monkopedia.ksrpc.channels.CallData<1:0>){}[0]
-}
-
 abstract interface com.monkopedia.ksrpc.channels/CancellationSupport { // com.monkopedia.ksrpc.channels/CancellationSupport|null[0]
     abstract fun cancelHandler(com.monkopedia.ksrpc.channels/RpcCallId, kotlin.coroutines.cancellation/CancellationException? = ...) // com.monkopedia.ksrpc.channels/CancellationSupport.cancelHandler|cancelHandler(com.monkopedia.ksrpc.channels.RpcCallId;kotlin.coroutines.cancellation.CancellationException?){}[0]
     abstract fun registerHandler(com.monkopedia.ksrpc.channels/RpcCallId, kotlinx.coroutines/Job) // com.monkopedia.ksrpc.channels/CancellationSupport.registerHandler|registerHandler(com.monkopedia.ksrpc.channels.RpcCallId;kotlinx.coroutines.Job){}[0]
@@ -121,6 +117,10 @@ abstract interface com.monkopedia.ksrpc/ServiceExecutor { // com.monkopedia.ksrp
 
 abstract interface com.monkopedia.ksrpc/SuspendCloseableObservable : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc/SuspendCloseableObservable|null[0]
     abstract suspend fun onClose(kotlin.coroutines/SuspendFunction0<kotlin/Unit>) // com.monkopedia.ksrpc/SuspendCloseableObservable.onClose|onClose(kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
+}
+
+abstract interface com.monkopedia.ksrpc/UnhandledMethodHandler { // com.monkopedia.ksrpc/UnhandledMethodHandler|null[0]
+    abstract suspend fun <#A1: kotlin/Any?> onUnhandled(kotlin/String, com.monkopedia.ksrpc.channels/CallData<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/UnhandledMethodHandler.onUnhandled|onUnhandled(kotlin.String;com.monkopedia.ksrpc.channels.CallData<0:0>){0§<kotlin.Any?>}[0]
 }
 
 sealed interface <#A: kotlin/Any?> com.monkopedia.ksrpc/Transformer { // com.monkopedia.ksrpc/Transformer|null[0]

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -90,6 +90,10 @@ abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc/KsrpcEnvironment { // 
     }
 }
 
+abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc/UnhandledMethodHandler { // com.monkopedia.ksrpc/UnhandledMethodHandler|null[0]
+    abstract suspend fun onUnhandled(kotlin/String, com.monkopedia.ksrpc.channels/CallData<#A>): com.monkopedia.ksrpc.channels/CallData<#A> // com.monkopedia.ksrpc/UnhandledMethodHandler.onUnhandled|onUnhandled(kotlin.String;com.monkopedia.ksrpc.channels.CallData<1:0>){}[0]
+}
+
 abstract interface com.monkopedia.ksrpc.channels/CancellationSupport { // com.monkopedia.ksrpc.channels/CancellationSupport|null[0]
     abstract fun cancelHandler(com.monkopedia.ksrpc.channels/RpcCallId, kotlin.coroutines.cancellation/CancellationException? = ...) // com.monkopedia.ksrpc.channels/CancellationSupport.cancelHandler|cancelHandler(com.monkopedia.ksrpc.channels.RpcCallId;kotlin.coroutines.cancellation.CancellationException?){}[0]
     abstract fun registerHandler(com.monkopedia.ksrpc.channels/RpcCallId, kotlinx.coroutines/Job) // com.monkopedia.ksrpc.channels/CancellationSupport.registerHandler|registerHandler(com.monkopedia.ksrpc.channels.RpcCallId;kotlinx.coroutines.Job){}[0]

--- a/ksrpc-core/src/commonMain/kotlin/UnhandledMethodHandler.kt
+++ b/ksrpc-core/src/commonMain/kotlin/UnhandledMethodHandler.kt
@@ -40,7 +40,7 @@ import com.monkopedia.ksrpc.channels.CallData
  * Services that do not implement this interface preserve the existing
  * unknown-endpoint error behavior.
  */
-interface UnhandledMethodHandler<T> {
+interface UnhandledMethodHandler {
     /**
      * Invoked when an incoming call targets an endpoint that is not registered on
      * this service.
@@ -50,5 +50,5 @@ interface UnhandledMethodHandler<T> {
      * @param input The serialized call payload as it arrived on the wire.
      * @return The serialized payload to return to the caller.
      */
-    suspend fun onUnhandled(method: String, input: CallData<T>): CallData<T>
+    suspend fun <T> onUnhandled(method: String, input: CallData<T>): CallData<T>
 }

--- a/ksrpc-core/src/commonMain/kotlin/UnhandledMethodHandler.kt
+++ b/ksrpc-core/src/commonMain/kotlin/UnhandledMethodHandler.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.channels.CallData
+
+/**
+ * Opt-in fallback for services that want to handle incoming RPC calls targeting
+ * method names that are not registered on the service.
+ *
+ * An [RpcService] may implement this interface in addition to its normal
+ * [com.monkopedia.ksrpc.annotation.KsMethod]-annotated endpoints. When a call arrives
+ * for an endpoint that [RpcObject.findEndpoint] does not recognize, ksrpc will route
+ * the call to [onUnhandled] instead of immediately returning an
+ * [RpcEndpointException] to the caller.
+ *
+ * The handler receives the raw [CallData] payload for the call and must return a
+ * [CallData] payload to be serialized back to the caller. This type is transport
+ * agnostic — it's the same envelope that core's dispatch path passes around for
+ * every call, so implementations work unchanged across every ksrpc transport
+ * (JSON-RPC, packet-framed, JNI, etc.).
+ *
+ * Exceptions thrown from [onUnhandled] are reported back to the caller as remote
+ * errors, identical to the path taken when a normal handler throws.
+ *
+ * This is a receiver-side fallback: senders dispatch exactly as they do today.
+ * Services that do not implement this interface preserve the existing
+ * unknown-endpoint error behavior.
+ */
+interface UnhandledMethodHandler<T> {
+    /**
+     * Invoked when an incoming call targets an endpoint that is not registered on
+     * this service.
+     *
+     * @param method The endpoint name the caller requested (with any leading `/`
+     *   stripped, matching how registered endpoints are stored).
+     * @param input The serialized call payload as it arrived on the wire.
+     * @return The serialized payload to return to the caller.
+     */
+    suspend fun onUnhandled(method: String, input: CallData<T>): CallData<T>
+}

--- a/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
@@ -157,8 +157,7 @@ internal class HostSerializedServiceImpl<T : RpcService, S>(
         } catch (t: RpcEndpointException) {
             // Opt-in fallback: if the service implements UnhandledMethodHandler, route
             // unknown endpoints to it instead of propagating the endpoint-not-found error.
-            @Suppress("UNCHECKED_CAST")
-            val handler = service as? UnhandledMethodHandler<S>
+            val handler = service as? UnhandledMethodHandler
             if (handler != null) {
                 return handler.onUnhandled(endpoint, input)
             }

--- a/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
@@ -22,6 +22,7 @@ import com.monkopedia.ksrpc.RpcObject
 import com.monkopedia.ksrpc.RpcService
 import com.monkopedia.ksrpc.SuspendCloseable
 import com.monkopedia.ksrpc.TrackingService
+import com.monkopedia.ksrpc.UnhandledMethodHandler
 import com.monkopedia.ksrpc.asString
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.ChannelClient
@@ -151,7 +152,18 @@ internal class HostSerializedServiceImpl<T : RpcService, S>(
     private val onCloseCallbacks = mutableSetOf<suspend () -> Unit>()
 
     override suspend fun call(endpoint: String, input: CallData<S>): CallData<S> {
-        val rpcEndpoint = rpcObject.findEndpoint(endpoint)
+        val rpcEndpoint = try {
+            rpcObject.findEndpoint(endpoint)
+        } catch (t: RpcEndpointException) {
+            // Opt-in fallback: if the service implements UnhandledMethodHandler, route
+            // unknown endpoints to it instead of propagating the endpoint-not-found error.
+            @Suppress("UNCHECKED_CAST")
+            val handler = service as? UnhandledMethodHandler<S>
+            if (handler != null) {
+                return handler.onUnhandled(endpoint, input)
+            }
+            throw t
+        }
         return rpcEndpoint.call(this, service, input)
     }
 

--- a/ksrpc-test/src/commonTest/kotlin/UnhandledMethodHandlerTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/UnhandledMethodHandlerTest.kt
@@ -64,21 +64,24 @@ class RpcUnhandledMethodHandlerImplementedTest :
             val env = ksrpcEnvironment { }
             val impl = object :
                 UnhandledHandlerService,
-                UnhandledMethodHandler<String> {
+                UnhandledMethodHandler {
                 override suspend fun known(input: String): String = "known:$input"
 
-                override suspend fun onUnhandled(
+                override suspend fun <T> onUnhandled(
                     method: String,
-                    input: CallData<String>
-                ): CallData<String> {
+                    input: CallData<T>
+                ): CallData<T> {
+                    @Suppress("UNCHECKED_CAST")
+                    val stringInput = input as CallData<String>
                     val payload = env.serialization.decodeCallData(
                         String.serializer(),
-                        input
+                        stringInput
                     )
+                    @Suppress("UNCHECKED_CAST")
                     return env.serialization.createCallData(
                         String.serializer(),
                         "handled:$method:$payload"
-                    )
+                    ) as CallData<T>
                 }
             }
             impl.serialized(env)
@@ -129,13 +132,13 @@ class RpcUnhandledMethodHandlerThrowsTest :
         serializedChannel = {
             val impl = object :
                 UnhandledHandlerService,
-                UnhandledMethodHandler<String> {
+                UnhandledMethodHandler {
                 override suspend fun known(input: String): String = "known:$input"
 
-                override suspend fun onUnhandled(
+                override suspend fun <T> onUnhandled(
                     method: String,
-                    input: CallData<String>
-                ): CallData<String> {
+                    input: CallData<T>
+                ): CallData<T> {
                     throw IllegalStateException("boom:$method")
                 }
             }

--- a/ksrpc-test/src/commonTest/kotlin/UnhandledMethodHandlerTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/UnhandledMethodHandlerTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.channels.CallData
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.builtins.serializer
+
+@KsService
+interface UnhandledHandlerService : RpcService {
+    @KsMethod("/known")
+    suspend fun known(input: String): String
+}
+
+/**
+ * Verifies that a service without [UnhandledMethodHandler] keeps the current
+ * endpoint-not-found behavior when called with an unregistered method.
+ */
+class RpcUnhandledMethodHandlerNotImplementedTest :
+    RpcFunctionalityTest(
+        serializedChannel = {
+            val impl = object : UnhandledHandlerService {
+                override suspend fun known(input: String): String = "known:$input"
+            }
+            impl.serialized(ksrpcEnvironment { })
+        },
+        verifyOnChannel = { channel ->
+            val response = channel.call("missing", CallData.create("ignored"))
+            assertTrue(channel.env.serialization.isError(response))
+            val exception = channel.env.serialization.decodeErrorCallData(response)
+            val message = exception.message ?: ""
+            assertTrue(
+                message.contains("Unknown endpoint: missing"),
+                message
+            )
+        }
+    )
+
+/**
+ * Verifies that when a service implements [UnhandledMethodHandler], unknown
+ * endpoints are routed to [UnhandledMethodHandler.onUnhandled] and the handler's
+ * serialized return value reaches the caller.
+ */
+class RpcUnhandledMethodHandlerImplementedTest :
+    RpcFunctionalityTest(
+        serializedChannel = {
+            val env = ksrpcEnvironment { }
+            val impl = object :
+                UnhandledHandlerService,
+                UnhandledMethodHandler<String> {
+                override suspend fun known(input: String): String = "known:$input"
+
+                override suspend fun onUnhandled(
+                    method: String,
+                    input: CallData<String>
+                ): CallData<String> {
+                    val payload = env.serialization.decodeCallData(
+                        String.serializer(),
+                        input
+                    )
+                    return env.serialization.createCallData(
+                        String.serializer(),
+                        "handled:$method:$payload"
+                    )
+                }
+            }
+            impl.serialized(env)
+        },
+        verifyOnChannel = { channel ->
+            // Known endpoint still dispatches normally.
+            val knownResponse = channel.call(
+                "known",
+                channel.env.serialization.createCallData(
+                    String.serializer(),
+                    "hi"
+                )
+            )
+            assertFalse(channel.env.serialization.isError(knownResponse))
+            assertEquals(
+                "known:hi",
+                channel.env.serialization.decodeCallData(
+                    String.serializer(),
+                    knownResponse
+                )
+            )
+
+            // Unknown endpoint is routed to onUnhandled and its return value propagates.
+            val unknownResponse = channel.call(
+                "missing",
+                channel.env.serialization.createCallData(
+                    String.serializer(),
+                    "payload"
+                )
+            )
+            assertFalse(channel.env.serialization.isError(unknownResponse))
+            assertEquals(
+                "handled:missing:payload",
+                channel.env.serialization.decodeCallData(
+                    String.serializer(),
+                    unknownResponse
+                )
+            )
+        }
+    )
+
+/**
+ * Verifies that exceptions thrown from [UnhandledMethodHandler.onUnhandled] are
+ * reported back to the caller as remote errors, matching the normal handler path.
+ */
+class RpcUnhandledMethodHandlerThrowsTest :
+    RpcFunctionalityTest(
+        serializedChannel = {
+            val impl = object :
+                UnhandledHandlerService,
+                UnhandledMethodHandler<String> {
+                override suspend fun known(input: String): String = "known:$input"
+
+                override suspend fun onUnhandled(
+                    method: String,
+                    input: CallData<String>
+                ): CallData<String> {
+                    throw IllegalStateException("boom:$method")
+                }
+            }
+            impl.serialized(ksrpcEnvironment { })
+        },
+        verifyOnChannel = { channel ->
+            val response = channel.call(
+                "missing",
+                channel.env.serialization.createCallData(
+                    String.serializer(),
+                    "payload"
+                )
+            )
+            assertTrue(channel.env.serialization.isError(response))
+            val exception = channel.env.serialization.decodeErrorCallData(response)
+            val message = exception.message ?: ""
+            assertTrue(
+                message.contains("boom:missing"),
+                message
+            )
+        }
+    )


### PR DESCRIPTION
## Summary

- New opt-in `UnhandledMethodHandler<T>` interface in `ksrpc-core`. Services can implement it alongside their normal `RpcService` to catch calls targeting endpoints that `findEndpoint` does not recognize, instead of the current unconditional `RpcEndpointException`.
- `HostSerializedServiceImpl.call` now catches `RpcEndpointException` from `findEndpoint`, checks whether the underlying service implements `UnhandledMethodHandler<S>`, and if so routes the call to `onUnhandled(method, input)`. Services that don't implement it keep the existing error behavior.
- Handler exceptions flow through the same outer `try/catch` in `HostSerializedChannelImpl.call` as regular handler exceptions, so they reach callers as remote errors.

## Approach — payload type

Used the existing `com.monkopedia.ksrpc.channels.CallData<T>` envelope. This is the transport-agnostic wrapper core's dispatch path already passes around (`SerializedService<T>.call(endpoint, input: CallData<T>)`) — it already accommodates both serialized strings (JSON transports) and binary (`ByteReadChannel`) payloads. No new sealed type was needed, no `JsonElement`, no `Any?`. Every transport benefits automatically because routing lives in the core dispatch path.

Interface signature:

```kotlin
interface UnhandledMethodHandler<T> {
    suspend fun onUnhandled(method: String, input: CallData<T>): CallData<T>
}
```

## Test plan

Tests live in `ksrpc-test/src/commonTest/` so they run across all four `RpcFunctionalityTest` transports (SERIALIZE, PIPE, HTTP, WEBSOCKET):

- [x] `RpcUnhandledMethodHandlerNotImplementedTest` — service without handler: unknown method yields `Unknown endpoint: missing` error, preserving current behavior.
- [x] `RpcUnhandledMethodHandlerImplementedTest` — service with handler: known endpoints still dispatch; unknown endpoint invokes `onUnhandled` and its serialized return value reaches the caller.
- [x] `RpcUnhandledMethodHandlerThrowsTest` — exception from `onUnhandled` is reported to the caller as a remote error.
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-test:jvmTest`
- [x] `./gradlew :ksrpc-core:linuxX64Test :ksrpc-test:linuxX64Test`
- [x] `./gradlew :ksrpc-core:apiDump` and `apiCheck` (api diff committed)
- [x] ktlint

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)