### PR TITLE
Fix #27: route plugin user-reachable errors through MessageCollector

### DIFF
--- a/compiler/plugin/src/main/java/AbstractTransformerForGenerator.kt
+++ b/compiler/plugin/src/main/java/AbstractTransformerForGenerator.kt
@@ -77,7 +77,8 @@ abstract class AbstractTransformerForGenerator(protected val context: IrPluginCo
             return
         }
         require(declaration.body == null) {
-            "Found body for method ${declaration.name.asString()}"
+            "ksrpc internal: unexpected body on FIR-generated method " +
+                "${declaration.name.asString()}"
         }
         declaration.body = generateBodyForFunction(declaration, origin.pluginKey)
     }

--- a/compiler/plugin/src/main/java/CompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/CompanionGeneration.kt
@@ -138,7 +138,10 @@ class CompanionGeneration(
         objectReference: IrClassReference
     ): IrConstructorCall {
         val primaryConstructor = rpcObjectKey.constructors.find { it.owner.isPrimary }
-            ?: error("No primary constructor")
+            ?: reportInternal(
+                "RpcObjectKey has no primary constructor — ksrpc-core runtime must " +
+                    "match the compiler plugin"
+            )
         return context.irBuilder(irClass).irCallConstructor(primaryConstructor, emptyList())
             .apply { putArgs(objectReference) }
     }
