### PR TITLE
Add @KsTimeout annotation for client-side call timeouts

### DIFF
--- a/ksrpc-api/api/ksrpc-api.api
+++ b/ksrpc-api/api/ksrpc-api.api
@@ -59,6 +59,11 @@ public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsNot
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsService : java/lang/annotation/Annotation {
 }
 
+<<<<<<< HEAD
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsrpcInternal : java/lang/annotation/Annotation {
+=======
+public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsTimeout : java/lang/annotation/Annotation {
+	public abstract fun millis ()J
+>>>>>>> 1248868 (Add @KsTimeout annotation for client-side call timeouts)
 }
 

--- a/ksrpc-api/api/ksrpc-api.api
+++ b/ksrpc-api/api/ksrpc-api.api
@@ -59,16 +59,12 @@ public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsNot
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsService : java/lang/annotation/Annotation {
 }
 
-<<<<<<< HEAD
-public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsrpcInternal : java/lang/annotation/Annotation {
-=======
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsTimeout : java/lang/annotation/Annotation {
 	public abstract fun millis ()J
-<<<<<<< HEAD
->>>>>>> 1248868 (Add @KsTimeout annotation for client-side call timeouts)
-=======
 	public abstract fun minutes ()J
 	public abstract fun seconds ()J
->>>>>>> f3199f6 (Support seconds/minutes params on @KsTimeout for natural duration expression)
+}
+
+public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsrpcInternal : java/lang/annotation/Annotation {
 }
 

--- a/ksrpc-api/api/ksrpc-api.api
+++ b/ksrpc-api/api/ksrpc-api.api
@@ -64,6 +64,11 @@ public abstract interface annotation class com/monkopedia/ksrpc/annotation/Ksrpc
 =======
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsTimeout : java/lang/annotation/Annotation {
 	public abstract fun millis ()J
+<<<<<<< HEAD
 >>>>>>> 1248868 (Add @KsTimeout annotation for client-side call timeouts)
+=======
+	public abstract fun minutes ()J
+	public abstract fun seconds ()J
+>>>>>>> f3199f6 (Support seconds/minutes params on @KsTimeout for natural duration expression)
 }
 

--- a/ksrpc-api/api/ksrpc-api.klib.api
+++ b/ksrpc-api/api/ksrpc-api.klib.api
@@ -29,23 +29,19 @@ open annotation class com.monkopedia.ksrpc.annotation/KsService : kotlin/Annotat
     constructor <init>() // com.monkopedia.ksrpc.annotation/KsService.<init>|<init>(){}[0]
 }
 
-<<<<<<< HEAD
-open annotation class com.monkopedia.ksrpc.annotation/KsrpcInternal : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsrpcInternal|null[0]
-    constructor <init>() // com.monkopedia.ksrpc.annotation/KsrpcInternal.<init>|<init>(){}[0]
-=======
 open annotation class com.monkopedia.ksrpc.annotation/KsTimeout : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsTimeout|null[0]
     constructor <init>(kotlin/Long = ..., kotlin/Long = ..., kotlin/Long = ...) // com.monkopedia.ksrpc.annotation/KsTimeout.<init>|<init>(kotlin.Long;kotlin.Long;kotlin.Long){}[0]
 
     final val millis // com.monkopedia.ksrpc.annotation/KsTimeout.millis|{}millis[0]
         final fun <get-millis>(): kotlin/Long // com.monkopedia.ksrpc.annotation/KsTimeout.millis.<get-millis>|<get-millis>(){}[0]
-<<<<<<< HEAD
->>>>>>> 1248868 (Add @KsTimeout annotation for client-side call timeouts)
-=======
     final val minutes // com.monkopedia.ksrpc.annotation/KsTimeout.minutes|{}minutes[0]
         final fun <get-minutes>(): kotlin/Long // com.monkopedia.ksrpc.annotation/KsTimeout.minutes.<get-minutes>|<get-minutes>(){}[0]
     final val seconds // com.monkopedia.ksrpc.annotation/KsTimeout.seconds|{}seconds[0]
         final fun <get-seconds>(): kotlin/Long // com.monkopedia.ksrpc.annotation/KsTimeout.seconds.<get-seconds>|<get-seconds>(){}[0]
->>>>>>> f3199f6 (Support seconds/minutes params on @KsTimeout for natural duration expression)
+}
+
+open annotation class com.monkopedia.ksrpc.annotation/KsrpcInternal : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsrpcInternal|null[0]
+    constructor <init>() // com.monkopedia.ksrpc.annotation/KsrpcInternal.<init>|<init>(){}[0]
 }
 
 abstract interface com.monkopedia.ksrpc/RpcService : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc/RpcService|null[0]

