### PR TITLE
Refactor: extract common FIR/IR patterns in the ksrpc compiler plugin

### DIFF
--- a/compiler/plugin/src/main/java/CompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/CompanionGeneration.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.irThrow
 import org.jetbrains.kotlin.ir.backend.js.utils.isDispatchReceiver
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
-import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irBranch
 import org.jetbrains.kotlin.ir.builders.irCall
@@ -36,12 +35,10 @@ import org.jetbrains.kotlin.ir.builders.irInt
 import org.jetbrains.kotlin.ir.builders.irNotEquals
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irString
-import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.builders.irWhen
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
-import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
@@ -105,7 +102,7 @@ class CompanionGeneration(
             .firstOrNull { it.name == FqConstants.ENDPOINTS }
             ?.let { property ->
                 val endpoints = cls.endpoints.keys.map { it.trimStart('/') }
-                val listExpr = context.irBuilder(property).irListOfStrings(endpoints)
+                val listExpr = context.irBuilder(property).irListOfStrings(env, endpoints)
                 property.backingField?.initializer =
                     irFactory.createExpressionBody(
                         SYNTHETIC_OFFSET,
@@ -113,7 +110,7 @@ class CompanionGeneration(
                         listExpr
                     )
                 property.getter?.body = context.irBuilder(property.getter!!).irSynthBody {
-                    +irReturn(irListOfStrings(endpoints))
+                    +irReturn(irListOfStrings(env, endpoints))
                 }
             }
         // For generic service companions, eagerly emit the `arity` getter body — the
@@ -160,7 +157,7 @@ class CompanionGeneration(
             if (propertyName == FqConstants.ENDPOINTS) {
                 val endpoints = cls.endpoints.keys.map { it.trimStart('/') }
                 return context.irBuilder(function).irSynthBody {
-                    +irReturn(irListOfStrings(endpoints))
+                    +irReturn(irListOfStrings(env, endpoints))
                 }
             }
             if (propertyName == FqConstants.ARITY) {
@@ -339,16 +336,6 @@ class CompanionGeneration(
             )
         }
     }
-
-    private fun IrBuilderWithScope.irListOfStrings(values: List<String>) =
-        irCall(env.listOfFunction)
-            .apply {
-                typeArguments[0] = context.irBuiltIns.stringType
-                val varargParameter = env.listOfFunction.owner.parameters
-                    .single { it.kind == IrParameterKind.Regular }
-                arguments[varargParameter] =
-                    irVararg(context.irBuiltIns.stringType, values.map { irString(it) })
-            }
 
     override fun generateBodyForConstructor(
         constructor: IrConstructor,

--- a/compiler/plugin/src/main/java/FirCompanionDeclarationGenerator.kt
+++ b/compiler/plugin/src/main/java/FirCompanionDeclarationGenerator.kt
@@ -170,6 +170,7 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
                 } else {
                     emptyList()
                 }
+
                 else -> emptyList()
             }
         }
@@ -352,11 +353,13 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
         val key = origin?.key as? Key
         return when {
             key == null -> setOf(FIND_ENDPOINT, CREATE_STUB, SERVICE_NAME, ENDPOINTS)
+
             key.isGeneric -> if (factorySupported) {
                 setOf(INVOKE, CREATE, ARITY, SpecialNames.INIT)
             } else {
                 setOf(INVOKE, SpecialNames.INIT)
             }
+
             else -> setOf(FIND_ENDPOINT, CREATE_STUB, SERVICE_NAME, ENDPOINTS, SpecialNames.INIT)
         }
     }

--- a/compiler/plugin/src/main/java/FirCompanionDeclarationGenerator.kt
+++ b/compiler/plugin/src/main/java/FirCompanionDeclarationGenerator.kt
@@ -213,10 +213,7 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
         val retTypeProvider: (List<org.jetbrains.kotlin.fir.declarations.FirTypeParameter>) ->
         ConeKotlinType = { tps ->
             // RpcObject<Service<T1, T2, ...>>
-            val serviceType = ownerKey.classId.createConeType(
-                session,
-                tps.map { it.symbol.toConeType() }.toTypedArray()
-            )
+            val serviceType = ownerKey.classId.createConeTypeForRefs(session, tps)
             RPC_OBJECT.createConeType(session, arrayOf(serviceType))
         }
         val function = createMemberFunction(
@@ -232,17 +229,7 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
             for (tp in serviceTypeParams) {
                 typeParameter(tp.name, Variance.INVARIANT, isReified = false)
             }
-            for ((idx, tp) in serviceTypeParams.withIndex()) {
-                valueParameter(
-                    Name.identifier(tp.name.asString() + "Serializer"),
-                    { types ->
-                        KSERIALIZER.createConeType(
-                            session,
-                            arrayOf(types[idx].symbol.toConeType())
-                        )
-                    }
-                )
-            }
+            addSerializerValueParameters(session, serviceTypeParams)
         }
         return listOf(function.symbol)
     }