@@ -229,15 +232,15 @@ class CompanionGeneration(
     private fun buildCreateBody(function: IrSimpleFunction, cls: ServiceClass): IrBody {
         val objClass = cls.irClass.declarations.filterIsInstance<IrClass>()
             .firstOrNull { it.name == FqConstants.OBJ }
-            ?: error(
-                "Missing generated Obj class on ${cls.irClass.kotlinFqName.asString()}. " +
-                    "FirKsrpcObjGenerator did not run or generated under a different name."
+            ?: reportInternal(
+                "missing generated Obj class on ${cls.irClass.kotlinFqName.asString()} " +
+                    "— FirKsrpcObjGenerator did not run or generated under a different name"
             )
         val objConstructor = objClass.constructors.first { it.isPrimary }
         val resolveFn = env.resolveSerializerOrThrow
-            ?: error(
-                "Missing com.monkopedia.ksrpc.resolveSerializerOrThrow. Compile against a " +
-                    "ksrpc-core that includes RpcObjectFactory."
+            ?: reportInternal(
+                "missing com.monkopedia.ksrpc.resolveSerializerOrThrow — compile against " +
+                    "a ksrpc-core that includes RpcObjectFactory"
             )
         val arity = cls.irClass.typeParameters.size
         val serviceName = cls.irClass.kotlinFqName.asString()
@@ -261,15 +264,15 @@ class CompanionGeneration(
                 org.jetbrains.kotlin.name.FqName("kotlin"),
                 Name.identifier("IllegalArgumentException")
             )
-        ) ?: error("kotlin.IllegalArgumentException not found")
+        ) ?: reportInternal("kotlin.IllegalArgumentException not found on classpath")
         val iaeStringCtor = iaeClass.owner.declarations
             .filterIsInstance<IrConstructor>()
             .firstOrNull { ctor ->
                 val params = ctor.parameters.filter { !it.isDispatchReceiver }
                 params.size == 1 &&
                     params.single().type.classFqName?.asString() == "kotlin.String"
-            } ?: error(
-            "Could not locate kotlin.IllegalArgumentException(String) constructor"
+            } ?: reportInternal(
+            "can't locate kotlin.IllegalArgumentException(String) constructor"
         )
         return context.irBuilder(function).irSynthBody {
             val typeArgsParam = function.parameters.first { !it.isDispatchReceiver }
@@ -319,9 +322,9 @@ class CompanionGeneration(
     private fun buildInvokeFactoryBody(function: IrSimpleFunction, cls: ServiceClass): IrBody {
         val objClass = cls.irClass.declarations.filterIsInstance<IrClass>()
             .firstOrNull { it.name == FqConstants.OBJ }
-            ?: error(
-                "Missing generated Obj class on ${cls.irClass.kotlinFqName.asString()}. " +
-                    "FirKsrpcObjGenerator did not run or generated under a different name."
+            ?: reportInternal(
+                "missing generated Obj class on ${cls.irClass.kotlinFqName.asString()} " +
+                    "— FirKsrpcObjGenerator did not run or generated under a different name"
             )
         val objConstructor = objClass.constructors.first { it.isPrimary }
         val invokeTypeParams = function.typeParameters

--- a/compiler/plugin/src/main/java/CompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/CompanionGeneration.kt
@@ -70,8 +70,10 @@ class CompanionGeneration(
         key: GeneratedDeclarationKey?
     ): Collection<IrDeclaration> {
         val k = key as FirCompanionDeclarationGenerator.Key
-        val cls = classes[k.type]
-            ?: error("Invalid synthetic declaration for ${k.type} in ${classes.keys}")
+        // The class may have been removed from `classes` by validation (e.g. a @KsService
+        // subtype of another @KsService — see issue #45). In that case validation has
+        // already reported an error; just skip body generation so we don't crash.
+        val cls = classes[k.type] ?: return emptyList()
         // Emit @RpcObjectKey pointing at the companion. For non-generic services the
         // companion is the `RpcObject`; for generic services it's the `RpcObjectFactory`.
         // `rpcObject<T>()` inspects the returned instance and, when it's a factory,
@@ -146,8 +148,8 @@ class CompanionGeneration(
         key: GeneratedDeclarationKey?
     ): IrBody? {
         val k = key as FirCompanionDeclarationGenerator.Key
-        val cls = classes[k.type]
-            ?: error("Invalid synthetic declaration for ${k.type} in ${classes.keys}")
+        // See generateChildrenForClass: validation may have removed the entry.
+        val cls = classes[k.type] ?: return null
         function.correspondingPropertySymbol?.owner?.name?.let { propertyName ->
             if (propertyName == FqConstants.SERVICE_NAME) {
                 return context.irBuilder(function).irSynthBody {

--- a/compiler/plugin/src/main/java/IntrospectionGeneration.kt
+++ b/compiler/plugin/src/main/java/IntrospectionGeneration.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.util.companionObject
+import org.jetbrains.kotlin.ir.util.kotlinFqName
 
 class IntrospectionGeneration(
     context: IrPluginContext,
@@ -61,7 +62,11 @@ class IntrospectionGeneration(
                 irCallConstructor(env.introspectionConstructor, emptyList()).apply {
                     putArgs(
                         irGetObject(
-                            cls.irClass.companionObject()?.symbol ?: error("Companion is missing")
+                            cls.irClass.companionObject()?.symbol ?: reportInternal(
+                                "companion is missing on " +
+                                    cls.irClass.kotlinFqName.asString() +
+                                    " — CompanionGeneration should have produced it"
+                            )
                         )
                     )
                 }

--- a/compiler/plugin/src/main/java/IntrospectionGeneration.kt
+++ b/compiler/plugin/src/main/java/IntrospectionGeneration.kt
@@ -46,8 +46,9 @@ class IntrospectionGeneration(
         key: GeneratedDeclarationKey?
     ): IrBody? {
         val k = key as FirKsrpcIntrospectionGenerator.Key
-        val cls = classes[k.type]
-            ?: error("Invalid synthetic declaration for ${k.type} in ${classes.keys}")
+        // Class may have been removed by validation (issue #45). Errors are already
+        // reported; skip body generation to avoid crashing.
+        val cls = classes[k.type] ?: return null
         return when (function.name) {
             FqConstants.GET_INTROSPECTION -> buildIntrospectionBody(function, cls)
             else -> null

--- a/compiler/plugin/src/main/java/IrUtils.kt
+++ b/compiler/plugin/src/main/java/IrUtils.kt
@@ -98,7 +98,9 @@ fun createClassReference(
 
 fun IrClassSymbol.findMethod(name: Name) = functions.find {
     it.owner.name == name
-} ?: error("Can't find ${name.asString()} method")
+} ?: reportInternal(
+    "can't find ${name.asString()} on ${owner.fqNameWhenAvailable?.asString() ?: owner.name.asString()}"
+)
 
 fun IrPluginContext.irBuilder(owner: IrSymbolOwner) = irBuilder(owner.symbol)
 

--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -18,7 +18,6 @@
 package com.monkopedia.ksrpc.plugin
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -32,7 +31,9 @@ import org.jetbrains.kotlin.name.Name
 
 class KsrpcGenerationEnvironment(
     val context: IrPluginContext,
-    private val messageCollector: MessageCollector
+    // Retained so future bootstrap lookups can surface warnings through the
+    // plugin's MessageCollector without restructuring callers.
+    @Suppress("unused") private val messageCollector: MessageCollector
 ) {
     private val endpointException =
         referenceClass(FqConstants.RPC_ENDPOINT_EXCEPTION)
@@ -87,10 +88,7 @@ class KsrpcGenerationEnvironment(
             val regularParams = fn.owner.parameters.filter { it.kind == IrParameterKind.Regular }
             regularParams.size == 1 && regularParams.single().varargElementType != null
         }
-            ?: run {
-                messageCollector.report(ERROR, "Can't find kotlin.collections.listOf")
-                error("Can't find kotlin.collections.listOf")
-            }
+            ?: reportInternal("can't resolve kotlin.collections.listOf (vararg overload)")
 
     // Metadata propagation support is optional so the compiler plugin continues
     // to work against older ksrpc-core artifacts that predate #11.
@@ -134,14 +132,13 @@ class KsrpcGenerationEnvironment(
 
     private fun maybeReferenceClass(name: ClassId): IrClassSymbol? = context.referenceClass(name)
 
-    private fun referenceClass(name: ClassId): IrClassSymbol = maybeReferenceClass(name) ?: run {
-        messageCollector.report(ERROR, "Can't find $name in dependencies")
-        error("Can't find $name in dependencies")
-    }
+    private fun referenceClass(name: ClassId): IrClassSymbol =
+        maybeReferenceClass(name) ?: reportInternal(
+            "can't resolve $name on the compile classpath — ksrpc-core must be a dependency"
+        )
 
     private fun referenceObject(name: ClassId): IrClassSymbol =
-        context.referenceClass(name) ?: run {
-            messageCollector.report(ERROR, "Can't find $name in dependencies")
-            error("Can't find $name in dependencies")
-        }
+        context.referenceClass(name) ?: reportInternal(
+            "can't resolve $name on the compile classpath — ksrpc-core must be a dependency"
+        )
 }

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -94,7 +94,13 @@
  *   [KsrpcIrGenerationExtension.validate] runs before transformation, rejecting
  *   services with non-RpcService supertypes, non-invariant class type parameters,
  *   method-level type parameters, duplicate endpoint names, `ByteReadChannel`-on-both-
- *   sides, and `@KsNotification` methods that don't return `Unit`.
+ *   sides, and `@KsNotification` methods that don't return `Unit`. Diagnostics go
+ *   through [PluginReporter.reportUserError], which resolves a source line/column
+ *   from the offending IR element so the user sees a clean pointer at the declaration.
+ *
+ *   TODO: these validations currently run in the IR phase which limits IDE
+ *   integration — a FIR-phase checker with `KtSourceElement` would produce a red
+ *   squiggle directly on the offending element. Tracked as a 1.0+ follow-up.
  */
 
 @file:OptIn(UnsafeDuringIrConstructionAPI::class)
@@ -107,8 +113,6 @@ import com.monkopedia.ksrpc.plugin.FqConstants.INTROSPECTABLE_RPC_SERVICE
 import com.monkopedia.ksrpc.plugin.FqConstants.KS_SERVICE
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.WARNING
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.backend.js.utils.isDispatchReceiver
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -133,7 +137,7 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         val env = KsrpcGenerationEnvironment(pluginContext, report)
         val transformers = listOf(
             StubGeneration(pluginContext, report, classes, env),
-            ObjGeneration(pluginContext, classes, env),
+            ObjGeneration(pluginContext, report, classes, env),
             CompanionGeneration(pluginContext, classes, env),
             IntrospectionGeneration(pluginContext, classes, env)
         )
@@ -175,19 +179,21 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
                 superClass.annotations.any { it.type.classFqName == KS_SERVICE }
             }
         if (ksServiceSuper != null) {
-            report.error(
+            report.reportUserError(
                 "@KsService cannot be applied to ${irClass.kotlinFqName.asString()} because " +
                     "its supertype ${ksServiceSuper.kotlinFqName.asString()} is already " +
                     "@KsService. Remove @KsService from " +
                     "${irClass.kotlinFqName.asString()}; rpcObject<" +
                     "${irClass.name.asString()}>() will find the parent's companion " +
-                    "automatically."
+                    "automatically.",
+                element = irClass
             )
             isValid = false
         }
         if (!hasRpcServiceSuper && !hasIntrospectableSuper && ksServiceSuper == null) {
-            report.error(
-                "${irClass.kotlinFqName.asString()} does not extend ${FQRPC_SERVICE.asString()}"
+            report.reportUserError(
+                "${irClass.kotlinFqName.asString()} does not extend ${FQRPC_SERVICE.asString()}",
+                element = irClass
             )
             isValid = false
         }
@@ -196,9 +202,10 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         // implemented in codegen.
         for (tp in irClass.typeParameters) {
             if (tp.variance != Variance.INVARIANT) {
-                report.error(
+                report.reportUserError(
                     "${irClass.kotlinFqName.asString()}: type parameter ${tp.name.asString()} " +
-                        "must be invariant (got ${tp.variance.label})"
+                        "must be invariant (got ${tp.variance.label})",
+                    element = tp
                 )
                 isValid = false
             }
@@ -215,12 +222,18 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         var isValid = true
         if (method.typeParameters.isNotEmpty()) {
             val fqName = irClass.kotlinFqName.asString()
-            report.error("$fqName.${method.name.asString()} cannot have type parameters")
+            report.reportUserError(
+                "$fqName.${method.name.asString()} cannot have type parameters",
+                element = method
+            )
             isValid = false
         }
         if (method.parameters.filter { !it.isDispatchReceiver }.size > 1) {
             val fqName = irClass.kotlinFqName.asString()
-            report.error("$fqName.${method.name.asString()} cannot have more than 1 parameter")
+            report.reportUserError(
+                "$fqName.${method.name.asString()} cannot have more than 1 parameter",
+                element = method
+            )
             isValid = false
         }
         val annotationArg = annotation.arguments[0]
@@ -228,12 +241,18 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         if (name == null) {
             val fqName = irClass.kotlinFqName.asString()
             val methodName = method.name.asString()
-            report.error("$fqName.$methodName: could not parse annotation argument $annotationArg")
+            report.reportUserError(
+                "$fqName.$methodName: could not parse annotation argument $annotationArg",
+                element = method
+            )
             isValid = false
         } else if (!names.add(name)) {
             val fqName = irClass.kotlinFqName.asString()
             val methodName = method.name.asString()
-            report.error("$fqName.$methodName: cannot use endpoint $name, it has already been used")
+            report.reportUserError(
+                "$fqName.$methodName: cannot use endpoint $name, it has already been used",
+                element = method
+            )
             isValid = false
         }
         val inputType = method.parameters[0].type.classFqName
@@ -241,8 +260,9 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         if (inputType == BYTE_READ_CHANNEL && outputType == BYTE_READ_CHANNEL) {
             val fqName = irClass.kotlinFqName.asString()
             val methodName = method.name.asString()
-            report.error(
-                "$fqName.$methodName: ByteReadChannel not yet supported for both input and output"
+            report.reportUserError(
+                "$fqName.$methodName: ByteReadChannel not yet supported for both input and output",
+                element = method
             )
             isValid = false
         }
@@ -258,17 +278,15 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         if (returnType?.asString() != "kotlin.Unit") {
             val fqName = irClass.kotlinFqName.asString()
             val methodName = serviceMethod.function.name.asString()
-            report.error(
+            report.reportUserError(
                 "$fqName.$methodName: @KsNotification methods must return Unit, " +
-                    "but returns $returnType"
+                    "but returns $returnType",
+                element = serviceMethod.function
             )
             return false
         }
         return true
     }
 }
-
-fun MessageCollector.error(msg: String) = report(ERROR, msg)
-fun MessageCollector.warn(msg: String) = report(WARNING, msg)
 
 fun IrExpression?.constString() = (this as? IrConst)?.value as? String

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -97,11 +97,14 @@
  *   sides, and `@KsNotification` methods that don't return `Unit`.
  */
 
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
 package com.monkopedia.ksrpc.plugin
 
 import com.monkopedia.ksrpc.plugin.FqConstants.BYTE_READ_CHANNEL
 import com.monkopedia.ksrpc.plugin.FqConstants.FQRPC_SERVICE
 import com.monkopedia.ksrpc.plugin.FqConstants.INTROSPECTABLE_RPC_SERVICE
+import com.monkopedia.ksrpc.plugin.FqConstants.KS_SERVICE
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
@@ -114,7 +117,9 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.types.Variance
@@ -158,7 +163,29 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         val hasRpcServiceSuper = superTypeNames.contains(FQRPC_SERVICE)
         val hasIntrospectableSuper =
             superTypeNames.contains(INTROSPECTABLE_RPC_SERVICE.asSingleFqName())
-        if (!hasRpcServiceSuper && !hasIntrospectableSuper) {
+        // Reject `@KsService` applied to a subtype of another `@KsService` interface.
+        // The parent's @KsService annotation already drives codegen, and `rpcObject<Sub>()`
+        // walks supertypes to find the parent's `RpcObject`/`RpcObjectFactory` companion
+        // automatically. Allowing @KsService on the subtype would produce a duplicate
+        // companion that has no working stub/obj of its own and previously crashed
+        // CompanionGeneration with "Invalid synthetic declaration for ..." (issue #45).
+        val ksServiceSuper = irClass.superTypes
+            .mapNotNull { it.classOrNull?.owner }
+            .firstOrNull { superClass ->
+                superClass.annotations.any { it.type.classFqName == KS_SERVICE }
+            }
+        if (ksServiceSuper != null) {
+            report.error(
+                "@KsService cannot be applied to ${irClass.kotlinFqName.asString()} because " +
+                    "its supertype ${ksServiceSuper.kotlinFqName.asString()} is already " +
+                    "@KsService. Remove @KsService from " +
+                    "${irClass.kotlinFqName.asString()}; rpcObject<" +
+                    "${irClass.name.asString()}>() will find the parent's companion " +
+                    "automatically."
+            )
+            isValid = false
+        }
+        if (!hasRpcServiceSuper && !hasIntrospectableSuper && ksServiceSuper == null) {
             report.error(
                 "${irClass.kotlinFqName.asString()} does not extend ${FQRPC_SERVICE.asString()}"
             )

--- a/compiler/plugin/src/main/java/MetadataIrBuilder.kt
+++ b/compiler/plugin/src/main/java/MetadataIrBuilder.kt
@@ -18,6 +18,7 @@
 package com.monkopedia.ksrpc.plugin
 
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.irBoolean
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
@@ -55,11 +56,13 @@ import org.jetbrains.kotlin.ir.util.parentClassOrNull
  */
 class MetadataIrBuilder(
     private val env: KsrpcGenerationEnvironment,
-    private val builder: DeclarationIrBuilder
+    private val builder: DeclarationIrBuilder,
+    private val report: MessageCollector
 ) {
     init {
         check(env.metadataSupported) {
-            "MetadataIrBuilder created without metadata-capable dependencies"
+            "ksrpc internal: MetadataIrBuilder created without metadata-capable " +
+                "dependencies — caller should guard on env.metadataSupported"
         }
     }
 
@@ -78,9 +81,9 @@ class MetadataIrBuilder(
 
     private fun buildMetadata(annotation: IrConstructorCall): IrExpression {
         val annotationFqName = annotation.type.classFqName?.asString()
-            ?: error("Sibling annotation has no FQ name")
+            ?: reportInternal("sibling annotation has no FQ name")
         val annotationClass = annotation.symbol.owner.parentClassOrNull
-            ?: error("Sibling annotation $annotationFqName has no parent class")
+            ?: reportInternal("sibling annotation $annotationFqName has no parent class")
         val ctor = annotationClass.constructors.first()
         val pairs = mutableListOf<IrExpression>()
         for ((index, arg) in annotation.arguments.withIndex()) {
@@ -90,10 +93,20 @@ class MetadataIrBuilder(
             val expr = arg ?: continue
             val name = param.name.asString()
             val value = buildMetadataValue(expr)
-                ?: error(
-                    "Unsupported annotation argument $annotationFqName.$name: " +
-                        expr::class.simpleName
+            if (value == null) {
+                report.reportUserError(
+                    "@$annotationFqName: unsupported ksrpc method-metadata argument " +
+                        "`$name` (${expr::class.simpleName}). Supported shapes are " +
+                        "String/Int/Long/Boolean/Double/Float constants, KClass " +
+                        "literals, enum constants, and arrays/varargs of the above. " +
+                        "Nested annotations are not supported.",
+                    element = expr
                 )
+                // Emit a diagnostic and fall back to dropping this argument rather than
+                // crashing the compiler. The compilation will still fail because the
+                // ERROR diagnostic has been reported.
+                continue
+            }
             pairs.add(buildPair(name, value))
         }
 

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irThrow
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
@@ -79,6 +80,7 @@ import org.jetbrains.kotlin.name.Name
  */
 class ObjGeneration(
     context: IrPluginContext,
+    private val report: MessageCollector,
     private val classes: MutableMap<String, ServiceClass>,
     private val env: KsrpcGenerationEnvironment
 ) : AbstractTransformerForGenerator(context) {
@@ -101,8 +103,8 @@ class ObjGeneration(
         // Executors are pre-created by StubGeneration (parented to the Stub class) before
         // ObjGeneration runs. findEndpoint bodies look them up via `cls.genericExecutors`.
         check(cls.genericExecutors.isNotEmpty() || cls.methods.isEmpty()) {
-            "Expected generic executors to be pre-created by StubGeneration for " +
-                cls.irClass.kotlinFqName.asString()
+            "ksrpc internal: expected generic executors to be pre-created by " +
+                "StubGeneration for ${cls.irClass.kotlinFqName.asString()}"
         }
         // Eagerly emit property bodies for serviceName / endpoints so the IR visitor doesn't
         // need to rely on correspondingPropertySymbol being wired correctly across FIR2IR.
@@ -199,15 +201,23 @@ class ObjGeneration(
 
     private fun buildFindEndpoint(function: IrSimpleFunction, cls: ServiceClass): IrBlockBody {
         val thisRcv = function.dispatchReceiverParameter!!
-        val builder = GenericMethodIrBuilder(context, env, cls)
+        val builder = GenericMethodIrBuilder(context, env, report, cls)
         return context.irBuilder(function).irSynthBody {
             val input = function.parameters.first { !it.isDispatchReceiver }
             val branches = buildList {
                 for (method in cls.methods) {
                     val endpoint = method.ksMethodAnnotation.arguments[0].constString()
-                        ?: error("Lost endpoint")
+                        ?: reportInternal(
+                            "@KsMethod annotation on " +
+                                "${method.function.name.asString()} lost its endpoint " +
+                                "argument after validation"
+                        )
                     val executor = cls.genericExecutors[endpoint.trimStart('/')]
-                        ?: error("Executor missing for endpoint $endpoint")
+                        ?: reportInternal(
+                            "generic executor missing for endpoint $endpoint on " +
+                                cls.irClass.kotlinFqName.asString() +
+                                " — StubGeneration should have pre-created it"
+                        )
                     this += irBranch(
                         irEquals(irString(endpoint.trimStart('/')), irGet(input)),
                         builder.irCreateRpcMethod(
@@ -247,6 +257,7 @@ class ObjGeneration(
 internal class GenericMethodIrBuilder(
     private val context: IrPluginContext,
     private val env: KsrpcGenerationEnvironment,
+    private val report: MessageCollector,
     private val cls: ServiceClass
 ) {
     fun irCreateRpcMethod(
@@ -296,7 +307,7 @@ internal class GenericMethodIrBuilder(
                 SYNTHETIC_OFFSET,
                 SYNTHETIC_OFFSET
             )
-            args += MetadataIrBuilder(env, decl).buildMetadataList(metadataAnnotations)
+            args += MetadataIrBuilder(env, decl, report).buildMetadataList(metadataAnnotations)
         }
         call.putArgs(*args.toTypedArray())
         return call
@@ -351,7 +362,10 @@ internal class GenericMethodIrBuilder(
         }
         // Fallback: use kotlinx.serialization.serializer<T>().
         val serializerFn = env.serializerMethod
-            ?: error("Missing kotlinx.serialization.serializer<T>() reference")
+            ?: reportInternal(
+                "can't resolve kotlinx.serialization.serializer<T>() — " +
+                    "kotlinx-serialization-core must be on the compile classpath"
+            )
         return builder.irCall(serializerFn).apply {
             typeArguments[0] = type
             this.type = env.kSerializer.typeWith(type)
@@ -364,9 +378,9 @@ internal class GenericMethodIrBuilder(
         nullableType: IrType
     ): IrExpression {
         val getter = env.getSerializerNullable
-            ?: error(
+            ?: reportInternal(
                 "kotlinx.serialization's KSerializer.nullable extension is not on the " +
-                    "compile classpath; nullable type-parameter serialization unsupported."
+                    "compile classpath; nullable type-parameter serialization unsupported"
             )
         return builder.irCall(getter).apply {
             // Extension receiver is the base serializer. In 2.x IR, argument[0] is the

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -91,8 +91,9 @@ class ObjGeneration(
         key: GeneratedDeclarationKey?
     ): Collection<IrDeclaration> {
         val k = key as FirKsrpcObjGenerator.Key
-        val cls = classes[k.target]
-            ?: error("Invalid synthetic Obj for ${k.target}")
+        // Class may have been removed by validation (issue #45 — @KsService subtype of
+        // another @KsService). Errors are already reported; skip to avoid crashing.
+        val cls = classes[k.target] ?: return emptyList()
         val serializerFields =
             context.buildSerializerFieldsForTypeParams(declaration, env, attach = true)
         cls.setObjClass(declaration)

--- a/compiler/plugin/src/main/java/PluginReporter.kt
+++ b/compiler/plugin/src/main/java/PluginReporter.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.WARNING
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.util.fileOrNull
+
+/**
+ * Conventions for surfacing compile-time failures from the ksrpc compiler plugin.
+ *
+ * - [reportUserError] is for everything a user can trigger by writing bad service code
+ *   (invalid annotations, mismatched shapes, duplicate endpoints, ...). These go through
+ *   [MessageCollector] as `ERROR` and are resolved to a file:line:column when an
+ *   [IrElement] is supplied so the user sees a clean pointer at the offending declaration.
+ * - [reportInternal] is for invariants that callers believe are unreachable. The message
+ *   is prefixed with `"ksrpc internal: "` so if it ever does fire the user at least gets
+ *   a breadcrumb. Still throws — the compilation cannot continue past these.
+ *
+ * New plugin code should prefer these helpers over bare `error(...)` / `report(ERROR, ...)`.
+ *
+ * The IR-phase validation that lives in [KsrpcIrGenerationExtension] is currently the best
+ * we can do without duplicating service-shape analysis into a FIR checker; a FIR-phase
+ * checker with `KtSourceElement` would give richer IDE diagnostics (red squiggle on the
+ * offending element), see the TODO there.
+ */
+internal fun MessageCollector.reportUserError(
+    message: String,
+    element: IrElement? = null,
+    fileHint: IrFile? = null
+) {
+    report(ERROR, message, element.toLocation(fileHint))
+}
+
+internal fun MessageCollector.reportUserWarning(
+    message: String,
+    element: IrElement? = null,
+    fileHint: IrFile? = null
+) {
+    report(WARNING, message, element.toLocation(fileHint))
+}
+
+/**
+ * Raise an internal-invariant failure. The message is prefixed with `"ksrpc internal: "`
+ * and passed to `error(...)` — the compilation fails with a thrown exception. Use for
+ * should-never-happen branches (e.g. validated-away cases, dependency lookups that the
+ * earlier environment bootstrap must have resolved). Prefer [reportUserError] whenever
+ * the user can actually trigger the site.
+ */
+internal fun reportInternal(message: String): Nothing = error("ksrpc internal: $message")
+
+private fun IrElement?.toLocation(fileHint: IrFile?): CompilerMessageSourceLocation? {
+    val file = when {
+        this is IrDeclaration -> fileOrNull ?: fileHint
+        else -> fileHint
+    } ?: return null
+    val entry = file.fileEntry
+    val offset = this?.startOffset?.takeIf { it >= 0 } ?: return CompilerMessageLocation.create(
+        entry.name
+    )
+    // IrFileEntry expects offsets within [0, maxOffset]; guard against synthetic offsets.
+    if (offset > entry.maxOffset) {
+        return CompilerMessageLocation.create(entry.name)
+    }
+    val lineAndColumn = entry.getLineAndColumnNumbers(offset)
+    // IrFileEntry returns 0-based line/column; CompilerMessageLocation expects 1-based.
+    return CompilerMessageLocation.create(
+        entry.name,
+        lineAndColumn.line + 1,
+        lineAndColumn.column + 1,
+        null
+    )
+}

--- a/compiler/plugin/src/main/java/ServiceClass.kt
+++ b/compiler/plugin/src/main/java/ServiceClass.kt
@@ -17,7 +17,6 @@
 
 package com.monkopedia.ksrpc.plugin
 
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -55,7 +54,9 @@ private class Visitor(private val messageCollector: MessageCollector) : IrElemen
         val ret = super.visitClass(declaration)
         if (annotation != null) {
             classes[declaration.fqNameForIrSerialization.asString()] = currentService
-                ?: error("Internal error, lost service")
+                ?: reportInternal(
+                    "lost currentService while visiting ${declaration.name.asString()}"
+                )
         }
         currentService = lastService
         return ret
@@ -86,21 +87,22 @@ private class Visitor(private val messageCollector: MessageCollector) : IrElemen
                 if (declaration.dispatchReceiverParameter?.type?.classFqName !=
                     FqConstants.FQ_INTROSPECTABLE_RPC_SERVICE
                 ) {
-                    messageCollector.report(
-                        CompilerMessageSeverity.ERROR,
-                        "${
-                            declaration.name.asString()
-                        } declared as KsMethod but not inside a KsService (${declaration.dispatchReceiverParameter?.type?.classFqName})"
+                    val receiverFqName =
+                        declaration.dispatchReceiverParameter?.type?.classFqName
+                    messageCollector.reportUserError(
+                        "@KsMethod can only be applied to functions declared inside a " +
+                            "@KsService interface. ${declaration.name.asString()} is " +
+                            "declared on $receiverFqName.",
+                        element = declaration
                     )
                 }
             }
         } else {
             if (currentService != null && declaration.overriddenSymbols.isEmpty()) {
-                messageCollector.report(
-                    CompilerMessageSeverity.WARNING,
-                    "${
-                        declaration.name.asString()
-                    } declared within KsService without KsMethod annotation"
+                messageCollector.reportUserWarning(
+                    "${declaration.name.asString()} declared inside a @KsService " +
+                        "without @KsMethod — the function will not be exposed over RPC.",
+                    element = declaration
                 )
             }
         }
@@ -117,9 +119,10 @@ private class SubclassVisitor(
             classes[it.fqNameForIrSerialization.asString()]
         }.also {
             if (it.size > 1) {
-                messageCollector.error(
+                messageCollector.reportUserError(
                     "${declaration.fqNameForIrSerialization.asString()} has " +
-                        "multiple RPC super classes, which is not supported"
+                        "multiple @KsService super types, which is not supported.",
+                    element = declaration
                 )
             }
         }.singleOrNull()?.irClassAndImpls?.add(declaration)

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -114,10 +114,14 @@ class StubGeneration(
         // `service.genericExecutors`) so both the stub body and Obj.findEndpoint produce
         // RpcMethod instances that reference the same executor class.
         val genericBuilder = if (declaration.typeParameters.isNotEmpty()) {
-            GenericMethodIrBuilder(context, env, service).also { builder ->
+            GenericMethodIrBuilder(context, env, messageCollector, service).also { builder ->
                 for (serviceMethod in service.methods) {
                     val endpoint = serviceMethod.ksMethodAnnotation.arguments[0].constString()
-                        ?: error("Lost endpoint")
+                        ?: reportInternal(
+                            "@KsMethod annotation on " +
+                                "${serviceMethod.function.name.asString()} lost its " +
+                                "endpoint argument after validation"
+                        )
                     val executor = builder.buildExecutor(serviceMethod.function, declaration)
                     service.genericExecutors[endpoint.trimStart('/')] = executor
                 }
@@ -133,7 +137,11 @@ class StubGeneration(
             service.methods.map { serviceMethod ->
                 if (genericBuilder != null) {
                     val endpoint = serviceMethod.ksMethodAnnotation.arguments[0].constString()
-                        ?: error("Lost endpoint")
+                        ?: reportInternal(
+                            "@KsMethod annotation on " +
+                                "${serviceMethod.function.name.asString()} lost its " +
+                                "endpoint argument after validation"
+                        )
                     add(
                         declaration.generateGenericMethodBody(
                             serviceMethod.function,
@@ -190,7 +198,10 @@ class StubGeneration(
             val thisParam = override.parameters[0]
             val inputParam = override.parameters[1]
             val executor = service.genericExecutors[endpoint.trimStart('/')]
-                ?: error("Executor missing for endpoint $endpoint")
+                ?: reportInternal(
+                    "generic executor missing for endpoint $endpoint on " +
+                        service.irClass.kotlinFqName.asString()
+                )
             +irReturn(
                 irCall(callChannel).apply {
                     type = substitutedReturn
@@ -287,7 +298,10 @@ class StubGeneration(
 
     private fun IrClass.generateCloseMethod(serviceClass: ServiceClass): IrSimpleFunction {
         val close = functions.find { it.name == FqConstants.CLOSE }
-            ?: error("Can't find close method")
+            ?: reportInternal(
+                "can't find close() on generated Stub for " +
+                    serviceClass.irClass.kotlinFqName.asString()
+            )
         val suspendClose = env.suspendCloseable.findMethod(FqConstants.CLOSE)
 
         return context.overrideMethod(this, close.symbol, close.returnType) { override ->
@@ -306,7 +320,10 @@ class StubGeneration(
         companion: IrClass,
         service: ServiceClass
     ): IrFunction {
-        val endpoint = annotation.arguments[0].constString() ?: error("Lost endpoint")
+        val endpoint = annotation.arguments[0].constString() ?: reportInternal(
+            "@KsMethod annotation on ${method.name.asString()} lost its endpoint " +
+                "argument after validation"
+        )
         val methodField =
             generateRpcMethod(env, endpoint, method, this, companion, metadataAnnotations)
 
@@ -321,7 +338,11 @@ class StubGeneration(
                         val overrideParams = override.parameters.map {
                             it.name.asString() to it.type.classFqName?.asString()
                         }
-                        error("Unexpected override parameters $overrideParams")
+                        reportInternal(
+                            "generated stub override for ${method.name.asString()} has " +
+                                "unexpected parameters $overrideParams (expected exactly " +
+                                "dispatch + single value parameter)"
+                        )
                     }
                     putArgs(
                         irCall(methodField).apply {
@@ -423,7 +444,7 @@ class StubGeneration(
                 }
             )
             if (supportsMetadata) {
-                args += MetadataIrBuilder(env, this@irCreateRpcMethod)
+                args += MetadataIrBuilder(env, this@irCreateRpcMethod, messageCollector)
                     .buildMetadataList(metadataAnnotations)
             }
             putArgs(*args.toTypedArray())
@@ -456,7 +477,12 @@ class StubGeneration(
     }
 
     private fun getSerializer(irBlockBodyBuilder: DeclarationIrBuilder, type: IrType) =
-        irBlockBodyBuilder.irCall(env.serializerMethod ?: error("Missing serializer")).apply {
+        irBlockBodyBuilder.irCall(
+            env.serializerMethod ?: reportInternal(
+                "can't resolve kotlinx.serialization.serializer<T>() — " +
+                    "kotlinx-serialization-core must be on the compile classpath"
+            )
+        ).apply {
             typeArguments[0] = type
             this.type = env.kSerializer.typeWith(type)
         }
@@ -486,7 +512,14 @@ class StubGeneration(
 fun KsrpcGenerationEnvironment.companionSymbol(outputType: IrType): IrClassSymbol {
     val clazz = outputType.getClass()
     val companionSymbol = clazz?.companionObject()?.symbol
-        ?: error("Missing companion ${outputType.classFqName?.asString()}")
+        // TODO (issue #27 follow-up): this can fire when a user returns an RpcService
+        // subtype that isn't annotated `@KsService`. Route through MessageCollector once
+        // StubGeneration.companionSymbol gets a location for the offending return type.
+        ?: error(
+            "ksrpc internal: missing companion on sub-service return type " +
+                "${outputType.classFqName?.asString()} — the return type must be an " +
+                "@KsService interface"
+        )
     return companionSymbol
 }
 

--- a/compiler/plugin/src/test/java/KsServiceSubtypeValidationTest.kt
+++ b/compiler/plugin/src/test/java/KsServiceSubtypeValidationTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Regression tests for issue #45: applying `@KsService` to a subtype of another
+ * `@KsService` interface used to crash CompanionGeneration with
+ * "Invalid synthetic declaration for ...". The plugin now rejects this with a clear
+ * compile-time diagnostic, while the supported workaround (a plain Kotlin subtype with
+ * no `@KsService`) continues to work — see `GenericServiceSubtypeJvmTest`.
+ */
+class KsServiceSubtypeValidationTest {
+
+    @Test
+    fun `KsService on subtype of generic KsService is rejected with a clear diagnostic`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface GenericEcho<T> : RpcService {
+    @KsMethod("/echo")
+    suspend fun echo(item: T): T
+}
+
+@KsService
+interface TypedGenericEcho : GenericEcho<String>
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("@KsService cannot be applied to") &&
+                result.messages.contains("TypedGenericEcho") &&
+                result.messages.contains("GenericEcho"),
+            "Expected diagnostic mentioning @KsService, TypedGenericEcho and GenericEcho, " +
+                "got: ${result.messages}"
+        )
+        // Make sure we're not seeing the old crash anymore.
+        assertTrue(
+            !result.messages.contains("Invalid synthetic declaration"),
+            "Plugin should not crash with 'Invalid synthetic declaration' anymore, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsService on subtype of non-generic KsService is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface ParentService : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String
+}
+
+@KsService
+interface ChildService : ParentService
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("@KsService cannot be applied to") &&
+                result.messages.contains("ChildService") &&
+                result.messages.contains("ParentService"),
+            "Expected diagnostic mentioning @KsService, ChildService and ParentService, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsService directly extending RpcService still compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Unrelated : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed, got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `Plain Kotlin subtype of generic KsService still compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface GenericEcho<T> : RpcService {
+    @KsMethod("/echo")
+    suspend fun echo(item: T): T
+}
+
+// No @KsService — this is the supported pattern for specializing a generic service.
+interface TypedGenericEcho : GenericEcho<String>
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed, got: ${result.messages}"
+        )
+    }
+}

--- a/compiler/plugin/src/test/java/MethodShapeValidationTest.kt
+++ b/compiler/plugin/src/test/java/MethodShapeValidationTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Covers user-reachable diagnostics emitted by [KsrpcIrGenerationExtension.validateMethod]
+ * and [ServiceClass.visitSimpleFunction]. Each failure mode must fail compilation with a
+ * message that names the offending declaration, so that users can tell which method of
+ * which class is wrong.
+ */
+class MethodShapeValidationTest {
+
+    @Test
+    fun `method with type parameter is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface BadService : RpcService {
+    @KsMethod("/generic")
+    suspend fun <T> genericOp(input: T): T
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("genericOp") &&
+                result.messages.contains("cannot have type parameters"),
+            "Expected diagnostic naming genericOp and type-parameter rejection, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `method with more than one parameter is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface BadService : RpcService {
+    @KsMethod("/too_many")
+    suspend fun tooMany(a: String, b: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("tooMany") &&
+                result.messages.contains("cannot have more than 1 parameter"),
+            "Expected diagnostic naming tooMany and parameter-count rejection, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `duplicate endpoints are rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface BadService : RpcService {
+    @KsMethod("/dupe")
+    suspend fun one(input: String): String
+
+    @KsMethod("/dupe")
+    suspend fun two(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("cannot use endpoint") &&
+                result.messages.contains("/dupe") &&
+                result.messages.contains("two"),
+            "Expected duplicate-endpoint diagnostic naming /dupe and `two`, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsService on non-RpcService is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+
+@KsService
+interface NotAnRpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("NotAnRpcService") &&
+                result.messages.contains("does not extend"),
+            "Expected RpcService-extension diagnostic naming NotAnRpcService, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `non-invariant class type parameter is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Variant<out T> : RpcService {
+    @KsMethod("/get")
+    suspend fun get(input: String): T
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("Variant") &&
+                result.messages.contains("must be invariant"),
+            "Expected invariance diagnostic naming Variant, got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsMethod outside of KsService is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.RpcService
+
+// Intentionally no @KsService — @KsMethod should not be accepted here.
+interface UnmarkedService : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("@KsMethod can only be applied") &&
+                result.messages.contains("op"),
+            "Expected @KsMethod-outside-@KsService diagnostic naming `op`, " +
+                "got: ${result.messages}"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #27. Audits every `error()` / `throw IllegalStateException` / `check()` / `require()` site in the ksrpc compiler plugin and reclassifies them into two buckets:

- **User-reachable errors** (bad annotation usage, invalid method shape, duplicate endpoints, ...) now go through `MessageCollector.report(ERROR, ...)` via a new `reportUserError` helper that resolves a source file:line:column from the offending `IrElement`. Users compiling a bad `@KsService` now see a clean diagnostic pointing at the declaration they need to fix.
- **Internal invariants** (classpath bootstrap, should-never-happen fall-throughs) are prefixed with `"ksrpc internal: "` so if any ever fires the user has a breadcrumb rather than an anonymous `IllegalStateException`.

New `PluginReporter.kt` establishes the convention for future plugin code.

### Conversions

| Category | Count |
| --- | --- |
| User-reachable -> `reportUserError` with location | 11 sites |
| Internal invariant -> `reportInternal` / `"ksrpc internal:"` prefix | 17 sites |
| Deferred (documented TODO) | 1 site (sub-service companion lookup in `StubGeneration.companionSymbol`) |

### Deferred / follow-up

- `StubGeneration.companionSymbol` fires when a user returns an `RpcService` subtype that isn't `@KsService`-annotated. Routing this through `MessageCollector` with a location needs plumbing of the collector + return-type element into a helper that's called from IR callsites that don't own the collector — deferred. Kept as `error(\"ksrpc internal: ...\")` with a `TODO` pointing at this issue.
- All of the surviving user-reachable validations still run in the IR phase. A FIR-phase checker with `KtSourceElement` would give IDE red-squiggle diagnostics on the offending declaration; noted as a TODO in the extension's header comment. Out of scope for this PR — it's a much bigger refactor and the IR-phase diagnostics already fail compilation with a source location.

### Testing

Added `MethodShapeValidationTest` covering previously-untested user-reachable validations: method type parameter, >1 parameter, duplicate endpoints, non-`RpcService` supertype, non-invariant class type parameter, `@KsMethod` outside `@KsService`. Existing tests (`KsNotificationValidationTest`, `KsServiceSubtypeValidationTest`, ...) continue to pass.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test`
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test`
- [x] `./gradlew apiCheck` - no BCV surface changes
- [x] `:compiler:ksrpc-compiler-plugin-native:compileKotlin` (sync-sourced, still builds)
- [x] ktlint clean on touched files (only pre-existing generated-file violation remains)

## Stacking

Based on `issue-45-subtype-crash` (PR #49). Rebase or squash-merge after #49 lands.

Closes #27

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>