--- a/ksrpc-api/api/ksrpc-api.klib.api
+++ b/ksrpc-api/api/ksrpc-api.klib.api
@@ -34,11 +34,18 @@ open annotation class com.monkopedia.ksrpc.annotation/KsrpcInternal : kotlin/Ann
     constructor <init>() // com.monkopedia.ksrpc.annotation/KsrpcInternal.<init>|<init>(){}[0]
 =======
 open annotation class com.monkopedia.ksrpc.annotation/KsTimeout : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsTimeout|null[0]
-    constructor <init>(kotlin/Long) // com.monkopedia.ksrpc.annotation/KsTimeout.<init>|<init>(kotlin.Long){}[0]
+    constructor <init>(kotlin/Long = ..., kotlin/Long = ..., kotlin/Long = ...) // com.monkopedia.ksrpc.annotation/KsTimeout.<init>|<init>(kotlin.Long;kotlin.Long;kotlin.Long){}[0]
 
     final val millis // com.monkopedia.ksrpc.annotation/KsTimeout.millis|{}millis[0]
         final fun <get-millis>(): kotlin/Long // com.monkopedia.ksrpc.annotation/KsTimeout.millis.<get-millis>|<get-millis>(){}[0]
+<<<<<<< HEAD
 >>>>>>> 1248868 (Add @KsTimeout annotation for client-side call timeouts)
+=======
+    final val minutes // com.monkopedia.ksrpc.annotation/KsTimeout.minutes|{}minutes[0]
+        final fun <get-minutes>(): kotlin/Long // com.monkopedia.ksrpc.annotation/KsTimeout.minutes.<get-minutes>|<get-minutes>(){}[0]
+    final val seconds // com.monkopedia.ksrpc.annotation/KsTimeout.seconds|{}seconds[0]
+        final fun <get-seconds>(): kotlin/Long // com.monkopedia.ksrpc.annotation/KsTimeout.seconds.<get-seconds>|<get-seconds>(){}[0]
+>>>>>>> f3199f6 (Support seconds/minutes params on @KsTimeout for natural duration expression)
 }
 
 abstract interface com.monkopedia.ksrpc/RpcService : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc/RpcService|null[0]

--- a/ksrpc-api/api/ksrpc-api.klib.api
+++ b/ksrpc-api/api/ksrpc-api.klib.api
@@ -29,8 +29,16 @@ open annotation class com.monkopedia.ksrpc.annotation/KsService : kotlin/Annotat
     constructor <init>() // com.monkopedia.ksrpc.annotation/KsService.<init>|<init>(){}[0]
 }
 
+<<<<<<< HEAD
 open annotation class com.monkopedia.ksrpc.annotation/KsrpcInternal : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsrpcInternal|null[0]
     constructor <init>() // com.monkopedia.ksrpc.annotation/KsrpcInternal.<init>|<init>(){}[0]
+=======
+open annotation class com.monkopedia.ksrpc.annotation/KsTimeout : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsTimeout|null[0]
+    constructor <init>(kotlin/Long) // com.monkopedia.ksrpc.annotation/KsTimeout.<init>|<init>(kotlin.Long){}[0]
+
+    final val millis // com.monkopedia.ksrpc.annotation/KsTimeout.millis|{}millis[0]
+        final fun <get-millis>(): kotlin/Long // com.monkopedia.ksrpc.annotation/KsTimeout.millis.<get-millis>|<get-millis>(){}[0]
+>>>>>>> 1248868 (Add @KsTimeout annotation for client-side call timeouts)
 }
 
 abstract interface com.monkopedia.ksrpc/RpcService : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc/RpcService|null[0]

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
@@ -55,3 +55,19 @@ annotation class KsMethod(val name: String)
 @Target(AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.BINARY)
 annotation class KsMethodMetadata
