### PR TITLE
Drop pointless allSupertypesPreservingArguments wrapper

### DIFF
--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -246,7 +246,6 @@ public abstract interface annotation class com/monkopedia/ksrpc/RpcObjectKey : j
 }
 
 public final class com/monkopedia/ksrpc/RpcObjectKt {
-	public static final fun allSupertypesPreservingArguments (Lkotlin/reflect/KType;)Ljava/util/List;
 	public static final fun getAsString (Ljava/lang/Throwable;)Ljava/lang/String;
 }
 

--- a/ksrpc-core/src/jvmMain/kotlin/RpcObject.kt
+++ b/ksrpc-core/src/jvmMain/kotlin/RpcObject.kt
@@ -50,10 +50,11 @@ actual inline fun <reified T : RpcService> rpcObject(): RpcObject<T> {
             return (companion as RpcObjectFactory<T>).create(typeArgs)
         }
     }
-    // Walk supertypes using KType so type arguments are preserved. For example, for
-    // `interface TypedGenericEcho : GenericEcho<String>`, `allSupertypes` yields a KType for
-    // `GenericEcho<String>` with `String` in `arguments`, which we feed to the factory.
-    for (supertype in kotlin.reflect.typeOf<T>().allSupertypesPreservingArguments()) {
+    // Walk supertypes via KClass.allSupertypes, which returns KTypes with type arguments
+    // already substituted. For `interface TypedGenericEcho : GenericEcho<String>` this yields
+    // a KType for `GenericEcho<String>` with `String` in `arguments` — exactly what the
+    // factory needs.
+    for (supertype in klass.allSupertypes) {
         val superKlass = supertype.classifier as? KClass<*> ?: continue
         when (val superCompanion = superKlass.companionObjectInstance) {
             is RpcObject<*> -> return superCompanion as RpcObject<T>
@@ -69,19 +70,6 @@ actual inline fun <reified T : RpcService> rpcObject(): RpcObject<T> {
         }
     }
     return error("Can't find rpc companion for $klass")
-}
-
-/**
- * Walk the supertypes of this [kotlin.reflect.KType], preserving the concrete type
- * arguments of each supertype. Uses [kotlin.reflect.KClass.allSupertypes] on the classifier
- * of this type — `allSupertypes` already returns the supertypes with their declared type
- * parameters substituted, so `GenericEcho<String>` shows up with `String` in its arguments
- * when queried from `TypedGenericEcho`.
- */
-@PublishedApi
-internal fun kotlin.reflect.KType.allSupertypesPreservingArguments(): List<kotlin.reflect.KType> {
-    val classifier = this.classifier as? KClass<*> ?: return emptyList()
-    return classifier.allSupertypes.toList()
 }
 
 actual val Throwable.asString: String


### PR DESCRIPTION
## Summary

- Inline `classifier.allSupertypes.toList()` at the single call site in `rpcObject()`.
- Drop the `allSupertypesPreservingArguments` extension — it was a no-op wrapper whose name claimed behavior that `kotlin.reflect.KClass.allSupertypes` already provides.
- Removes one `@PublishedApi internal` symbol from the ksrpc-core BCV surface.

## Why

Flagged during review of PR #42. The helper added no behavior but leaked into BCV.

## Test plan

- [x] `./gradlew :ksrpc-core:apiCheck` passes with updated dump
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-test:jvmTest` pass