### PR TITLE
Fix #40: support 0-argument @KsMethod functions

### DIFF
--- a/compiler/plugin/src/main/java/IrUtils.kt
+++ b/compiler/plugin/src/main/java/IrUtils.kt
@@ -219,6 +219,12 @@ internal fun IrPluginContext.buildAnonymousServiceExecutor(
         }
     }
     val invokeMethod = env.serviceExecutor.findMethod(FqConstants.INVOKE)
+    // The referenced user function may be declared with 0 or 1 value parameters.
+    // ServiceExecutor.invoke always passes (service, input: Any?); for 0-arg functions
+    // we simply discard the input and call with just the dispatch receiver.
+    val referencedValueParams = referencedFunction.parameters.filter {
+        it != referencedFunction.dispatchReceiverParameter
+    }
     val override = overrideMethod(
         executorClass,
         invokeMethod,
@@ -227,16 +233,22 @@ internal fun IrPluginContext.buildAnonymousServiceExecutor(
         +irReturn(
             irCall(referencedFunction).apply {
                 type = referencedFunction.returnType
-                putArgs(
-                    irImplicitCast(
-                        irGet(override.parameters[1]),
-                        referencedFunction.dispatchReceiverParameter?.type!!
-                    ),
-                    irImplicitCast(
-                        irGet(override.parameters[2]),
-                        referencedFunction.parameters[1].type
-                    )
+                val dispatchArg = irImplicitCast(
+                    irGet(override.parameters[1]),
+                    referencedFunction.dispatchReceiverParameter?.type!!
                 )
+                if (referencedValueParams.isEmpty()) {
+                    // 0-arg @KsMethod: ignore the `input: Any?` parameter entirely.
+                    putArgs(dispatchArg)
+                } else {
+                    putArgs(
+                        dispatchArg,
+                        irImplicitCast(
+                            irGet(override.parameters[2]),
+                            referencedValueParams[0].type
+                        )
+                    )
+                }
             }
         )
     }

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -228,7 +228,8 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
             )
             isValid = false
         }