@@ -265,12 +252,8 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
         ) { ConeStarProjection }
         val serviceStarType = serviceClassId.createConeType(session, starProjections)
         val retType = RPC_OBJECT.createConeType(session, arrayOf(serviceStarType))
-        val listClassId = ClassId(
-            org.jetbrains.kotlin.name.FqName("kotlin.collections"),
-            Name.identifier("List")
-        )
         val listOfKType =
-            listClassId.createConeType(session, arrayOf(KTYPE.createConeType(session)))
+            LIST_CLASS_ID.createConeType(session, arrayOf(KTYPE.createConeType(session)))
         val function = createMemberFunction(owner, ownerKey, callableId.callableName, retType) {
             modality = FINAL
             status {
@@ -338,10 +321,8 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
         owner: FirClassSymbol<*>,
         ownerKey: Key
     ): List<FirPropertySymbol> {
-        val listType = ClassId(
-            org.jetbrains.kotlin.name.FqName("kotlin.collections"),
-            Name.identifier("List")
-        ).createConeType(session, arrayOf(session.builtinTypes.stringType.coneType))
+        val listType = LIST_CLASS_ID
+            .createConeType(session, arrayOf(session.builtinTypes.stringType.coneType))
         val property = createMemberProperty(
             owner,
             ownerKey,

--- a/compiler/plugin/src/main/java/FirGeneratorUtils.kt
+++ b/compiler/plugin/src/main/java/FirGeneratorUtils.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.plugin
+
+import com.monkopedia.ksrpc.plugin.FqConstants.KSERIALIZER
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.FirTypeParameterRef
+import org.jetbrains.kotlin.fir.plugin.FunctionBuildingContext
+import org.jetbrains.kotlin.fir.plugin.createConeType
+import org.jetbrains.kotlin.fir.scopes.impl.toConeType
+import org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * Helpers shared across the FIR declaration generators. Patterns captured here appear in
+ * two or more of [FirCompanionDeclarationGenerator], [FirKsrpcObjGenerator] and
+ * [FirKsrpcStubGenerator].
+ */
+
+/**
+ * Build the name used for the per-type-parameter `KSerializer<T>` field/parameter on
+ * generated `Obj`, `Stub` and factory `invoke`. Single source of truth for the naming
+ * scheme so FIR and IR sides agree.
+ */
+internal fun serializerParameterName(typeParameterName: Name): Name =
+    Name.identifier(typeParameterName.asString() + "Serializer")
+
+/**
+ * Adds a `KSerializer<Tn>` value parameter for each service/stub/obj type parameter, named
+ * consistently (see [serializerParameterName]). The type provider is positional and uses
+ * the surrounding declaration's type parameter refs by index.
+ */
+internal fun FunctionBuildingContext<*>.addSerializerValueParameters(
+    session: FirSession,
+    typeParams: List<FirTypeParameterSymbol>
+) {
+    for ((idx, tp) in typeParams.withIndex()) {
+        valueParameter(
+            serializerParameterName(tp.name),
+            typeProvider = { refs ->
+                KSERIALIZER.createConeType(
+                    session,
+                    arrayOf(refs[idx].symbol.toConeType())
+                )
+            }
+        )
+    }
+}
+
+/**
+ * Builds `ClassId<T1, T2, ...>` as a ConeKotlinType whose type arguments are the passed
+ * type-parameter refs, in order. Used to construct service instantiations that mirror the
+ * enclosing declaration's type parameters (e.g. `RpcObject<Service<T1, T2>>`).
+ */
+internal fun ClassId.createConeTypeForRefs(
+    session: FirSession,
+    refs: List<FirTypeParameterRef>
+): ConeKotlinType = createConeType(
+    session,
+    refs.map { it.symbol.toConeType() }.toTypedArray()
+)
+
+internal val LIST_CLASS_ID =
+    ClassId(FqName("kotlin.collections"), Name.identifier("List"))

--- a/compiler/plugin/src/main/java/FirGeneratorUtils.kt
+++ b/compiler/plugin/src/main/java/FirGeneratorUtils.kt
@@ -27,19 +27,13 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-/**
- * Helpers shared across the FIR declaration generators. Patterns captured here appear in
- * two or more of [FirCompanionDeclarationGenerator], [FirKsrpcObjGenerator] and
- * [FirKsrpcStubGenerator].
- */
-
-/**
- * Build the name used for the per-type-parameter `KSerializer<T>` field/parameter on
- * generated `Obj`, `Stub` and factory `invoke`. Single source of truth for the naming
- * scheme so FIR and IR sides agree.
- */
-internal fun serializerParameterName(typeParameterName: Name): Name =
-    Name.identifier(typeParameterName.asString() + "Serializer")
+// Helpers shared across the FIR declaration generators. Patterns captured here appear in
+// two or more of FirCompanionDeclarationGenerator, FirKsrpcObjGenerator and
+// FirKsrpcStubGenerator.
+//
+// The per-type-parameter `KSerializer<T>` field/parameter naming helper lives in
+// IrUtils.kt (`serializerFieldName`) and is reused here so the FIR declaration side and
+// the IR body/field side agree byte-for-byte on the generated names.
 
 /**
  * Adds a `KSerializer<Tn>` value parameter for each service/stub/obj type parameter, named
@@ -52,7 +46,7 @@ internal fun FunctionBuildingContext<*>.addSerializerValueParameters(
 ) {
     for ((idx, tp) in typeParams.withIndex()) {
         valueParameter(
-            serializerParameterName(tp.name),
+            serializerFieldName(tp.name),
             typeProvider = { refs ->
                 KSERIALIZER.createConeType(
                     session,

--- a/compiler/plugin/src/main/java/FirKsrpcObjGenerator.kt
+++ b/compiler/plugin/src/main/java/FirKsrpcObjGenerator.kt
@@ -18,7 +18,6 @@ package com.monkopedia.ksrpc.plugin
 import com.monkopedia.ksrpc.plugin.FqConstants.CREATE_STUB
 import com.monkopedia.ksrpc.plugin.FqConstants.ENDPOINTS
 import com.monkopedia.ksrpc.plugin.FqConstants.FIND_ENDPOINT
-import com.monkopedia.ksrpc.plugin.FqConstants.KSERIALIZER
 import com.monkopedia.ksrpc.plugin.FqConstants.KS_METHOD
 import com.monkopedia.ksrpc.plugin.FqConstants.KS_SERVICE
 import com.monkopedia.ksrpc.plugin.FqConstants.OBJ
@@ -52,8 +51,6 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.ConeStarProjection
 import org.jetbrains.kotlin.name.CallableId
-import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
 
@@ -96,10 +93,7 @@ class FirKsrpcObjGenerator(session: FirSession) : FirDeclarationGenerationExtens
                 typeParameter(tp.name)
             }
             superType { refs ->
-                val serviceType = owner.classId.createConeType(
-                    session,
-                    refs.map { it.symbol.toConeType() }.toTypedArray()
-                )
+                val serviceType = owner.classId.createConeTypeForRefs(session, refs)
                 RPC_OBJECT.createConeType(session, arrayOf(serviceType))
             }
         }.build().symbol
@@ -115,17 +109,7 @@ class FirKsrpcObjGenerator(session: FirSession) : FirDeclarationGenerationExtens
         val owner = context.owner as FirRegularClassSymbol
         val objTypeParams = owner.typeParameterSymbols
         val constructor = createConstructor(owner, ownerKey, isPrimary = true) {
-            for ((idx, tp) in objTypeParams.withIndex()) {
-                valueParameter(
-                    Name.identifier(tp.name.asString() + "Serializer"),
-                    typeProvider = { refs ->
-                        KSERIALIZER.createConeType(
-                            session,
-                            arrayOf(refs[idx].symbol.toConeType())
-                        )
-                    }
-                )
-            }
+            addSerializerValueParameters(session, objTypeParams)
         }
         return listOf(constructor.symbol)
     }
@@ -232,10 +216,8 @@ class FirKsrpcObjGenerator(session: FirSession) : FirDeclarationGenerationExtens
         owner: FirRegularClassSymbol,
         ownerKey: Key
     ): List<FirPropertySymbol> {
-        val listType = ClassId(
-            FqName("kotlin.collections"),
-            Name.identifier("List")
-        ).createConeType(session, arrayOf(session.builtinTypes.stringType.coneType))
+        val listType = LIST_CLASS_ID
+            .createConeType(session, arrayOf(session.builtinTypes.stringType.coneType))
         val property = createMemberProperty(
             owner,
             ownerKey,

--- a/compiler/plugin/src/main/java/FirKsrpcStubGenerator.kt
+++ b/compiler/plugin/src/main/java/FirKsrpcStubGenerator.kt
@@ -81,10 +81,7 @@ class FirKsrpcStubGenerator(session: FirSession) : FirDeclarationGenerationExten
                 if (serviceTypeParams.isEmpty()) {
                     owner.defaultType()
                 } else {
-                    owner.classId.createConeType(
-                        session,
-                        refs.map { it.symbol.toConeType() }.toTypedArray()
-                    )
+                    owner.classId.createConeTypeForRefs(session, refs)
                 }
             }
             superType(RPC_SERVICE.createConeType(session))
@@ -108,17 +105,7 @@ class FirKsrpcStubGenerator(session: FirSession) : FirDeclarationGenerationExten
                 CHANNEL,
                 SERIALIZED_SERVICE.createConeType(session, arrayOf(ConeStarProjection))
             )
-            for ((idx, tp) in stubTypeParams.withIndex()) {
-                valueParameter(
-                    Name.identifier(tp.name.asString() + "Serializer"),
-                    typeProvider = { refs ->
-                        KSERIALIZER.createConeType(
-                            session,
-                            arrayOf(refs[idx].symbol.toConeType())
-                        )
-                    }
-                )
-            }
+            addSerializerValueParameters(session, stubTypeParams)
         }
         return listOf(constructor.symbol)
     }

--- a/compiler/plugin/src/main/java/IrUtils.kt
+++ b/compiler/plugin/src/main/java/IrUtils.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
 package com.monkopedia.ksrpc.plugin
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -20,8 +22,12 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irConcat
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrSymbolOwner
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
@@ -101,4 +107,22 @@ fun IrMemberAccessExpression<*>.putArgs(vararg args: IrExpression) {
     args.forEachIndexed { index, irExpression ->
         arguments[index] = irExpression
     }
+}
+
+/**
+ * Emit a `listOf<String>(v0, v1, ...)` IR expression via the vararg overload of
+ * `kotlin.collections.listOf`. Shared between CompanionGeneration and ObjGeneration which
+ * both emit `endpoints` property bodies.
+ */
+internal fun IrBuilderWithScope.irListOfStrings(
+    env: KsrpcGenerationEnvironment,
+    values: List<String>
+): IrExpression = irCall(env.listOfFunction).apply {
+    typeArguments[0] = context.irBuiltIns.stringType
+    val varargParameter = env.listOfFunction.owner.parameters
+        .single { it.kind == IrParameterKind.Regular }
+    arguments[varargParameter] = irVararg(
+        context.irBuiltIns.stringType,
+        values.map { irString(it) }
+    )
 }

--- a/compiler/plugin/src/main/java/IrUtils.kt
+++ b/compiler/plugin/src/main/java/IrUtils.kt
@@ -19,14 +19,27 @@ package com.monkopedia.ksrpc.plugin
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
+import org.jetbrains.kotlin.ir.builders.declarations.addConstructor
+import org.jetbrains.kotlin.ir.builders.declarations.addField
+import org.jetbrains.kotlin.ir.builders.declarations.buildClass
+import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irConcat
+import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irImplicitCast
+import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrField
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrSymbolOwner
@@ -38,16 +51,22 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrStringConcatenationImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.starProjectedType
+import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
+import org.jetbrains.kotlin.ir.util.addChild
 import org.jetbrains.kotlin.ir.util.allOverridden
-import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.util.constructors
+import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
+import org.jetbrains.kotlin.ir.util.defaultType as irClassDefaultType
 import org.jetbrains.kotlin.ir.util.erasedUpperBound
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.util.capitalizeDecapitalize.capitalizeAsciiOnly
 
 fun IrBuilderWithScope.buildStringFormat(vararg args: IrExpression): IrStringConcatenationImpl =
     irConcat().apply {
@@ -66,7 +85,7 @@ fun createClassReference(
     startOffset: Int = SYNTHETIC_OFFSET,
     endOffset: Int = SYNTHETIC_OFFSET
 ): IrClassReference {
-    val classType = irClass.defaultType
+    val classType = irClass.irClassDefaultType
     val classSymbol = irClass.symbol
     return IrClassReferenceImpl(
         startOffset,
@@ -107,6 +126,121 @@ fun IrMemberAccessExpression<*>.putArgs(vararg args: IrExpression) {
     args.forEachIndexed { index, irExpression ->
         arguments[index] = irExpression
     }
+}
+
+/**
+ * Single source of truth for the `"${Tn}Serializer"` field/parameter naming scheme used
+ * across generated Obj / Stub declarations. Must match the name chosen in the FIR
+ * generators (see [serializerParameterName]).
+ */
+internal fun serializerFieldName(typeParameterName: Name): Name =
+    Name.identifier(typeParameterName.asString() + "Serializer")
+
+/**
+ * Emits one private `KSerializer<Tn>` `IrField` per type parameter on [container],
+ * attaching the fields to [container] via [addField] when [attach] is true. When
+ * [attach] is false the fields are built free-standing (StubGeneration uses this
+ * because [generateChildrenForClass] attaches them itself via its returned list).
+ */
+internal fun IrPluginContext.buildSerializerFieldsForTypeParams(
+    container: IrClass,
+    env: KsrpcGenerationEnvironment,
+    attach: Boolean
+): List<IrField> = container.typeParameters.map { tp ->
+    val fieldType = env.kSerializer.typeWith(tp.defaultType)
+    val fieldName = serializerFieldName(tp.name)
+    if (attach) {
+        container.addField {
+            startOffset = SYNTHETIC_OFFSET
+            endOffset = SYNTHETIC_OFFSET
+            name = fieldName
+            origin = IrDeclarationOrigin.DELEGATE
+            visibility = DescriptorVisibilities.PRIVATE
+            type = fieldType
+            isFinal = true
+            isStatic = false
+        }
+    } else {
+        irFactory.buildField {
+            startOffset = SYNTHETIC_OFFSET
+            endOffset = SYNTHETIC_OFFSET
+            name = fieldName
+            origin = IrDeclarationOrigin.DELEGATE
+            visibility = DescriptorVisibilities.PRIVATE
+            type = fieldType
+            isFinal = true
+            isStatic = false
+        }
+    }
+}
+
+/**
+ * Build the anonymous `ServiceExecutor` implementation class for [referencedFunction],
+ * parented to [container]. The class name follows the historical
+ * `"Anonymous${CapitalizedFunctionName}"` convention so both the generic and
+ * non-generic code paths produce identical output. The override of
+ * `ServiceExecutor.invoke` defers to [referencedFunction] with implicit casts on the
+ * dispatch receiver and value argument.
+ *
+ * Shared between [StubGeneration] (non-generic services) and [GenericMethodIrBuilder]
+ * (generic services).
+ */
+internal fun IrPluginContext.buildAnonymousServiceExecutor(
+    env: KsrpcGenerationEnvironment,
+    referencedFunction: IrSimpleFunction,
+    container: IrClass
+): IrClass {
+    val executorClass = irFactory.buildClass {
+        startOffset = referencedFunction.startOffset
+        endOffset = referencedFunction.endOffset
+        name = Name.identifier(
+            "Anonymous${referencedFunction.name.asString().capitalizeAsciiOnly()}"
+        )
+        visibility = DescriptorVisibilities.INTERNAL
+        kind = ClassKind.CLASS
+        modality = Modality.FINAL
+        isCompanion = false
+    }.apply {
+        parent = container
+        superTypes = listOf(env.serviceExecutor.typeWith())
+        createThisReceiverParameter()
+        addConstructor {
+            startOffset = SYNTHETIC_OFFSET
+            endOffset = SYNTHETIC_OFFSET
+            isPrimary = true
+        }.apply {
+            body = irBuilder(symbol).irBlockBody {
+                +irDelegatingConstructorCall(
+                    irBuiltIns.anyClass.owner.constructors.single()
+                )
+            }
+        }
+    }
+    val invokeMethod = env.serviceExecutor.findMethod(FqConstants.INVOKE)
+    val override = overrideMethod(
+        executorClass,
+        invokeMethod,
+        referencedFunction.returnType
+    ) { override ->
+        +irReturn(
+            irCall(referencedFunction).apply {
+                type = referencedFunction.returnType
+                putArgs(
+                    irImplicitCast(
+                        irGet(override.parameters[1]),
+                        referencedFunction.dispatchReceiverParameter?.type!!
+                    ),
+                    irImplicitCast(
+                        irGet(override.parameters[2]),
+                        referencedFunction.parameters[1].type
+                    )
+                )
+            }
+        )
+    }
+    executorClass.addChild(override)
+    container.addChild(executorClass)
+    return executorClass
 }
 
 /**

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -13,6 +13,90 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Generation pipeline overview
+ * ============================
+ *
+ * The ksrpc compiler plugin operates in two phases. FIR declaration generators synthesize
+ * the public shape of the generated code (classes, members, signatures), then IR
+ * transformers attach field definitions, fill in bodies and register behavior.
+ *
+ * FIR phase — declaration shape
+ * -----------------------------
+ *
+ *   KsrpcComponentRegistrar wires FirKsrpcRegistrar, which registers four declaration
+ *   generators (see FqConstants for FQ names):
+ *
+ *   - FirKsrpcStubGenerator           Emits a nested `Stub<T...>` class on every
+ *                                     `@KsService` interface. The stub implements the
+ *                                     service and holds the `SerializedService` channel
+ *                                     plus one `KSerializer<Tn>` per service type param.
+ *
+ *   - FirCompanionDeclarationGenerator Emits a Companion object on every @KsService.
+ *                                     For non-generic services the companion directly
+ *                                     extends `RpcObject<Service>` and exposes
+ *                                     `findEndpoint`/`createStub`/`serviceName`/`endpoints`.
+ *                                     For generic services the companion instead extends
+ *                                     `RpcObjectFactory<Service<*, ...>>` and exposes
+ *                                     `operator fun <T...> invoke(serializers...)` plus
+ *                                     `arity` and `create(typeArgs)`.
+ *
+ *   - FirKsrpcObjGenerator            Only runs for generic services. Emits a nested
+ *                                     `Obj<T...>` class which implements
+ *                                     `RpcObject<Service<T...>>`. Obj is what Companion's
+ *                                     `invoke` returns and what `create` instantiates.
+ *
+ *   - FirKsrpcIntrospectionGenerator  Emits `getIntrospection()` on services that opt in
+ *                                     via `@KsIntrospectable`.
+ *
+ *   Shared FIR helpers live in `FirGeneratorUtils.kt` (serializer value parameters,
+ *   cone-type threading, kotlin.collections.List ClassId).
+ *
+ * IR phase — bodies and implementation
+ * ------------------------------------
+ *
+ *   KsrpcIrGenerationExtension (this file) runs four transformers in order, each
+ *   matching against the `GeneratedDeclarationKey` emitted by its FIR counterpart:
+ *
+ *   - StubGeneration         Attaches the channel field, per-TP serializer fields,
+ *                            per-endpoint executor classes, method bodies that call
+ *                            `RpcMethod.callChannel(...)`, and a `close()` override.
+ *                            For non-generic services each method is backed by a lazy
+ *                            RpcMethod on the Stub.Companion; for generic services we
+ *                            emit a fresh `RpcMethod` per call, wiring in the stub
+ *                            instance's serializer fields. Also pre-creates the
+ *                            per-endpoint ServiceExecutor classes that ObjGeneration
+ *                            later reuses via `ServiceClass.genericExecutors`.
+ *
+ *   - ObjGeneration          For generic services only: fills in Obj's serializer
+ *                            fields, primary constructor body, `createStub`,
+ *                            `findEndpoint`, and the `serviceName`/`endpoints`
+ *                            properties. Emits RpcMethod constructor calls that resolve
+ *                            type-parameter-bearing serializers from the Obj instance
+ *                            fields (see [GenericMethodIrBuilder]).
+ *
+ *   - CompanionGeneration    Fills in `findEndpoint`, `createStub` (non-generic),
+ *                            `invoke` and `create` (generic), plus the
+ *                            `serviceName`/`endpoints`/`arity` property bodies and the
+ *                            `@RpcObjectKey` annotation that points runtime dispatch
+ *                            at this companion.
+ *
+ *   - IntrospectionGeneration Fills in `getIntrospection()` body.
+ *
+ *   Shared IR helpers live in `IrUtils.kt` (listOf<String>, serializer field creation,
+ *   anonymous ServiceExecutor class, overrideMethod, etc.). Metadata propagation from
+ *   sibling `@KsMethodMetadata` annotations is handled by `MetadataIrBuilder.kt`.
+ *
+ * Validation
+ * ----------
+ *
+ *   [KsrpcIrGenerationExtension.validate] runs before transformation, rejecting
+ *   services with non-RpcService supertypes, non-invariant class type parameters,
+ *   method-level type parameters, duplicate endpoint names, `ByteReadChannel`-on-both-
+ *   sides, and `@KsNotification` methods that don't return `Unit`.
+ */
+
 package com.monkopedia.ksrpc.plugin
 
 import com.monkopedia.ksrpc.plugin.FqConstants.BYTE_READ_CHANNEL

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -43,7 +43,6 @@ import org.jetbrains.kotlin.ir.builders.irImplicitCast
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.builders.irString
-import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.builders.irWhen
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
@@ -441,16 +440,3 @@ internal class GenericMethodIrBuilder(
     }
 }
 
-// Extract the irListOfStrings helper so both CompanionGeneration and ObjGeneration can share it.
-internal fun IrBuilderWithScope.irListOfStrings(
-    env: KsrpcGenerationEnvironment,
-    values: List<String>
-): IrExpression = irCall(env.listOfFunction).apply {
-    typeArguments[0] = context.irBuiltIns.stringType
-    val varargParameter = env.listOfFunction.owner.parameters
-        .single { it.kind == org.jetbrains.kotlin.ir.declarations.IrParameterKind.Regular }
-    arguments[varargParameter] = irVararg(
-        context.irBuiltIns.stringType,
-        values.map { irString(it) }
-    )
-}

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -93,18 +93,8 @@ class ObjGeneration(
         val k = key as FirKsrpcObjGenerator.Key
         val cls = classes[k.target]
             ?: error("Invalid synthetic Obj for ${k.target}")
-        val serializerFields = declaration.typeParameters.map { tp ->
-            declaration.addField {
-                startOffset = SYNTHETIC_OFFSET
-                endOffset = SYNTHETIC_OFFSET
-                name = Name.identifier(tp.name.asString() + "Serializer")
-                origin = IrDeclarationOrigin.DELEGATE
-                visibility = DescriptorVisibilities.PRIVATE
-                type = env.kSerializer.typeWith(tp.defaultType)
-                isFinal = true
-                isStatic = false
-            }
-        }
+        val serializerFields =
+            context.buildSerializerFieldsForTypeParams(declaration, env, attach = true)
         cls.setObjClass(declaration)
         cls.setObjSerializerFields(serializerFields)
         // Executors are pre-created by StubGeneration (parented to the Stub class) before
@@ -385,58 +375,6 @@ internal class GenericMethodIrBuilder(
         }
     }
 
-    fun buildExecutor(referencedFunction: IrSimpleFunction, container: IrClass): IrClass {
-        val executorClass = context.irFactory.buildClass {
-            startOffset = referencedFunction.startOffset
-            endOffset = referencedFunction.endOffset
-            name = Name.identifier(
-                "Anonymous${referencedFunction.name.asString().replaceFirstChar { it.uppercase() }}"
-            )
-            visibility = DescriptorVisibilities.INTERNAL
-            kind = ClassKind.CLASS
-            modality = Modality.FINAL
-            isCompanion = false
-        }
-        executorClass.parent = container
-        executorClass.superTypes = listOf(env.serviceExecutor.typeWith())
-        executorClass.createThisReceiverParameter()
-
-        executorClass.addConstructor {
-            startOffset = SYNTHETIC_OFFSET
-            endOffset = SYNTHETIC_OFFSET
-            isPrimary = true
-        }.apply {
-            body = context.irBuilder(symbol).irBlockBody {
-                +irDelegatingConstructorCall(
-                    context.irBuiltIns.anyClass.owner.constructors.single()
-                )
-            }
-        }
-        val invokeMethod = env.serviceExecutor.findMethod(FqConstants.INVOKE)
-        val override = context.overrideMethod(
-            executorClass,
-            invokeMethod,
-            referencedFunction.returnType
-        ) { override ->
-            +irReturn(
-                irCall(referencedFunction).apply {
-                    type = referencedFunction.returnType
-                    putArgs(
-                        irImplicitCast(
-                            irGet(override.parameters[1]),
-                            referencedFunction.dispatchReceiverParameter?.type!!
-                        ),
-                        irImplicitCast(
-                            irGet(override.parameters[2]),
-                            referencedFunction.parameters[1].type
-                        )
-                    )
-                }
-            )
-        }
-        executorClass.addChild(override)
-        container.addChild(executorClass)
-        return executorClass
-    }
+    fun buildExecutor(referencedFunction: IrSimpleFunction, container: IrClass): IrClass =
+        context.buildAnonymousServiceExecutor(env, referencedFunction, container)
 }
-

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -101,20 +101,10 @@ class StubGeneration(
         val target = (key as? FirKsrpcStubGenerator.Key)?.target
         val service = classes[target] ?: return emptyList()
         // For generic services, also add per-instance serializer fields on the Stub so
-        // method bodies can reach the injected KSerializer<T>.
+        // method bodies can reach the injected KSerializer<T>. We build these free-standing
+        // (attach = false) so `generateChildrenForClass` can add them via its returned list.
         val stubSerializerFields = if (declaration.typeParameters.isNotEmpty()) {
-            declaration.typeParameters.map { tp ->
-                irFactory.buildField {
-                    startOffset = SYNTHETIC_OFFSET
-                    endOffset = SYNTHETIC_OFFSET
-                    name = Name.identifier(tp.name.asString() + "Serializer")
-                    origin = IrDeclarationOrigin.DELEGATE
-                    visibility = DescriptorVisibilities.PRIVATE
-                    type = env.kSerializer.typeWith(tp.defaultType)
-                    isFinal = true
-                    isStatic = false
-                }
-            }
+            context.buildSerializerFieldsForTypeParams(declaration, env, attach = false)
         } else {
             emptyList()
         }
@@ -421,7 +411,9 @@ class StubGeneration(
                 createTypeConverter(inputRpcType, inputType, this@irCreateRpcMethod),
                 createTypeConverter(outputRpcType, outputType, this@irCreateRpcMethod),
                 irBlock {
-                    val createServiceExecutor = irCreateServiceExecutor(method, serviceInterface)
+                    val createServiceExecutor =
+                        this@StubGeneration.context
+                            .buildAnonymousServiceExecutor(env, method, serviceInterface)
                     +irCallConstructor(
                         createServiceExecutor.constructors.first().symbol,
                         emptyList()
@@ -462,60 +454,6 @@ class StubGeneration(
             putArgs(getSerializer(declarationIrBuilder, outputType))
         }
     }
-
-    private fun irCreateServiceExecutor(referencedFunction: IrSimpleFunction, receiver: IrClass) =
-        context.irFactory.buildClass {
-            startOffset = referencedFunction.startOffset
-            endOffset = referencedFunction.endOffset
-            name = Name.identifier(
-                "Anonymous${referencedFunction.name.asString().capitalizeAsciiOnly()}"
-            )
-            visibility = DescriptorVisibilities.INTERNAL
-            kind = ClassKind.CLASS
-            modality = Modality.FINAL
-            isCompanion = false
-        }.apply {
-            this.parent = receiver
-            superTypes = listOf(env.serviceExecutor.typeWith())
-            createThisReceiverParameter()
-
-            addConstructor {
-                startOffset = SYNTHETIC_OFFSET
-                endOffset = SYNTHETIC_OFFSET
-                isPrimary = true
-            }.apply {
-                body = context.irBuilder(symbol).irBlockBody {
-                    +irDelegatingConstructorCall(
-                        context.irBuiltIns.anyClass.owner.constructors.single()
-                    )
-                }
-            }
-            val invoke = env.serviceExecutor.findMethod(INVOKE)
-            val override = context.overrideMethod(
-                this,
-                invoke,
-                referencedFunction.returnType
-            ) { override ->
-                +irReturn(
-                    irCall(referencedFunction).apply {
-                        type = referencedFunction.returnType
-
-                        putArgs(
-                            irImplicitCast(
-                                irGet(override.parameters[1]),
-                                referencedFunction.dispatchReceiverParameter?.type!!
-                            ),
-                            irImplicitCast(
-                                irGet(override.parameters[2]),
-                                referencedFunction.parameters[1].type
-                            )
-                        )
-                    }
-                )
-            }
-            this.addChild(override)
-            receiver.addChild(this)
-        }
 
     private fun getSerializer(irBlockBodyBuilder: DeclarationIrBuilder, type: IrType) =
         irBlockBodyBuilder.irCall(env.serializerMethod ?: error("Missing serializer")).apply {


### PR DESCRIPTION
## Summary

Mechanical refactor of the ksrpc compiler plugin. No behavioral changes — BCV dumps unchanged, all tests green. Extracts patterns that repeated across the FIR declaration generators and IR transformers after the generic-service support landed in #42.

### Extracted helpers / consolidations

- `irListOfStrings` — a single shared `IrBuilderWithScope.irListOfStrings(env, values)` in `IrUtils.kt`. CompanionGeneration and ObjGeneration previously had their own copies with different signatures.
- `FirGeneratorUtils.kt` (new file) with:
  - `addSerializerValueParameters(session, typeParams)` — extension on `FunctionBuildingContext<*>` that adds one `KSerializer<Tn>` value parameter per type parameter, used by the companion `invoke` factory, Obj ctor and Stub ctor.
  - `ClassId.createConeTypeForRefs(session, refs)` — the recurring `classId<refs[0], refs[1], ...>` cone-type construction.
  - `LIST_CLASS_ID` — shared `kotlin.collections.List` ClassId.
- `IrUtils.kt` gains:
  - `serializerFieldName(Name)` — single source of truth for the `"${Tn}Serializer"` naming scheme shared by FIR signatures and IR fields.
  - `buildSerializerFieldsForTypeParams(container, env, attach)` — one-per-type-param `KSerializer<Tn>` IrField creation, replacing inlined copies in `ObjGeneration` and `StubGeneration`.
  - `buildAnonymousServiceExecutor(env, referencedFunction, container)` — the anonymous `ServiceExecutor` subclass construction (primary ctor + `invoke` override) previously duplicated between `StubGeneration.irCreateServiceExecutor` and `GenericMethodIrBuilder.buildExecutor`.
- File-level comment at the top of `KsrpcIrGenerationExtension.kt` that documents the two-phase (FIR declaration + IR body) pipeline, spelling out which file is responsible for what so future contributors don't have to reverse-engineer it.

### Behavior-unchanged assertion

- No API/public shape changes.
- No changes to generated output for any test service.
- `./gradlew apiCheck` clean — no `.api` or `.klib.api` files modified.
- The only new public surface in the plugin module is `internal` helpers added above.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` (includes `GenericServiceTest`, `KsNotificationValidationTest`, `IrPluginTest`, etc.) — pass
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-api:jvmTest :ksrpc-test:jvmTest :ksrpc-jsonrpc:jvmTest :ksrpc-introspection:jvmTest` — pass
- [x] `./gradlew :ksrpc-core:linuxX64Test :ksrpc-api:linuxX64Test :ksrpc-test:linuxX64Test :ksrpc-jsonrpc:linuxX64Test :ksrpc-introspection:linuxX64Test` — pass / skip (no tests defined)
- [x] `./gradlew :ksrpc-packets:jvmTest :ksrpc-packets:linuxX64Test` — pass / skip
- [x] `./gradlew apiCheck` — pass, zero diff against main
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:ktlintCheck` on touched files — clean (only pre-existing BuildConfig indent warning remains)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)