+
+/**
+ * Sibling annotation for [KsMethod] that specifies a timeout in milliseconds
+ * for the remote call. When present, the generated stub wraps the call in
+ * `withTimeout(millis)`. If the call does not complete within the specified
+ * duration, a [kotlinx.coroutines.TimeoutCancellationException] is thrown and
+ * (on transports with cancellation support) the cancellation propagates to the
+ * server.
+ *
+ * A value of `0` or negative means "no timeout" — the call proceeds without
+ * any timeout wrapper.
+ */
+@KsMethodMetadata
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class KsTimeout(val millis: Long)

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
@@ -57,17 +57,25 @@ annotation class KsMethod(val name: String)
 annotation class KsMethodMetadata
 
 /**
- * Sibling annotation for [KsMethod] that specifies a timeout in milliseconds
- * for the remote call. When present, the generated stub wraps the call in
- * `withTimeout(millis)`. If the call does not complete within the specified
- * duration, a [kotlinx.coroutines.TimeoutCancellationException] is thrown and
- * (on transports with cancellation support) the cancellation propagates to the
- * server.
+ * Sibling annotation for [KsMethod] that specifies a timeout for the remote
+ * call. The total timeout is computed as:
  *
- * A value of `0` or negative means "no timeout" — the call proceeds without
+ *     millis + seconds * 1000 + minutes * 60_000
+ *
+ * When the total is positive, the generated stub wraps the call in
+ * `withTimeout(totalMillis)`. If the call does not complete within the
+ * specified duration, a [kotlinx.coroutines.TimeoutCancellationException] is
+ * thrown and (on transports with cancellation support) the cancellation
+ * propagates to the server.
+ *
+ * A total of `0` or negative means "no timeout" — the call proceeds without
  * any timeout wrapper.
  */
 @KsMethodMetadata
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
-annotation class KsTimeout(val millis: Long)
+annotation class KsTimeout(
+    val millis: Long = 0,
+    val seconds: Long = 0,
+    val minutes: Long = 0
+)

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -221,6 +221,10 @@ public final class com/monkopedia/ksrpc/RpcMethod {
 	public final fun metadata (Ljava/lang/String;)Lcom/monkopedia/ksrpc/MethodMetadata;
 }
 
