### PR TITLE
Flow/streaming support via KsFlowService sub-service protocol

### DIFF
--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -463,6 +463,68 @@ public final class com/monkopedia/ksrpc/channels/UtilsJvmKt {
 	public static final fun randomUuid ()Ljava/lang/String;
 }
 
+public final class com/monkopedia/ksrpc/flow/AsKsFlowKt {
+	public static final fun asKsFlow (Lkotlinx/coroutines/flow/Flow;)Lcom/monkopedia/ksrpc/flow/KsFlowService;
+}
+
+public final class com/monkopedia/ksrpc/flow/AutoClosingFlow : kotlinx/coroutines/flow/Flow {
+	public fun <init> (Lcom/monkopedia/ksrpc/flow/KsFlowService;)V
+	public fun collect (Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/monkopedia/ksrpc/flow/KsCollectionToken : com/monkopedia/ksrpc/RpcService {
+	public abstract fun cancelCollection (Lkotlin/Unit;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsCollectionToken$DefaultImpls {
+	public static fun close (Lcom/monkopedia/ksrpc/flow/KsCollectionToken;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsCollectionTokenObject : com/monkopedia/ksrpc/RpcObject {
+	public static final field INSTANCE Lcom/monkopedia/ksrpc/flow/KsCollectionTokenObject;
+	public synthetic fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/RpcService;
+	public fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/flow/KsCollectionToken;
+	public fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
+	public fun getEndpoints ()Ljava/util/List;
+	public fun getServiceName ()Ljava/lang/String;
+}
+
+public abstract interface class com/monkopedia/ksrpc/flow/KsFlowCollector : com/monkopedia/ksrpc/RpcService {
+	public abstract fun onComplete (Lkotlin/Unit;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onError (Lcom/monkopedia/ksrpc/RpcFailure;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onItem (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$DefaultImpls {
+	public static fun close (Lcom/monkopedia/ksrpc/flow/KsFlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollectorObject : com/monkopedia/ksrpc/RpcObject {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/RpcService;
+	public fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/flow/KsFlowCollector;
+	public fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
+	public fun getEndpoints ()Ljava/util/List;
+	public fun getServiceName ()Ljava/lang/String;
+}
+
+public abstract interface class com/monkopedia/ksrpc/flow/KsFlowService : com/monkopedia/ksrpc/RpcService, kotlinx/coroutines/flow/Flow {
+	public abstract fun startCollection (Lcom/monkopedia/ksrpc/flow/KsFlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowService$DefaultImpls {
+	public static fun close (Lcom/monkopedia/ksrpc/flow/KsFlowService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowServiceObject : com/monkopedia/ksrpc/RpcObject {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/RpcService;
+	public fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/flow/KsFlowService;
+	public fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
+	public fun getEndpoints ()Ljava/util/List;
+	public fun getServiceName ()Ljava/lang/String;
+}
+
 public final class com/monkopedia/ksrpc/internal/ClientChannelContext : kotlin/coroutines/CoroutineContext$Element {
 	public fun <init> (Lcom/monkopedia/ksrpc/channels/ChannelClient;)V
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -63,6 +63,16 @@ abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.channels/SingleChannel
     abstract suspend fun registerDefault(com.monkopedia.ksrpc.channels/SerializedService<#A>) // com.monkopedia.ksrpc.channels/SingleChannelHost.registerDefault|registerDefault(com.monkopedia.ksrpc.channels.SerializedService<1:0>){}[0]
 }
 
+abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/KsFlowCollector : com.monkopedia.ksrpc/RpcService { // com.monkopedia.ksrpc.flow/KsFlowCollector|null[0]
+    abstract suspend fun onComplete(kotlin/Unit) // com.monkopedia.ksrpc.flow/KsFlowCollector.onComplete|onComplete(kotlin.Unit){}[0]
+    abstract suspend fun onError(com.monkopedia.ksrpc/RpcFailure) // com.monkopedia.ksrpc.flow/KsFlowCollector.onError|onError(com.monkopedia.ksrpc.RpcFailure){}[0]
+    abstract suspend fun onItem(#A) // com.monkopedia.ksrpc.flow/KsFlowCollector.onItem|onItem(1:0){}[0]
+}
+
+abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/KsFlowService : com.monkopedia.ksrpc/RpcService, kotlinx.coroutines.flow/Flow<#A> { // com.monkopedia.ksrpc.flow/KsFlowService|null[0]
+    abstract suspend fun startCollection(com.monkopedia.ksrpc.flow/KsFlowCollector<#A>): com.monkopedia.ksrpc.flow/KsCollectionToken // com.monkopedia.ksrpc.flow/KsFlowService.startCollection|startCollection(com.monkopedia.ksrpc.flow.KsFlowCollector<1:0>){}[0]
+}
+
 abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc/CallDataSerializer { // com.monkopedia.ksrpc/CallDataSerializer|null[0]
     abstract fun <#A1: kotlin/Any?> createCallData(kotlinx.serialization/KSerializer<#A1>, #A1): com.monkopedia.ksrpc.channels/CallData<#A> // com.monkopedia.ksrpc/CallDataSerializer.createCallData|createCallData(kotlinx.serialization.KSerializer<0:0>;0:0){0§<kotlin.Any?>}[0]
     abstract fun <#A1: kotlin/Any?> createEndpointNotFoundCallData(kotlinx.serialization/KSerializer<#A1>, #A1): com.monkopedia.ksrpc.channels/CallData<#A> // com.monkopedia.ksrpc/CallDataSerializer.createEndpointNotFoundCallData|createEndpointNotFoundCallData(kotlinx.serialization.KSerializer<0:0>;0:0){0§<kotlin.Any?>}[0]
@@ -103,6 +113,10 @@ abstract interface com.monkopedia.ksrpc.channels/ContextContainer { // com.monko
 }
 
 abstract interface com.monkopedia.ksrpc.channels/RpcCallId // com.monkopedia.ksrpc.channels/RpcCallId|null[0]
+
+abstract interface com.monkopedia.ksrpc.flow/KsCollectionToken : com.monkopedia.ksrpc/RpcService { // com.monkopedia.ksrpc.flow/KsCollectionToken|null[0]
+    abstract suspend fun cancelCollection(kotlin/Unit) // com.monkopedia.ksrpc.flow/KsCollectionToken.cancelCollection|cancelCollection(kotlin.Unit){}[0]
+}
 
 abstract interface com.monkopedia.ksrpc/Logger { // com.monkopedia.ksrpc/Logger|null[0]
     open fun debug(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.debug|debug(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
@@ -160,6 +174,36 @@ final class <#A: com.monkopedia.ksrpc/RpcService> com.monkopedia.ksrpc/Subservic
 
     final suspend fun <#A1: kotlin/Any?> transform(#A, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/SubserviceTransformer.transform|transform(1:0;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
     final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): #A // com.monkopedia.ksrpc/SubserviceTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+}
+
+final class <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/AutoClosingFlow : kotlinx.coroutines.flow/Flow<#A> { // com.monkopedia.ksrpc.flow/AutoClosingFlow|null[0]
+    constructor <init>(com.monkopedia.ksrpc.flow/KsFlowService<#A>) // com.monkopedia.ksrpc.flow/AutoClosingFlow.<init>|<init>(com.monkopedia.ksrpc.flow.KsFlowService<1:0>){}[0]
+
+    final suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // com.monkopedia.ksrpc.flow/AutoClosingFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
+}
+
+final class <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/KsFlowCollectorObject : com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowCollector<#A>> { // com.monkopedia.ksrpc.flow/KsFlowCollectorObject|null[0]
+    constructor <init>(kotlinx.serialization/KSerializer<#A>) // com.monkopedia.ksrpc.flow/KsFlowCollectorObject.<init>|<init>(kotlinx.serialization.KSerializer<1:0>){}[0]
+
+    final val endpoints // com.monkopedia.ksrpc.flow/KsFlowCollectorObject.endpoints|{}endpoints[0]
+        final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsFlowCollectorObject.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
+    final val serviceName // com.monkopedia.ksrpc.flow/KsFlowCollectorObject.serviceName|{}serviceName[0]
+        final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsFlowCollectorObject.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+
+    final fun <#A1: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.flow/KsFlowCollector<#A> // com.monkopedia.ksrpc.flow/KsFlowCollectorObject.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsFlowCollectorObject.findEndpoint|findEndpoint(kotlin.String){}[0]
+}
+
+final class <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/KsFlowServiceObject : com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowService<#A>> { // com.monkopedia.ksrpc.flow/KsFlowServiceObject|null[0]
+    constructor <init>(kotlinx.serialization/KSerializer<#A>) // com.monkopedia.ksrpc.flow/KsFlowServiceObject.<init>|<init>(kotlinx.serialization.KSerializer<1:0>){}[0]
+
+    final val endpoints // com.monkopedia.ksrpc.flow/KsFlowServiceObject.endpoints|{}endpoints[0]
+        final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsFlowServiceObject.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
+    final val serviceName // com.monkopedia.ksrpc.flow/KsFlowServiceObject.serviceName|{}serviceName[0]
+        final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsFlowServiceObject.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+
+    final fun <#A1: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.flow/KsFlowService<#A> // com.monkopedia.ksrpc.flow/KsFlowServiceObject.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsFlowServiceObject.findEndpoint|findEndpoint(kotlin.String){}[0]
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc.internal/ClientChannelContext : kotlin.coroutines/CoroutineContext.Element { // com.monkopedia.ksrpc.internal/ClientChannelContext|null[0]
@@ -472,6 +516,16 @@ sealed class com.monkopedia.ksrpc/MetadataValue { // com.monkopedia.ksrpc/Metada
     }
 }
 
+final object com.monkopedia.ksrpc.flow/KsCollectionTokenObject : com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsCollectionToken> { // com.monkopedia.ksrpc.flow/KsCollectionTokenObject|null[0]
+    final val endpoints // com.monkopedia.ksrpc.flow/KsCollectionTokenObject.endpoints|{}endpoints[0]
+        final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsCollectionTokenObject.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
+    final val serviceName // com.monkopedia.ksrpc.flow/KsCollectionTokenObject.serviceName|{}serviceName[0]
+        final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsCollectionTokenObject.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+
+    final fun <#A1: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.flow/KsCollectionToken // com.monkopedia.ksrpc.flow/KsCollectionTokenObject.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsCollectionTokenObject.findEndpoint|findEndpoint(kotlin.String){}[0]
+}
+
 final object com.monkopedia.ksrpc/BinaryTransformer : com.monkopedia.ksrpc/Transformer<io.ktor.utils.io/ByteReadChannel> { // com.monkopedia.ksrpc/BinaryTransformer|null[0]
     final suspend fun <#A1: kotlin/Any?> transform(io.ktor.utils.io/ByteReadChannel, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/BinaryTransformer.transform|transform(io.ktor.utils.io.ByteReadChannel;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
     final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): io.ktor.utils.io/ByteReadChannel // com.monkopedia.ksrpc/BinaryTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
@@ -493,6 +547,7 @@ final fun (com.monkopedia.ksrpc/RpcObject<*>).com.monkopedia.ksrpc/serviceInterf
 final fun <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> (#A).com.monkopedia.ksrpc/serialized(com.monkopedia.ksrpc/RpcObject<#A>, com.monkopedia.ksrpc/KsrpcEnvironment<#B>): com.monkopedia.ksrpc.channels/SerializedService<#B> // com.monkopedia.ksrpc/serialized|serialized@0:0(com.monkopedia.ksrpc.RpcObject<0:0>;com.monkopedia.ksrpc.KsrpcEnvironment<0:1>){0§<com.monkopedia.ksrpc.RpcService>;1§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/onError(com.monkopedia.ksrpc/ErrorListener): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/onError|onError@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(com.monkopedia.ksrpc.ErrorListener){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/reconfigure(kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/reconfigure|reconfigure@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (kotlinx.coroutines.flow/Flow<#A>).com.monkopedia.ksrpc.flow/asKsFlow(): com.monkopedia.ksrpc.flow/KsFlowService<#A> // com.monkopedia.ksrpc.flow/asKsFlow|asKsFlow@kotlinx.coroutines.flow.Flow<0:0>(){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> com.monkopedia.ksrpc/ksrpcEnvironment(com.monkopedia.ksrpc/CallDataSerializer<#A>, kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/ksrpcEnvironment|ksrpcEnvironment(com.monkopedia.ksrpc.CallDataSerializer<0:0>;kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
 final fun com.monkopedia.ksrpc.channels/randomUuid(): kotlin/String // com.monkopedia.ksrpc.channels/randomUuid|randomUuid(){}[0]
 final fun com.monkopedia.ksrpc/ksrpcEnvironment(kotlinx.serialization/StringFormat = ..., kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<kotlin/String>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<kotlin/String> // com.monkopedia.ksrpc/ksrpcEnvironment|ksrpcEnvironment(kotlinx.serialization.StringFormat;kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<kotlin.String>,kotlin.Unit>){}[0]

--- a/ksrpc-core/src/commonMain/kotlin/flow/AsKsFlow.kt
+++ b/ksrpc-core/src/commonMain/kotlin/flow/AsKsFlow.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.asString
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.launch
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Wrap a standard [Flow] in a [KsFlowService] implementation suitable for
+ * hosting over ksrpc.
+ *
+ * Each call to [KsFlowService.startCollection] launches a new coroutine that
+ * collects from this flow, forwarding items to the provided
+ * [KsFlowCollector]. The returned [KsCollectionToken] can cancel that
+ * collection.
+ *
+ * The [KsFlowService] does NOT auto-close on collection completion -- it
+ * stays alive until [KsFlowService.close] is called.
+ */
+fun <T> Flow<T>.asKsFlow(): KsFlowService<T> = KsFlowServiceImpl(this)
+
+internal class KsFlowServiceImpl<T>(
+    private val source: Flow<T>
+) : KsFlowService<T> {
+    private val parentJob = SupervisorJob()
+
+    override suspend fun startCollection(collector: KsFlowCollector<T>): KsCollectionToken {
+        val scope = CoroutineScope(coroutineContext + parentJob)
+        val job = scope.launch {
+            try {
+                source.collect { item ->
+                    collector.onItem(item)
+                }
+                collector.onComplete(Unit)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // Collection was cancelled -- don't send onError for cancellation
+                throw e
+            } catch (e: Throwable) {
+                collector.onError(RpcFailure(e.asString))
+            }
+        }
+        return object : KsCollectionToken {
+            override suspend fun cancelCollection(u: Unit) {
+                job.cancel()
+            }
+        }
+    }
+
+    override suspend fun collect(collector: FlowCollector<T>) {
+        source.collect(collector)
+    }
+
+    override suspend fun close() {
+        parentJob.cancel()
+    }
+}

--- a/ksrpc-core/src/commonMain/kotlin/flow/AutoClosingFlow.kt
+++ b/ksrpc-core/src/commonMain/kotlin/flow/AutoClosingFlow.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+
+/**
+ * A [Flow] wrapper that closes the underlying [KsFlowService] after
+ * collection completes or fails.
+ *
+ * Used by the compiler for `Flow<T>` return types -- the client gets a
+ * single-use flow that automatically cleans up the sub-service.
+ */
+class AutoClosingFlow<T>(private val delegate: KsFlowService<T>) : Flow<T> {
+    override suspend fun collect(collector: FlowCollector<T>) {
+        try {
+            delegate.collect(collector)
+        } finally {
+            delegate.close()
+        }
+    }
+}

--- a/ksrpc-core/src/commonMain/kotlin/flow/KsCollectionToken.kt
+++ b/ksrpc-core/src/commonMain/kotlin/flow/KsCollectionToken.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcService
+
+/**
+ * Token returned from [KsFlowService.startCollection] that allows the client
+ * to cancel an active collection.
+ *
+ * Calling [cancelCollection] cancels the server-side collection coroutine.
+ * This is a notification (fire-and-forget).
+ */
+interface KsCollectionToken : RpcService {
+    /**
+     * Cancel the active collection associated with this token.
+     *
+     * This is a notification -- no response is expected.
+     */
+    suspend fun cancelCollection(u: Unit)
+}

--- a/ksrpc-core/src/commonMain/kotlin/flow/KsCollectionTokenObject.kt
+++ b/ksrpc-core/src/commonMain/kotlin/flow/KsCollectionTokenObject.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcEndpointException
+import com.monkopedia.ksrpc.RpcMethod
+import com.monkopedia.ksrpc.RpcObject
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.SerializerTransformer
+import com.monkopedia.ksrpc.ServiceExecutor
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.serialization.builtins.serializer
+
+/**
+ * [RpcObject] for [KsCollectionToken].
+ *
+ * Not generic -- [KsCollectionToken] has no type parameter.
+ */
+object KsCollectionTokenObject : RpcObject<KsCollectionToken> {
+    override val serviceName: String = "KsCollectionToken"
+    override val endpoints: List<String> = listOf("/cancel")
+
+    private val cancelMethod: RpcMethod<*, *, *> by lazy {
+        RpcMethod<KsCollectionToken, Unit, Unit>(
+            endpoint = "/cancel",
+            inputTransform = SerializerTransformer(Unit.serializer()),
+            outputTransform = SerializerTransformer(Unit.serializer()),
+            method = object : ServiceExecutor {
+                override suspend fun invoke(service: RpcService, input: Any?): Any? {
+                    (service as KsCollectionToken).cancelCollection(Unit)
+                    return Unit
+                }
+            },
+            metadata = emptyList()
+        )
+    }
+
+    override fun <S> createStub(channel: SerializedService<S>): KsCollectionToken =
+        KsCollectionTokenStub(channel)
+
+    override fun findEndpoint(endpoint: String): RpcMethod<*, *, *> = when (endpoint) {
+        "/cancel" -> cancelMethod
+        else -> throw RpcEndpointException("Unknown endpoint: $endpoint")
+    }
+}
+
+private class KsCollectionTokenStub<S>(
+    private val channel: SerializedService<S>
+) : KsCollectionToken {
+    override suspend fun cancelCollection(u: Unit) {
+        KsCollectionTokenObject.findEndpoint("/cancel").callChannel(channel, u)
+    }
+
+    override suspend fun close() {
+        channel.close()
+    }
+}

--- a/ksrpc-core/src/commonMain/kotlin/flow/KsFlowCollector.kt
+++ b/ksrpc-core/src/commonMain/kotlin/flow/KsFlowCollector.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.RpcService
+
+/**
+ * Sub-service interface for receiving flow items, errors, and completion signals.
+ *
+ * Each active collection gets its own [KsFlowCollector] instance. The server
+ * calls [onItem] for each element, [onComplete] when the flow finishes
+ * normally, and [onError] when it finishes with an exception.
+ *
+ * [onError] and [onComplete] are terminal -- after either is called, no more
+ * [onItem] calls will be made on this collector.
+ */
+interface KsFlowCollector<T> : RpcService {
+    /**
+     * Deliver an item from the flow to the collector.
+     *
+     * This is a suspend call through the sub-service path, providing natural
+     * back-pressure -- the server blocks until the client processes the item.
+     */
+    suspend fun onItem(item: T)
+
+    /**
+     * Signal that the flow terminated with an error.
+     *
+     * This is a notification (fire-and-forget). Terminal for this collection.
+     */
+    suspend fun onError(error: RpcFailure)
+
+    /**
+     * Signal that the flow completed normally.
+     *
+     * This is a notification (fire-and-forget). Terminal for this collection.
+     */
+    suspend fun onComplete(u: Unit)
+}

--- a/ksrpc-core/src/commonMain/kotlin/flow/KsFlowCollectorObject.kt
+++ b/ksrpc-core/src/commonMain/kotlin/flow/KsFlowCollectorObject.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcEndpointException
+import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.RpcMethod
+import com.monkopedia.ksrpc.RpcObject
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.SerializerTransformer
+import com.monkopedia.ksrpc.ServiceExecutor
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.serializer
+
+/**
+ * [RpcObject] for [KsFlowCollector] parameterized by item type.
+ *
+ * A new instance is needed for each concrete `T` because the `onItem`
+ * endpoint carries a value of type `T`.
+ */
+class KsFlowCollectorObject<T>(
+    private val itemSerializer: KSerializer<T>
+) : RpcObject<KsFlowCollector<T>> {
+    override val serviceName: String = "KsFlowCollector"
+    override val endpoints: List<String> = listOf("/onItem", "/onError", "/onComplete")
+
+    private val onItemMethod: RpcMethod<*, *, *> by lazy {
+        RpcMethod<KsFlowCollector<T>, T, Unit>(
+            endpoint = "/onItem",
+            inputTransform = SerializerTransformer(itemSerializer),
+            outputTransform = SerializerTransformer(Unit.serializer()),
+            method = object : ServiceExecutor {
+                @Suppress("UNCHECKED_CAST")
+                override suspend fun invoke(service: RpcService, input: Any?): Any? {
+                    (service as KsFlowCollector<T>).onItem(input as T)
+                    return Unit
+                }
+            },
+            metadata = emptyList()
+        )
+    }
+
+    private val onErrorMethod: RpcMethod<*, *, *> by lazy {
+        RpcMethod<KsFlowCollector<T>, RpcFailure, Unit>(
+            endpoint = "/onError",
+            inputTransform = SerializerTransformer(RpcFailure.serializer()),
+            outputTransform = SerializerTransformer(Unit.serializer()),
+            method = object : ServiceExecutor {
+                override suspend fun invoke(service: RpcService, input: Any?): Any? {
+                    (service as KsFlowCollector<*>).onError(input as RpcFailure)
+                    return Unit
+                }
+            },
+            metadata = emptyList()
+        )
+    }
+
+    private val onCompleteMethod: RpcMethod<*, *, *> by lazy {
+        RpcMethod<KsFlowCollector<T>, Unit, Unit>(
+            endpoint = "/onComplete",
+            inputTransform = SerializerTransformer(Unit.serializer()),
+            outputTransform = SerializerTransformer(Unit.serializer()),
+            method = object : ServiceExecutor {
+                override suspend fun invoke(service: RpcService, input: Any?): Any? {
+                    (service as KsFlowCollector<*>).onComplete(Unit)
+                    return Unit
+                }
+            },
+            metadata = emptyList()
+        )
+    }
+
+    override fun <S> createStub(channel: SerializedService<S>): KsFlowCollector<T> =
+        KsFlowCollectorStub(channel, this)
+
+    override fun findEndpoint(endpoint: String): RpcMethod<*, *, *> = when (endpoint) {
+        "/onItem" -> onItemMethod
+        "/onError" -> onErrorMethod
+        "/onComplete" -> onCompleteMethod
+        else -> throw RpcEndpointException("Unknown endpoint: $endpoint")
+    }
+}
+
+private class KsFlowCollectorStub<T, S>(
+    private val channel: SerializedService<S>,
+    private val obj: KsFlowCollectorObject<T>
+) : KsFlowCollector<T> {
+    override suspend fun onItem(item: T) {
+        obj.findEndpoint("/onItem").callChannel(channel, item)
+    }
+
+    override suspend fun onError(error: RpcFailure) {
+        obj.findEndpoint("/onError").callChannel(channel, error)
+    }
+
+    override suspend fun onComplete(u: Unit) {
+        obj.findEndpoint("/onComplete").callChannel(channel, u)
+    }
+
+    override suspend fun close() {
+        channel.close()
+    }
+}

--- a/ksrpc-core/src/commonMain/kotlin/flow/KsFlowService.kt
+++ b/ksrpc-core/src/commonMain/kotlin/flow/KsFlowService.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Sub-service interface that bridges a [Flow] over the ksrpc sub-service
+ * protocol.
+ *
+ * Extends both [Flow] (so it can be collected with standard coroutines APIs)
+ * and [RpcService] (for sub-service lifecycle management).
+ *
+ * **Common case (`Flow<T>` in signature):** The compiler wraps returns in
+ * [AutoClosingFlow] so the sub-service is closed after collection. Single-use.
+ *
+ * **Advanced case (`KsFlowService<T>` in signature):** The client gets the
+ * raw service, can call [collect] multiple times, and must call [close]
+ * explicitly when done.
+ */
+interface KsFlowService<T> : Flow<T>, RpcService {
+    /**
+     * Start collecting from this flow service.
+     *
+     * The caller provides a [KsFlowCollector] sub-service that will receive
+     * items, completion, and error signals. Returns a [KsCollectionToken] that
+     * can be used to cancel the collection.
+     *
+     * Multiple calls are allowed -- each gets its own collection job and token.
+     */
+    suspend fun startCollection(collector: KsFlowCollector<T>): KsCollectionToken
+}

--- a/ksrpc-core/src/commonMain/kotlin/flow/KsFlowServiceObject.kt
+++ b/ksrpc-core/src/commonMain/kotlin/flow/KsFlowServiceObject.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcEndpointException
+import com.monkopedia.ksrpc.RpcMethod
+import com.monkopedia.ksrpc.RpcObject
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.ServiceExecutor
+import com.monkopedia.ksrpc.SubserviceTransformer
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.serialization.KSerializer
+
+/**
+ * [RpcObject] for [KsFlowService] parameterized by item type.
+ *
+ * A new instance is needed for each concrete `T` because the sub-service
+ * transformers for [KsFlowCollector] carry a serializer for `T`.
+ */
+class KsFlowServiceObject<T>(
+    private val itemSerializer: KSerializer<T>
+) : RpcObject<KsFlowService<T>> {
+    internal val collectorObject = KsFlowCollectorObject(itemSerializer)
+
+    override val serviceName: String = "KsFlowService"
+    override val endpoints: List<String> = listOf("/collect")
+
+    private val collectMethod: RpcMethod<*, *, *> by lazy {
+        RpcMethod<KsFlowService<T>, KsFlowCollector<T>, KsCollectionToken>(
+            endpoint = "/collect",
+            inputTransform = SubserviceTransformer(collectorObject),
+            outputTransform = SubserviceTransformer(KsCollectionTokenObject),
+            method = object : ServiceExecutor {
+                @Suppress("UNCHECKED_CAST")
+                override suspend fun invoke(service: RpcService, input: Any?): Any? {
+                    return (service as KsFlowService<T>)
+                        .startCollection(input as KsFlowCollector<T>)
+                }
+            },
+            metadata = emptyList()
+        )
+    }
+
+    override fun <S> createStub(channel: SerializedService<S>): KsFlowService<T> =
+        KsFlowServiceStub(channel, this)
+
+    override fun findEndpoint(endpoint: String): RpcMethod<*, *, *> = when (endpoint) {
+        "/collect" -> collectMethod
+        else -> throw RpcEndpointException("Unknown endpoint: $endpoint")
+    }
+}
+
+/**
+ * Client-side stub for [KsFlowService].
+ *
+ * The [collect] implementation (from [kotlinx.coroutines.flow.Flow]):
+ * 1. Creates a [KsFlowCollector] that feeds items into the standard [FlowCollector]
+ * 2. Calls [startCollection] to get a [KsCollectionToken]
+ * 3. Suspends until [onComplete] or [onError]
+ * 4. On coroutine cancellation, calls [KsCollectionToken.cancelCollection]
+ */
+private class KsFlowServiceStub<T, S>(
+    private val channel: SerializedService<S>,
+    private val obj: KsFlowServiceObject<T>
+) : KsFlowService<T> {
+
+    override suspend fun startCollection(collector: KsFlowCollector<T>): KsCollectionToken {
+        @Suppress("UNCHECKED_CAST")
+        return obj.findEndpoint("/collect").callChannel(channel, collector) as KsCollectionToken
+    }
+
+    override suspend fun collect(collector: FlowCollector<T>) {
+        val completion = CompletableDeferred<Unit>()
+        val collectorImpl = object : KsFlowCollector<T> {
+            override suspend fun onItem(item: T) {
+                collector.emit(item)
+            }
+
+            override suspend fun onError(error: com.monkopedia.ksrpc.RpcFailure) {
+                completion.completeExceptionally(error.toException())
+            }
+
+            override suspend fun onComplete(u: Unit) {
+                completion.complete(Unit)
+            }
+        }
+        val token = startCollection(collectorImpl)
+        try {
+            completion.await()
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            token.cancelCollection(Unit)
+            throw e
+        }
+    }
+
+    override suspend fun close() {
+        channel.close()
+    }
+}

--- a/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.flow.AutoClosingFlow
+import com.monkopedia.ksrpc.flow.KsCollectionToken
+import com.monkopedia.ksrpc.flow.KsFlowCollector
+import com.monkopedia.ksrpc.flow.KsFlowService
+import com.monkopedia.ksrpc.flow.KsFlowServiceObject
+import com.monkopedia.ksrpc.flow.asKsFlow
+import com.monkopedia.ksrpc.sockets.asConnection
+import io.ktor.utils.io.close
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.builtins.serializer
+
+/**
+ * Tests for the KsFlowService sub-service protocol using manual wiring
+ * (no compiler plugin needed).
+ */
+class KsFlowServiceTest {
+
+    private val flowServiceObject = KsFlowServiceObject(String.serializer())
+
+    private fun <T : RpcService> T.manualSerialized(
+        rpcObject: RpcObject<T>,
+        env: KsrpcEnvironment<String>
+    ) = serialized(rpcObject, env)
+
+    /**
+     * Protocol test: Items flow from server to client through the sub-service
+     * protocol over a bidirectional pipe.
+     */
+    @Test
+    fun testBasicFlowCollection() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow {
+                emit("a")
+                emit("b")
+                emit("c")
+            }.asKsFlow()
+            c.registerDefault(
+                flowService.manualSerialized(flowServiceObject, c.env)
+            )
+        },
+        clientJob = { c ->
+            val stub = flowServiceObject.createStub(c.defaultChannel())
+            val items = stub.toList()
+            assertEquals(listOf("a", "b", "c"), items)
+        }
+    )
+
+    /**
+     * Auto-close test: Flow<T> wrapper closes the sub-service after collection.
+     */
+    @Test
+    fun testAutoClosingFlow() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow {
+                emit("x")
+                emit("y")
+            }.asKsFlow()
+            c.registerDefault(
+                flowService.manualSerialized(flowServiceObject, c.env)
+            )
+        },
+        clientJob = { c ->
+            val stub = flowServiceObject.createStub(c.defaultChannel())
+            val autoClosing = AutoClosingFlow(stub)
+            val items = autoClosing.toList()
+            assertEquals(listOf("x", "y"), items)
+        }
+    )
+
+    /**
+     * Multi-collection test: KsFlowService allows multiple sequential
+     * collections.
+     */
+    @Test
+    fun testMultipleCollections() = executePipe(
+        serviceJob = { c ->
+            val flowService = object : KsFlowService<String> {
+                private var counter = 0
+                override suspend fun startCollection(
+                    collector: KsFlowCollector<String>
+                ): KsCollectionToken {
+                    val batch = counter++
+                    return flow {
+                        emit("batch$batch-1")
+                        emit("batch$batch-2")
+                    }.asKsFlow().startCollection(collector)
+                }
+
+                override suspend fun collect(
+                    collector: kotlinx.coroutines.flow.FlowCollector<String>
+                ) {
+                    error("Server should not use collect directly")
+                }
+            }
+            c.registerDefault(
+                flowService.manualSerialized(flowServiceObject, c.env)
+            )
+        },
+        clientJob = { c ->
+            val stub = flowServiceObject.createStub(c.defaultChannel())
+            val first = stub.toList()
+            assertEquals(listOf("batch0-1", "batch0-2"), first)
+            val second = stub.toList()
+            assertEquals(listOf("batch1-1", "batch1-2"), second)
+        }
+    )
+
+    /**
+     * Error propagation: Server-side flow throws, onError fires, client-side
+     * collect throws.
+     */
+    @Test
+    fun testErrorPropagation() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow<String> {
+                emit("ok")
+                throw RuntimeException("test error from server")
+            }.asKsFlow()
+            c.registerDefault(
+                flowService.manualSerialized(flowServiceObject, c.env)
+            )
+        },
+        clientJob = { c ->
+            val stub = flowServiceObject.createStub(c.defaultChannel())
+            val items = mutableListOf<String>()
+            val exception = assertFailsWith<RpcException> {
+                stub.collect { item ->
+                    items.add(item)
+                }
+            }
+            assertEquals(listOf("ok"), items)
+            assertTrue(exception.message.contains("test error from server"))
+        }
+    )
+
+    /**
+     * Cancellation: Client cancels collection, cancelCollection fires,
+     * server-side collection job cancelled.
+     */
+    @Test
+    fun testCancellation() = executePipe(
+        serviceJob = { c ->
+            val serverCancelled = CompletableDeferred<Boolean>()
+            val flowService = flow<String> {
+                try {
+                    emit("1")
+                    emit("2")
+                    delay(10_000)
+                    emit("3")
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    serverCancelled.complete(true)
+                    throw e
+                }
+            }.asKsFlow()
+            c.registerDefault(
+                flowService.manualSerialized(flowServiceObject, c.env)
+            )
+            withTimeout(5000) {
+                assertTrue(serverCancelled.await())
+            }
+        },
+        clientJob = { c ->
+            val stub = flowServiceObject.createStub(c.defaultChannel())
+            val items = mutableListOf<String>()
+            val completion = CompletableDeferred<Unit>()
+            val collectorImpl = object : KsFlowCollector<String> {
+                override suspend fun onItem(item: String) {
+                    items.add(item)
+                }
+
+                override suspend fun onError(error: RpcFailure) {
+                    completion.completeExceptionally(error.toException())
+                }
+
+                override suspend fun onComplete(u: Unit) {
+                    completion.complete(Unit)
+                }
+            }
+            val token = stub.startCollection(collectorImpl)
+            delay(500)
+            token.cancelCollection(Unit)
+            assertEquals(listOf("1", "2"), items)
+        }
+    )
+
+    /**
+     * Back-pressure: Server's onItem blocks until client processes (since it's
+     * a suspend call through sub-service).
+     */
+    @Test
+    fun testBackPressure() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow {
+                emit("fast-1")
+                emit("fast-2")
+                emit("fast-3")
+            }.asKsFlow()
+            c.registerDefault(
+                flowService.manualSerialized(flowServiceObject, c.env)
+            )
+        },
+        clientJob = { c ->
+            val stub = flowServiceObject.createStub(c.defaultChannel())
+            val items = mutableListOf<String>()
+            val processOrder = mutableListOf<String>()
+            stub.collect { item ->
+                processOrder.add("start-$item")
+                delay(100)
+                processOrder.add("end-$item")
+                items.add(item)
+            }
+            assertEquals(listOf("fast-1", "fast-2", "fast-3"), items)
+            assertEquals(
+                listOf(
+                    "start-fast-1", "end-fast-1",
+                    "start-fast-2", "end-fast-2",
+                    "start-fast-3", "end-fast-3"
+                ),
+                processOrder
+            )
+        }
+    )
+
+    private fun executePipe(
+        serviceJob: suspend (Connection<String>) -> Unit,
+        clientJob: suspend (Connection<String>) -> Unit
+    ) = runBlockingUnit {
+        val (output, input) = createPipe()
+        val (so, si) = createPipe()
+        val serviceChannel = (si to output).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { }
+            }
+        )
+        val clientChannel = (input to so).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { }
+            }
+        )
+        val bgJob = GlobalScope.launch(Dispatchers.Default) {
+            serviceJob(serviceChannel)
+        }
+        try {
+            clientJob(clientChannel)
+        } finally {
+            try { clientChannel.close() } catch (_: Throwable) {}
+            try { serviceChannel.close() } catch (_: Throwable) {}
+            try { input.cancel(null) } catch (_: Throwable) {}
+            try { si.cancel(null) } catch (_: Throwable) {}
+            output.close(null)
+            so.close(null)
+            bgJob.join()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `KsFlowService<T>`, `KsFlowCollector<T>`, and `KsCollectionToken` interfaces in `ksrpc-core` that bridge `Flow<T>` over the existing sub-service protocol
- Provides manual `RpcObject` implementations (`KsFlowServiceObject`, `KsFlowCollectorObject`, `KsCollectionTokenObject`) parameterized by item serializer
- Implements host-side `Flow<T>.asKsFlow()` extension that wraps a standard flow in `KsFlowService`
- Implements `AutoClosingFlow<T>` wrapper for single-use `Flow<T>` return type semantics
- Client-side stub bridges `KsFlowService.collect()` through the sub-service protocol with proper cancellation, error propagation, and back-pressure

## What's implemented

**Core types (steps 1-5 from the agreed design):**
- Three sub-service interfaces matching the agreed wire protocol
- Host-side implementation: `startCollection` launches a collection coroutine, forwards items via `onItem`, signals completion/error, returns cancellation token
- Client-side stub: creates `KsFlowCollector` impl, calls `startCollection`, suspends until `onComplete`/`onError`, propagates cancellation
- `AutoClosingFlow` for single-use `Flow<T>` semantics (close sub-service after collection)
- `asKsFlow()` conversion helper
- BCV API dump updated

## What's deferred

**Compiler plugin automation:** The compiler plugin changes to automatically detect `Flow<T>` or `KsFlowService<T>` in `@KsMethod` signatures and generate the appropriate transformers are deferred. This requires:
- Detecting `Flow<T>` in return/param types and resolving `T` to get the concrete serializer
- Generating `FlowTransformer` (similar to `SubserviceTransformer`) for `Flow<T>` <-> `KsFlowService<T>` bridging
- Generating `AutoClosingFlow` wrapping for `Flow<T>` signatures on client side
- A follow-up issue should be filed for this work

The core types and protocol are the hard design work; compiler automation can follow.

## Test plan

Six tests over bidirectional pipe transport (manual wiring, no compiler plugin needed):
- [x] Basic flow collection: items flow server -> client
- [x] AutoClosingFlow: closes sub-service after collection completes
- [x] Multiple sequential collections on same `KsFlowService`
- [x] Error propagation: server flow throws -> `onError` -> client `collect` throws `RpcException`
- [x] Cancellation: client calls `cancelCollection` -> server collection job cancelled
- [x] Back-pressure: `onItem` suspend blocks server until client processes each item

All tests pass on JVM and linuxX64.

Closes #2

Generated with [Claude Code](https://claude.com/claude-code)