-        if (method.parameters.filter { !it.isDispatchReceiver }.size > 1) {
+        val valueParams = method.parameters.filter { !it.isDispatchReceiver }
+        if (valueParams.size > 1) {
             val fqName = irClass.kotlinFqName.asString()
             report.reportUserError(
                 "$fqName.${method.name.asString()} cannot have more than 1 parameter",
@@ -255,7 +256,10 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
             )
             isValid = false
         }
-        val inputType = method.parameters[0].type.classFqName
+        // valueParams may be empty for 0-arg @KsMethod functions; the RpcMethod is
+        // generated with `Unit` as the input type in that case, so there is no
+        // user-declared input to check against ByteReadChannel.
+        val inputType = valueParams.firstOrNull()?.type?.classFqName
         val outputType = method.returnType.classFqName
         if (inputType == BYTE_READ_CHANNEL && outputType == BYTE_READ_CHANNEL) {
             val fqName = irClass.kotlinFqName.asString()

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -269,7 +269,9 @@ internal class GenericMethodIrBuilder(
         metadataAnnotations: List<IrConstructorCall>,
         executor: IrClass
     ): IrConstructorCall {
-        val inputType = method.parameters.first { !it.isDispatchReceiver }.type
+        // 0-arg @KsMethod functions fall back to Unit as the input type.
+        val inputType = method.parameters.firstOrNull { !it.isDispatchReceiver }?.type
+            ?: context.irBuiltIns.unitType
         val outputType = method.returnType
         val serviceType = cls.irClass.typeWith(
             cls.irClass.typeParameters.map { it.defaultType }

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -59,6 +59,7 @@ import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
@@ -189,6 +190,7 @@ class StubGeneration(
         val callChannel = env.rpcMethod.findMethod(FqConstants.CALL_CHANNEL)
         val substitutor = stubTypeSubstitutor(service, this)
         val substitutedReturn = substitutor.substitute(method.returnType)
+        val hasValueParam = method.parameters.any { !it.isDispatchReceiver }
         return context.overrideMethodWithSubstitution(
             this,
             method.symbol,
@@ -196,7 +198,13 @@ class StubGeneration(
             substitutedReturn
         ) { override ->
             val thisParam = override.parameters[0]
-            val inputParam = override.parameters[1]
+            // For 0-arg @KsMethod functions the override has only the dispatch receiver
+            // and we pass Unit as the call input.
+            val inputExpr: IrExpression = if (hasValueParam) {
+                irGet(override.parameters[1])
+            } else {
+                irGetObject(context.irBuiltIns.unitClass)
+            }
             val executor = service.genericExecutors[endpoint.trimStart('/')]
                 ?: reportInternal(
                     "generic executor missing for endpoint $endpoint on " +
@@ -216,7 +224,7 @@ class StubGeneration(
                             executor = executor
                         ),
                         irGetField(irGet(thisParam), service.channel),
-                        irGet(inputParam)
+                        inputExpr
                     )
                 }
             )
@@ -330,26 +338,36 @@ class StubGeneration(
         service.addEndpoint(endpoint, methodField)
         val callChannel = env.rpcMethod.findMethod(FqConstants.CALL_CHANNEL)
 
+        val valueParams = method.parameters.filter { !it.isDispatchReceiver }
         return context.overrideMethod(this, method.symbol) { override ->
             +irReturn(
                 irCall(callChannel).apply {
                     type = method.returnType
-                    if (override.parameters.size != 2) {
+                    // Expected override params: dispatch receiver + 0 or 1 value
+                    // parameters (0 for @KsMethod functions with no declared input).
+                    val expectedSize = 1 + valueParams.size
+                    if (override.parameters.size != expectedSize) {
                         val overrideParams = override.parameters.map {
                             it.name.asString() to it.type.classFqName?.asString()
                         }
                         reportInternal(
                             "generated stub override for ${method.name.asString()} has " +
-                                "unexpected parameters $overrideParams (expected exactly " +
-                                "dispatch + single value parameter)"
+                                "unexpected parameters $overrideParams (expected " +
+                                "dispatch + $valueParams.size value parameter(s))"
                         )
+                    }
+                    val inputExpr: IrExpression = if (valueParams.isEmpty()) {
+                        // 0-arg @KsMethod: synthesize Unit as the call input.
+                        irGetObject(context.irBuiltIns.unitClass)
+                    } else {
+                        irGet(override.parameters[1])
                     }
                     putArgs(
                         irCall(methodField).apply {
                             putArgs(irGetObject(companion.symbol))
                         },
                         irGetField(irGet(override.parameters[0]), service.channel),
-                        irGet(override.parameters[1])
+                        inputExpr
                     )
                 }
             )
@@ -411,7 +429,10 @@ class StubGeneration(
         method: IrSimpleFunction,
         metadataAnnotations: List<IrConstructorCall>
     ): IrConstructorCall {
-        val inputType = method.parameters.first { !it.isDispatchReceiver }.type
+        // 0-arg @KsMethod functions have no user-declared input; fall back to Unit
+        // so the generated RpcMethod is shaped as `RpcMethod<Service, Unit, Out>`.
+        val inputType = method.parameters.firstOrNull { !it.isDispatchReceiver }?.type
+            ?: context.irBuiltIns.unitType
         val outputType = method.returnType
         val inputRpcType = determineType(inputType)
         val outputRpcType = determineType(outputType)

--- a/compiler/plugin/src/test/java/KsMethodZeroArgTest.kt
+++ b/compiler/plugin/src/test/java/KsMethodZeroArgTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Compile-only coverage for issue #40: `@KsMethod` functions should be accepted with
+ * zero value parameters. The generated `RpcMethod` uses `Unit` as the input type in
+ * that case, so mixing 0-arg and 1-arg methods on the same service must compile.
+ */
+class KsMethodZeroArgTest {
+
+    @Test
+    fun `zero arg KsMethod compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface ZeroArgService : RpcService {
+    @KsMethod("/ping")
+    suspend fun ping(): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed; messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `zero arg and one arg methods coexist`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface MixedService : RpcService {
+    @KsMethod("/ping")
+    suspend fun ping(): String
+
+    @KsMethod("/greet")
+    suspend fun greet(name: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed; messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `zero arg with explicit Unit still compiles for backward compat`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface ExplicitUnitService : RpcService {
+    @KsMethod("/ping")
+    suspend fun ping(u: Unit): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed; messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `zero arg on generic service compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface GenericZeroArg<T> : RpcService {
+    @KsMethod("/get")
+    suspend fun get(): T
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed; messages: ${result.messages}"
+        )
+    }
+}

--- a/ksrpc-test/src/commonTest/kotlin/KsMethodZeroArgTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsMethodZeroArgTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
+import com.monkopedia.ksrpc.internal.asClient
+import com.monkopedia.ksrpc.sockets.asConnection
+import io.ktor.utils.io.close
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Integration coverage for issue #40: `@KsMethod` functions with zero value parameters.
+ * Exercises a service that mixes 0-arg and 1-arg methods over the in-process SerializedChannel
+ * and over the PIPE transport, asserting values round-trip correctly in both directions.
+ */
+@KsService
+interface ZeroArgTestService : RpcService {
+    @KsMethod("/ping")
+    suspend fun ping(): String
+
+    @KsMethod("/greet")
+    suspend fun greet(name: String): String
+
+    @KsMethod("/count")
+    suspend fun count(): Int
+}
+
+private class ZeroArgTestServiceImpl : ZeroArgTestService {
+    override suspend fun ping(): String = "pong"
+    override suspend fun greet(name: String): String = "hello $name"
+    override suspend fun count(): Int = 42
+}
+
+class KsMethodZeroArgTest {
+
+    @Test
+    fun inProcessZeroArgRoundTrips() = runBlockingUnit {
+        val channel = HostSerializedChannelImpl(ksrpcEnvironment { })
+        try {
+            val impl: ZeroArgTestService = ZeroArgTestServiceImpl()
+            channel.registerDefault(
+                impl.serialized(rpcObject<ZeroArgTestService>(), channel.env)
+            )
+            val stub = rpcObject<ZeroArgTestService>()
+                .createStub(channel.asClient.defaultChannel())
+            assertEquals("pong", stub.ping())
+            assertEquals("hello world", stub.greet("world"))
+            assertEquals(42, stub.count())
+        } finally {
+            channel.close()
+        }
+    }
+
+    @Test
+    fun pipeZeroArgRoundTrips() = runBlockingUnit {
+        val env = ksrpcEnvironment { }
+        val (output, input) = createPipe()
+        val (so, si) = createPipe()
+        val serverConnection = (si to output).asConnection(env)
+        val clientConnection = (input to so).asConnection(env)
+        val serverJob = launch(Dispatchers.Default) {
+            val impl: ZeroArgTestService = ZeroArgTestServiceImpl()
+            serverConnection.registerDefault(
+                impl.serialized(rpcObject<ZeroArgTestService>(), env)
+            )
+        }
+        try {
+            val stub = rpcObject<ZeroArgTestService>()
+                .createStub(clientConnection.defaultChannel())
+            assertEquals("pong", stub.ping())
+            assertEquals("hello ksrpc", stub.greet("ksrpc"))
+            assertEquals(42, stub.count())
+        } finally {
+            try {
+                clientConnection.close()
+            } catch (_: Throwable) {
+            }
+            try {
+                serverConnection.close()
+            } catch (_: Throwable) {
+            }
+            try {
+                serverJob.cancel()
+            } catch (_: Throwable) {
+            }
+            try {
+                serverJob.join()
+            } catch (_: Throwable) {
+            }
+            try {
+                input.cancel(null)
+            } catch (_: Throwable) {
+            }
+            try {
+                si.cancel(null)
+            } catch (_: Throwable) {
+            }
+            output.close(null)
+            so.close(null)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Accept `@KsMethod` functions declared with zero value parameters so users can write `suspend fun ping(): String` instead of `suspend fun ping(u: Unit): String`. The generated `RpcMethod` treats the input as `Unit`, so 0-arg methods and explicit-`Unit` methods produce equivalent runtime behavior.
- Relaxes the IR-phase validator (`KsrpcIrGenerationExtension.validateMethod`) to allow 0..1 non-dispatch parameters. Fixes a latent off-by-one where the `ByteReadChannel` check was reading `parameters[0]` (the dispatch receiver) instead of the value parameter.
- Codegen paths that previously assumed a value parameter (StubGeneration non-generic `generateMethodField`, generic `generateGenericMethodBody` / `irCreateRpcMethod`, `ObjGeneration.GenericMethodIrBuilder.irCreateRpcMethod`, and the shared `buildAnonymousServiceExecutor` in `IrUtils.kt`) now fall back to `Unit` — synthesising the call input via `irGetObject(unitClass)` for stubs and dropping the argument on the host-side adapter.
- 0-arg support works on generic services too (`GenericZeroArg<T> { suspend fun get(): T }` compiles).

Backward compatibility: existing `suspend fun foo(u: Unit)` services keep working unchanged.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — existing tests plus the new `KsMethodZeroArgTest` (0-arg, mixed, explicit-Unit back-compat, generic-with-0-arg).
- [x] `./gradlew :ksrpc-test:jvmTest` — passes, including the new integration test that round-trips a 0-arg + 1-arg service in-process and over PIPE.
- [x] `./gradlew :ksrpc-test:linuxX64Test` — passes (0-arg round-trip works on Kotlin/Native too).
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test` — pass.
- [x] `./gradlew apiCheck` — clean; no BCV changes (generated output surface is unchanged).
- [x] ktlint on touched files clean (remaining `ktlintCheck` failures are pre-existing on unrelated files).

## Stacking

Based on `issue-27-error-handling` (PR #50). Uses `reportUserError` / `reportInternal` from that refactor for diagnostics consistency.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)