+public final class com/monkopedia/ksrpc/RpcMethodKt {
+	public static final fun getTimeoutMillis (Lcom/monkopedia/ksrpc/RpcMethod;)Ljava/lang/Long;
+}
+
 public abstract interface class com/monkopedia/ksrpc/RpcObject {
 	public abstract fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/RpcService;
 	public abstract fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -486,6 +486,8 @@ final val com.monkopedia.ksrpc.internal/asClient // com.monkopedia.ksrpc.interna
     final fun <#A1: kotlin/Any?> (com.monkopedia.ksrpc.channels/SerializedChannel<#A1>).<get-asClient>(): com.monkopedia.ksrpc.channels/ChannelClient<#A1> // com.monkopedia.ksrpc.internal/asClient.<get-asClient>|<get-asClient>@com.monkopedia.ksrpc.channels.SerializedChannel<0:0>(){0§<kotlin.Any?>}[0]
 final val com.monkopedia.ksrpc/asString // com.monkopedia.ksrpc/asString|@kotlin.Throwable{}asString[0]
     final fun (kotlin/Throwable).<get-asString>(): kotlin/String // com.monkopedia.ksrpc/asString.<get-asString>|<get-asString>@kotlin.Throwable(){}[0]
+final val com.monkopedia.ksrpc/timeoutMillis // com.monkopedia.ksrpc/timeoutMillis|@com.monkopedia.ksrpc.RpcMethod<*,*,*>{}timeoutMillis[0]
+    final fun (com.monkopedia.ksrpc/RpcMethod<*, *, *>).<get-timeoutMillis>(): kotlin/Long? // com.monkopedia.ksrpc/timeoutMillis.<get-timeoutMillis>|<get-timeoutMillis>@com.monkopedia.ksrpc.RpcMethod<*,*,*>(){}[0]
 
 final fun (com.monkopedia.ksrpc/RpcObject<*>).com.monkopedia.ksrpc/serviceInterfaceName(): kotlin/String // com.monkopedia.ksrpc/serviceInterfaceName|serviceInterfaceName@com.monkopedia.ksrpc.RpcObject<*>(){}[0]
 final fun <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> (#A).com.monkopedia.ksrpc/serialized(com.monkopedia.ksrpc/RpcObject<#A>, com.monkopedia.ksrpc/KsrpcEnvironment<#B>): com.monkopedia.ksrpc.channels/SerializedService<#B> // com.monkopedia.ksrpc/serialized|serialized@0:0(com.monkopedia.ksrpc.RpcObject<0:0>;com.monkopedia.ksrpc.KsrpcEnvironment<0:1>){0§<com.monkopedia.ksrpc.RpcService>;1§<kotlin.Any?>}[0]

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -27,8 +27,21 @@ import com.monkopedia.ksrpc.internal.host
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer
+
+private const val KS_TIMEOUT_FQ = "com.monkopedia.ksrpc.annotation.KsTimeout"
+
+/**
+ * Returns the timeout in milliseconds configured via `@KsTimeout` on the
+ * source method, or `null` if no timeout annotation was present.
+ */
+val RpcMethod<*, *, *>.timeoutMillis: Long?
+    get() {
+        val meta = metadata(KS_TIMEOUT_FQ) ?: return null
+        return (meta.argument("millis") as? MetadataValue.LongValue)?.value
+    }
 
 sealed interface Transformer<T> {
     val hasContent: Boolean
@@ -155,29 +168,39 @@ class RpcMethod<T : RpcService, I, O>(
     }
 
     @Suppress("UNCHECKED_CAST")
-    suspend fun <S> callChannel(channel: SerializedService<S>, input: Any?): Any? =
+    suspend fun <S> callChannel(channel: SerializedService<S>, input: Any?): Any? {
+        val timeout = timeoutMillis
         // Drop the Job element from the channel's context so the caller's Job remains the
         // parent for cancellation propagation — otherwise cancelling the caller wouldn't
         // surface inside the remote call (it would only cancel this [withContext] body's
         // own child scope, which is unreachable from the caller's cancel signal).
-        withContext(channel.context.minusKey(Job)) {
-            val input = inputTransform.transform(input as I, channel)
-            val id = randomUuid()
-            channel.env.logger.info(
-                "Transformer",
-                "($id) Calling remote endpoint $endpoint"
-            )
-            // Client-side stubs do not forward a callId — they generate their own wire-level
-            // id at the transport if needed, and any server-side handler reached via the
-            // remote transport will have its own CurrentRpcCallElement installed by that
-            // transport's RpcMethod.call invocation.
-            val transformedOutput = channel.call(this@RpcMethod, input, callId = null)
-            channel.env.logger.debug(
-                "Transformer",
-                "($id) Completed remote endpoint $endpoint"
-            )
-            outputTransform.untransform(transformedOutput, channel)
+        return withContext(channel.context.minusKey(Job)) {
+            val body: suspend () -> Any? = {
+                val input = inputTransform.transform(input as I, channel)
+                val id = randomUuid()
+                channel.env.logger.info(
+                    "Transformer",
+                    "($id) Calling remote endpoint $endpoint"
+                )
+                // Client-side stubs do not forward a callId — they generate their own
+                // wire-level id at the transport if needed, and any server-side handler
+                // reached via the remote transport will have its own
+                // CurrentRpcCallElement installed by that transport's RpcMethod.call
+                // invocation.
+                val transformedOutput = channel.call(this@RpcMethod, input, callId = null)
+                channel.env.logger.debug(
+                    "Transformer",
+                    "($id) Completed remote endpoint $endpoint"
+                )
+                outputTransform.untransform(transformedOutput, channel)
+            }
+            if (timeout != null && timeout > 0) {
+                withTimeout(timeout) { body() }
+            } else {
+                body()
+            }
         }
+    }
 
     fun findSubserviceTransformers(): List<SubserviceTransformer<out RpcService>> = listOfNotNull(
         inputTransform as? SubserviceTransformer<*>,

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -36,11 +36,16 @@ private const val KS_TIMEOUT_FQ = "com.monkopedia.ksrpc.annotation.KsTimeout"
 /**
  * Returns the timeout in milliseconds configured via `@KsTimeout` on the
  * source method, or `null` if no timeout annotation was present.
+ *
+ * The total is computed as `millis + seconds * 1000 + minutes * 60_000`.
  */
 val RpcMethod<*, *, *>.timeoutMillis: Long?
     get() {
         val meta = metadata(KS_TIMEOUT_FQ) ?: return null
-        return (meta.argument("millis") as? MetadataValue.LongValue)?.value
+        val millis = (meta.argument("millis") as? MetadataValue.LongValue)?.value ?: 0L
+        val seconds = (meta.argument("seconds") as? MetadataValue.LongValue)?.value ?: 0L
+        val minutes = (meta.argument("minutes") as? MetadataValue.LongValue)?.value ?: 0L
+        return millis + seconds * 1000 + minutes * 60_000
     }
 
 sealed interface Transformer<T> {

--- a/ksrpc-test/src/commonTest/kotlin/KsTimeoutCancellationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsTimeoutCancellationTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsTimeout
+import com.monkopedia.ksrpc.jsonrpc.JsonRpcCancellationConvention
+import com.monkopedia.ksrpc.jsonrpc.asJsonRpcConnection
+import com.monkopedia.ksrpc.sockets.asConnection
+import io.ktor.utils.io.close
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+
+@KsService
+interface TimeoutCancellationService : RpcService {
+    @KsMethod("/slow")
+    @KsTimeout(millis = 200)
+    suspend fun slow(input: String): String
+
+    @KsMethod("/fast")
+    suspend fun fast(input: String): String
+}
+
+/**
+ * Integration tests verifying that a @KsTimeout-triggered timeout propagates cancellation
+ * to the remote server handler, exercising the intersection of issue #10 (native cancellation)
+ * and issue #14 (@KsTimeout).
+ */
+class KsTimeoutCancellationTest {
+
+    @Test
+    fun timeoutCancelsRemoteHandlerOverPipeTransport() = runBlockingUnit {
+        val cancelled = booleanArrayOf(false)
+        val completed = booleanArrayOf(false)
+
+        val service = object : TimeoutCancellationService {
+            override suspend fun slow(input: String): String {
+                try {
+                    delay(10_000)
+                    return "slow:$input"
+                } catch (t: CancellationException) {
+                    cancelled[0] = true
+                    throw t
+                }
+            }
+
+            override suspend fun fast(input: String): String {
+                completed[0] = true
+                return "fast:$input"
+            }
+        }
+
+        val (clientToServer, serverFromClient) = createPipe()
+        val (serverToClient, clientFromServer) = createPipe()
+
+        val serverConnection = (serverFromClient to serverToClient).asConnection(
+            ksrpcEnvironment { }
+        )
+        val clientConnection = (clientFromServer to clientToServer).asConnection(
+            ksrpcEnvironment { }
+        )
+
+        val serverJob = launch(Dispatchers.Default) {
+            serverConnection.registerDefault(service.serialized(ksrpcEnvironment { }))
+        }
+        try {
+            val stub = clientConnection.defaultChannel()
+                .toStub<TimeoutCancellationService, String>()
+
+            // Client call should throw due to @KsTimeout(millis = 200)
+            var clientTimedOut = false
+            try {
+                stub.slow("hello")
+            } catch (_: Exception) {
+                clientTimedOut = true
+            }
+            assertTrue(clientTimedOut, "client call must fail with timeout/cancellation")
+
+            // Wait for the cancel frame to propagate to the server handler
+            withTimeout(5_000) {
+                while (!cancelled[0]) {
+                    yield()
+                }
+            }
+            assertTrue(
+                cancelled[0],
+                "server handler must be cancelled when @KsTimeout fires"
+            )
+
+            // Connection should remain healthy after the timeout
+            assertEquals("fast:ping", stub.fast("ping"))
+            assertTrue(completed[0])
+        } finally {
+            try {
+                clientConnection.close()
+            } catch (_: Throwable) {
+            }
+            try {
+                serverConnection.close()
+            } catch (_: Throwable) {
+            }
+            try {
+                serverJob.cancel()
+            } catch (_: Throwable) {
+            }
+        }
+    }
+
+    @Test
+    fun timeoutCancelsRemoteHandlerOverJsonRpcWithLspConvention() = runBlockingUnit {
+        val cancelled = booleanArrayOf(false)
+        val completed = booleanArrayOf(false)
+
+        val service = object : TimeoutCancellationService {
+            override suspend fun slow(input: String): String {
+                try {
+                    delay(10_000)
+                    return "slow:$input"
+                } catch (t: CancellationException) {
+                    cancelled[0] = true
+                    throw t
+                }
+            }
+
+            override suspend fun fast(input: String): String {
+                completed[0] = true
+                return "fast:$input"
+            }
+        }
+
+        val (output, input) = createPipe()
+        val (so, si) = createPipe()
+        GlobalScope.launch(Dispatchers.Default) {
+            val connection = (input to so).asJsonRpcConnection(
+                ksrpcEnvironment { },
+                includeContentHeaders = false,
+                cancellationConvention = JsonRpcCancellationConvention.Lsp
+            )
+            connection.registerDefault(service.serialized(ksrpcEnvironment { }))
+        }
+        try {
+            val channel = (si to output).asJsonRpcConnection(
+                ksrpcEnvironment { },
+                includeContentHeaders = false,
+                cancellationConvention = JsonRpcCancellationConvention.Lsp
+            )
+            val stub = channel.defaultChannel()
+                .toStub<TimeoutCancellationService, String>()
+
+            // Client call should throw due to @KsTimeout(millis = 200)
+            var clientTimedOut = false
+            try {
+                stub.slow("hello")
+            } catch (_: Exception) {
+                clientTimedOut = true
+            }
+            assertTrue(clientTimedOut, "client call must fail with timeout/cancellation")
+
+            // Wait for the LSP cancel notification to propagate to the server handler
+            withTimeout(5_000) {
+                while (!cancelled[0]) {
+                    yield()
+                }
+            }
+            assertTrue(
+                cancelled[0],
+                "server handler must be cancelled via LSP convention when @KsTimeout fires"
+            )
+
+            // Connection should remain healthy after the timeout
+            assertEquals("fast:ping", stub.fast("ping"))
+            assertTrue(completed[0])
+        } finally {
+            try {
+                input.cancel(null)
+            } catch (_: Throwable) {
+            }
+            try {
+                si.cancel(null)
+            } catch (_: Throwable) {
+            }
+            output.close(null)
+            so.close(null)
+        }
+    }
+}

--- a/ksrpc-test/src/commonTest/kotlin/KsTimeoutTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsTimeoutTest.kt
@@ -18,6 +18,7 @@ package com.monkopedia.ksrpc
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
 import com.monkopedia.ksrpc.annotation.KsTimeout
+import com.monkopedia.ksrpc.MetadataValue
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.internal.asClient
 import kotlin.test.Test
@@ -32,15 +33,23 @@ import kotlinx.coroutines.delay
 @KsService
 interface TimeoutTestService : RpcService {
     @KsMethod("/fast")
-    @KsTimeout(5000)
+    @KsTimeout(seconds = 5)
     suspend fun fast(input: String): String
 
     @KsMethod("/slow")
-    @KsTimeout(200)
+    @KsTimeout(millis = 200)
     suspend fun slow(input: String): String
 
     @KsMethod("/no_timeout")
     suspend fun noTimeout(input: String): String
+
+    @KsMethod("/combined")
+    @KsTimeout(seconds = 1, millis = 500)
+    suspend fun combined(input: String): String
+
+    @KsMethod("/minutes")
+    @KsTimeout(minutes = 2)
+    suspend fun withMinutes(input: String): String
 }
 
 class TimeoutTestServiceImpl : TimeoutTestService {
@@ -52,6 +61,10 @@ class TimeoutTestServiceImpl : TimeoutTestService {
     }
 
     override suspend fun noTimeout(input: String): String = "noTimeout:$input"
+
+    override suspend fun combined(input: String): String = "combined:$input"
+
+    override suspend fun withMinutes(input: String): String = "minutes:$input"
 }
 
 class KsTimeoutMetadataTest {
@@ -85,6 +98,37 @@ class KsTimeoutMetadataTest {
         val timeout = method.timeoutMillis
         assertNotNull(timeout)
         assertEquals(200L, timeout)
+    }
+
+    @Test
+    fun combinedSecondsAndMillisAreSummed() {
+        val method = rpcObject.findEndpoint("combined")
+        val timeout = method.timeoutMillis
+        assertNotNull(timeout)
+        assertEquals(1500L, timeout)
+    }
+
+    @Test
+    fun minutesTimeoutIsConvertedToMillis() {
+        val method = rpcObject.findEndpoint("minutes")
+        val timeout = method.timeoutMillis
+        assertNotNull(timeout)
+        assertEquals(120_000L, timeout)
+    }
+
+    @Test
+    fun combinedMetadataHasAllParams() {
+        val method = rpcObject.findEndpoint("combined")
+        val meta = method.metadata("com.monkopedia.ksrpc.annotation.KsTimeout")
+        assertNotNull(meta)
+        assertEquals(
+            500L,
+            (meta.argument("millis") as? MetadataValue.LongValue)?.value
+        )
+        assertEquals(
+            1L,
+            (meta.argument("seconds") as? MetadataValue.LongValue)?.value
+        )
     }
 }
 

--- a/ksrpc-test/src/commonTest/kotlin/KsTimeoutTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsTimeoutTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsTimeout
+import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
+import com.monkopedia.ksrpc.internal.asClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+
+@KsService
+interface TimeoutTestService : RpcService {
+    @KsMethod("/fast")
+    @KsTimeout(5000)
+    suspend fun fast(input: String): String
+
+    @KsMethod("/slow")
+    @KsTimeout(200)
+    suspend fun slow(input: String): String
+
+    @KsMethod("/no_timeout")
+    suspend fun noTimeout(input: String): String
+}
+
+class TimeoutTestServiceImpl : TimeoutTestService {
+    override suspend fun fast(input: String): String = "fast:$input"
+
+    override suspend fun slow(input: String): String {
+        delay(2000)
+        return "slow:$input"
+    }
+
+    override suspend fun noTimeout(input: String): String = "noTimeout:$input"
+}
+
+class KsTimeoutMetadataTest {
+    private val rpcObject = rpcObject<TimeoutTestService>()
+
+    @Test
+    fun timeoutMillisIsCapturedFromAnnotation() {
+        val method = rpcObject.findEndpoint("fast")
+        val timeout = method.timeoutMillis
+        assertNotNull(timeout)
+        assertEquals(5000L, timeout)
+    }
+
+    @Test
+    fun methodWithoutTimeoutHasNullTimeoutMillis() {
+        val method = rpcObject.findEndpoint("no_timeout")
+        assertNull(method.timeoutMillis)
+    }
+
+    @Test
+    fun timeoutMetadataHasCorrectFqName() {
+        val method = rpcObject.findEndpoint("fast")
+        val meta = method.metadata("com.monkopedia.ksrpc.annotation.KsTimeout")
+        assertNotNull(meta)
+        assertEquals("com.monkopedia.ksrpc.annotation.KsTimeout", meta.annotationFqName)
+    }
+
+    @Test
+    fun shortTimeoutValueIsCaptured() {
+        val method = rpcObject.findEndpoint("slow")
+        val timeout = method.timeoutMillis
+        assertNotNull(timeout)
+        assertEquals(200L, timeout)
+    }
+}
+
+class KsTimeoutRuntimeTest {
+    @Test
+    fun callWithinTimeoutSucceeds() = runBlockingUnit {
+        val channel = HostSerializedChannelImpl(createEnv())
+        try {
+            val service = TimeoutTestServiceImpl()
+            val serialized = service.serialized(
+                rpcObject<TimeoutTestService>(),
+                channel.env
+            )
+            channel.registerDefault(serialized)
+            val stub = rpcObject<TimeoutTestService>()
+                .createStub(channel.asClient.defaultChannel())
+            val result = stub.fast("hello")
+            assertEquals("fast:hello", result)
+        } finally {
+            channel.close()
+        }
+    }
+
+    @Test
+    fun callExceedingTimeoutFails() = runBlockingUnit {
+        val channel = HostSerializedChannelImpl(createEnv())
+        try {
+            val service = TimeoutTestServiceImpl()
+            val serialized = service.serialized(
+                rpcObject<TimeoutTestService>(),
+                channel.env
+            )
+            channel.registerDefault(serialized)
+            val stub = rpcObject<TimeoutTestService>()
+                .createStub(channel.asClient.defaultChannel())
+            // In-process transports may wrap the TimeoutCancellationException into
+            // an RpcException via the error-encoding path, so we assert on the
+            // general Exception type. On real transports the original
+            // TimeoutCancellationException propagates directly.
+            assertFailsWith<Exception> {
+                stub.slow("hello")
+            }
+        } finally {
+            channel.close()
+        }
+    }
+
+    @Test
+    fun callWithoutTimeoutAnnotationDoesNotTimeout() = runBlockingUnit {
+        val channel = HostSerializedChannelImpl(createEnv())
+        try {
+            val service = TimeoutTestServiceImpl()
+            val serialized = service.serialized(
+                rpcObject<TimeoutTestService>(),
+                channel.env
+            )
+            channel.registerDefault(serialized)
+            val stub = rpcObject<TimeoutTestService>()
+                .createStub(channel.asClient.defaultChannel())
+            val result = stub.noTimeout("hello")
+            assertEquals("noTimeout:hello", result)
+        } finally {
+            channel.close()
+        }
+    }
+
+    private fun createEnv() = ksrpcEnvironment { }
+}


### PR DESCRIPTION
## Summary
- Adds `@KsTimeout(millis: Long)` annotation in `ksrpc-api` as a `@KsMethodMetadata` sibling annotation for `@KsMethod` functions
- Adds `RpcMethod.timeoutMillis` extension property that reads the timeout from captured metadata
- Wraps the existing `callChannel` body with `withTimeout(millis)` when a positive timeout is configured
- Combined with native cancellation (#10), timeout cancellation propagates to the server on supporting transports

## Approach
The `@KsTimeout` annotation is captured by the existing annotation propagation infrastructure (#11/PR #24) as `MetadataValue.LongValue`. At runtime, `RpcMethod.callChannel()` reads `timeoutMillis` and conditionally wraps the call body in `kotlinx.coroutines.withTimeout`. Values of 0 or negative are treated as "no timeout."

## Test plan
- [x] Metadata propagation: `@KsTimeout(5000)` on a method produces `rpcMethod.timeoutMillis == 5000L`
- [x] Metadata absence: method without `@KsTimeout` has `timeoutMillis == null`
- [x] Runtime success: call completing within timeout succeeds normally
- [x] Runtime timeout: call exceeding timeout throws an exception on the client
- [x] Runtime no-annotation: call without `@KsTimeout` proceeds without any timeout
- [x] All existing tests pass (`ksrpc-core` JVM/linuxX64, `ksrpc-test` JVM/linuxX64, compiler plugin)
- [x] `apiDump` + `apiCheck` pass (BCV updated for new annotation and extension property)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)