### PR TITLE
Fix #44: complete serializer composition for List/Set/Map wrappers on generic services

### DIFF
--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -80,6 +80,44 @@ class KsrpcGenerationEnvironment(
             } == true
         }?.owner?.getter?.symbol
 
+    // Top-level builder functions in `kotlinx.serialization.builtins` that compose
+    // element serializers into `KSerializer<List<T>>` / `KSerializer<Set<T>>` /
+    // `KSerializer<Map<K, V>>`. Used by the generic @KsService codegen to build
+    // composed serializer expressions for wrapper types that reference a class-level
+    // type parameter. Resolved optimistically — callers fall back to reportUserError
+    // when the lookup misses (should only happen on a broken kotlinx-serialization
+    // classpath).
+    val listSerializerBuilder =
+        context.referenceFunctions(
+            CallableId(
+                FqName("kotlinx.serialization.builtins"),
+                Name.identifier("ListSerializer")
+            )
+        ).firstOrNull { fn ->
+            fn.owner.parameters.count { it.kind == IrParameterKind.Regular } == 1 &&
+                fn.owner.typeParameters.size == 1
+        }
+    val setSerializerBuilder =
+        context.referenceFunctions(
+            CallableId(
+                FqName("kotlinx.serialization.builtins"),
+                Name.identifier("SetSerializer")
+            )
+        ).firstOrNull { fn ->
+            fn.owner.parameters.count { it.kind == IrParameterKind.Regular } == 1 &&
+                fn.owner.typeParameters.size == 1
+        }
+    val mapSerializerBuilder =
+        context.referenceFunctions(
+            CallableId(
+                FqName("kotlinx.serialization.builtins"),
+                Name.identifier("MapSerializer")
+            )
+        ).firstOrNull { fn ->
+            fn.owner.parameters.count { it.kind == IrParameterKind.Regular } == 2 &&
+                fn.owner.typeParameters.size == 2
+        }
+
     val threadLocal = referenceClass(FqConstants.THREAD_LOCAL)
     val listOfFunction =
         context.referenceFunctions(

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -64,6 +64,8 @@ import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.isMarkedNullable
 import org.jetbrains.kotlin.ir.types.makeNotNull
+import org.jetbrains.kotlin.ir.types.typeOrFail
+import org.jetbrains.kotlin.ir.types.typeOrNull
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.addChild
@@ -71,6 +73,7 @@ import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.Name
 
 /**
@@ -287,9 +290,9 @@ internal class GenericMethodIrBuilder(
         }
 
         val inputConverter =
-            createTypeConverter(builder, inputType, serializerReceiver, serializerFields)
+            createTypeConverter(builder, inputType, serializerReceiver, serializerFields, method)
         val outputConverter =
-            createTypeConverter(builder, outputType, serializerReceiver, serializerFields)
+            createTypeConverter(builder, outputType, serializerReceiver, serializerFields, method)
         val executorInstance = builder.irCallConstructor(
             executor.constructors.first().symbol,
             emptyList()
@@ -319,7 +322,8 @@ internal class GenericMethodIrBuilder(
         builder: IrBuilderWithScope,
         type: IrType,
         serializerReceiver: IrValueParameter,
-        serializerFields: List<IrField>
+        serializerFields: List<IrField>,
+        method: IrSimpleFunction
     ): IrExpression {
         // BINARY (ByteReadChannel) transformer.
         if (type.classFqName == FqConstants.BYTE_READ_CHANNEL) {
@@ -334,16 +338,53 @@ internal class GenericMethodIrBuilder(
             listOf(type)
         ).apply {
             this.type = env.serializerTransformer.typeWith(type)
-            putArgs(buildSerializer(builder, type, serializerReceiver, serializerFields))
+            putArgs(buildSerializer(builder, type, serializerReceiver, serializerFields, method))
         }
     }
 
+    /**
+     * Recursively compose a `KSerializer<type>` IR expression.
+     *
+     * - Bare service-level type parameter (`T`): emit a field read against the injected
+     *   `KSerializer<T>` on [serializerReceiver].
+     * - `List<X>` / `Set<X>`: emit `ListSerializer(...)` / `SetSerializer(...)` with a
+     *   recursively built element serializer.
+     * - `Map<K, V>`: emit `MapSerializer(keySer, valueSer)` with recursively built arg
+     *   serializers.
+     * - Anything that doesn't transitively reference a class-level type parameter: fall
+     *   back to the static `kotlinx.serialization.serializer<T>()` lookup — the stock
+     *   behaviour already used by the non-generic codegen path.
+     * - A type that references a type parameter but isn't one of the recognized wrapper
+     *   shapes (e.g. a user-defined `@Serializable class Box<T>(val v: T)`): report a
+     *   clear user error. Supporting user-defined generic wrappers is tracked as a
+     *   follow-up on #44 and would require resolving the user type's serializer factory.
+     *
+     * Nullable wrapping is applied per layer — `List<T?>?` composes as
+     * `ListSerializer(T.nullable).nullable`, matching kotlinx.serialization's own rules.
+     */
     private fun buildSerializer(
         builder: IrBuilderWithScope,
         type: IrType,
         serializerReceiver: IrValueParameter,
-        serializerFields: List<IrField>
+        serializerFields: List<IrField>,
+        method: IrSimpleFunction
     ): IrExpression {
+        // If this type doesn't mention a class-level type parameter anywhere, we don't
+        // need to compose anything — kotlinx.serialization's reified `serializer<T>()`
+        // knows how to resolve it at runtime. This also matches how the non-generic
+        // (all-concrete) path builds its transforms.
+        if (!referencesTypeParameter(type)) {
+            val serializerFn = env.serializerMethod
+                ?: reportInternal(
+                    "can't resolve kotlinx.serialization.serializer<T>() — " +
+                        "kotlinx-serialization-core must be on the compile classpath"
+                )
+            return builder.irCall(serializerFn).apply {
+                typeArguments[0] = type
+                this.type = env.kSerializer.typeWith(type)
+            }
+        }
+
         val classifier = (type as? IrSimpleType)?.classifier
         val serviceTps = cls.irClass.typeParameters
         val tpIndex = if (classifier is org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol) {
@@ -362,7 +403,62 @@ internal class GenericMethodIrBuilder(
                 baseExpr
             }
         }
-        // Fallback: use kotlinx.serialization.serializer<T>().
+
+        // Recognized collection wrappers: List / Set / Map from kotlin.collections.
+        val classFq = type.classFqName?.asString()
+        val simple = type as? IrSimpleType
+        val composed: IrExpression? = when (classFq) {
+            "kotlin.collections.List" ->
+                buildListSerializer(
+                    builder,
+                    simple,
+                    serializerReceiver,
+                    serializerFields,
+                    method
+                )
+
+            "kotlin.collections.Set" ->
+                buildSetSerializer(
+                    builder,
+                    simple,
+                    serializerReceiver,
+                    serializerFields,
+                    method
+                )
+
+            "kotlin.collections.Map" ->
+                buildMapSerializer(
+                    builder,
+                    simple,
+                    serializerReceiver,
+                    serializerFields,
+                    method
+                )
+
+            else -> null
+        }
+        if (composed != null) {
+            return if (type.isMarkedNullable()) {
+                wrapNullable(builder, composed, type)
+            } else {
+                composed
+            }
+        }
+
+        // A non-wrapper type that references a class-level type parameter — e.g.
+        // `Box<T>` on a user-defined `@Serializable class Box<T>(...)`. We cannot
+        // compose its serializer without resolving the user type's companion/factory,
+        // which is out of scope for this change. Surface a clear user error at the
+        // offending method.
+        report.reportUserError(
+            "Cannot compose a KSerializer for ${type.render()} on " +
+                "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()} — " +
+                "only List/Set/Map wrappers of a service type parameter are supported. " +
+                "Refactor to a concrete or supported wrapper type.",
+            element = method
+        )
+        // Fall back to the static serializer<T>() call so codegen doesn't crash after
+        // reporting the diagnostic; the user already sees an ERROR above.
         val serializerFn = env.serializerMethod
             ?: reportInternal(
                 "can't resolve kotlinx.serialization.serializer<T>() — " +
@@ -371,6 +467,112 @@ internal class GenericMethodIrBuilder(
         return builder.irCall(serializerFn).apply {
             typeArguments[0] = type
             this.type = env.kSerializer.typeWith(type)
+        }
+    }
+
+    private fun buildListSerializer(
+        builder: IrBuilderWithScope,
+        simple: IrSimpleType?,
+        serializerReceiver: IrValueParameter,
+        serializerFields: List<IrField>,
+        method: IrSimpleFunction
+    ): IrExpression? {
+        val elementType = simple?.arguments?.singleOrNull()?.typeOrFail ?: return null
+        val listFn = env.listSerializerBuilder ?: run {
+            report.reportUserError(
+                "kotlinx.serialization.builtins.ListSerializer is not on the compile " +
+                    "classpath; cannot compose a serializer for List<...> on " +
+                    "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()}",
+                element = method
+            )
+            return null
+        }
+        val elementSer =
+            buildSerializer(builder, elementType, serializerReceiver, serializerFields, method)
+        return builder.irCall(listFn).apply {
+            typeArguments[0] = elementType
+            val listType = context.irBuiltIns.listClass.typeWith(elementType)
+            this.type = env.kSerializer.typeWith(listType)
+            arguments[0] = elementSer
+        }
+    }
+
+    private fun buildSetSerializer(
+        builder: IrBuilderWithScope,
+        simple: IrSimpleType?,
+        serializerReceiver: IrValueParameter,
+        serializerFields: List<IrField>,
+        method: IrSimpleFunction
+    ): IrExpression? {
+        val elementType = simple?.arguments?.singleOrNull()?.typeOrFail ?: return null
+        val setFn = env.setSerializerBuilder ?: run {
+            report.reportUserError(
+                "kotlinx.serialization.builtins.SetSerializer is not on the compile " +
+                    "classpath; cannot compose a serializer for Set<...> on " +
+                    "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()}",
+                element = method
+            )
+            return null
+        }
+        val elementSer =
+            buildSerializer(builder, elementType, serializerReceiver, serializerFields, method)
+        return builder.irCall(setFn).apply {
+            typeArguments[0] = elementType
+            val setType = context.irBuiltIns.setClass.typeWith(elementType)
+            this.type = env.kSerializer.typeWith(setType)
+            arguments[0] = elementSer
+        }
+    }
+
+    private fun buildMapSerializer(
+        builder: IrBuilderWithScope,
+        simple: IrSimpleType?,
+        serializerReceiver: IrValueParameter,
+        serializerFields: List<IrField>,
+        method: IrSimpleFunction
+    ): IrExpression? {
+        val args = simple?.arguments ?: return null
+        if (args.size != 2) return null
+        val keyType = args[0].typeOrFail
+        val valueType = args[1].typeOrFail
+        val mapFn = env.mapSerializerBuilder ?: run {
+            report.reportUserError(
+                "kotlinx.serialization.builtins.MapSerializer is not on the compile " +
+                    "classpath; cannot compose a serializer for Map<..., ...> on " +
+                    "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()}",
+                element = method
+            )
+            return null
+        }
+        val keySer =
+            buildSerializer(builder, keyType, serializerReceiver, serializerFields, method)
+        val valueSer =
+            buildSerializer(builder, valueType, serializerReceiver, serializerFields, method)
+        return builder.irCall(mapFn).apply {
+            typeArguments[0] = keyType
+            typeArguments[1] = valueType
+            val mapType = context.irBuiltIns.mapClass.typeWith(keyType, valueType)
+            this.type = env.kSerializer.typeWith(mapType)
+            arguments[0] = keySer
+            arguments[1] = valueSer
+        }
+    }
+
+    /**
+     * True iff [type] transitively references one of [cls]'s class-level type parameters.
+     * Used to short-circuit the recursive composer onto the static
+     * `kotlinx.serialization.serializer<T>()` path for types that don't need any
+     * per-instance serializer injection.
+     */
+    private fun referencesTypeParameter(type: IrType): Boolean {
+        val simple = type as? IrSimpleType ?: return false
+        val classifier = simple.classifier
+        if (classifier is org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol) {
+            return cls.irClass.typeParameters.any { it.symbol == classifier }
+        }
+        return simple.arguments.any { arg ->
+            val argType = arg.typeOrNull ?: return@any false
+            referencesTypeParameter(argType)
         }
     }
 

--- a/compiler/plugin/src/test/java/GenericServiceTest.kt
+++ b/compiler/plugin/src/test/java/GenericServiceTest.kt
@@ -161,6 +161,135 @@ interface KsBatcher<T>: RpcService {
     }
 
     @Test
+    fun `generic ksservice with List-of-T input and output compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface KsListEcho<T>: RpcService {
+    @KsMethod("/echo")
+    suspend fun echo(items: List<T>): List<T>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `generic ksservice with Set of T compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface KsSetEcho<T>: RpcService {
+    @KsMethod("/echo")
+    suspend fun echo(items: Set<T>): Set<T>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `generic ksservice with Map of String to T compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface KsMapEcho<T>: RpcService {
+    @KsMethod("/echo")
+    suspend fun echo(entries: Map<String, T>): Map<String, T>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `generic ksservice with nullable wrappers compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface KsNullableWrappers<T>: RpcService {
+    @KsMethod("/a")
+    suspend fun a(items: List<T>?): List<T>?
+
+    @KsMethod("/b")
+    suspend fun b(items: List<T?>): List<T?>
+
+    @KsMethod("/c")
+    suspend fun c(entries: Map<String, T?>?): Map<String, T?>?
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `generic ksservice with nested wrappers compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface KsNested<T>: RpcService {
+    @KsMethod("/a")
+    suspend fun a(items: List<List<T>>): List<List<T>>
+
+    @KsMethod("/b")
+    suspend fun b(entries: Map<String, List<T>>): Map<String, List<T>>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
     fun `method-level type parameters are still rejected`() {
         val source = SourceFile.kotlin(
             "main.kt",

--- a/ksrpc-test/src/commonTest/kotlin/GenericServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/GenericServiceTest.kt
@@ -41,6 +41,78 @@ private class GenericEchoStringImpl : GenericEcho<String> {
 }
 
 /**
+ * Exercises wrapper-type serializer composition for generic `@KsService`s:
+ * `List<T>`, `Set<T>`, `Map<K, V>`, nullable variants, and nesting. The generated
+ * `Stub` and `Obj` compose serializers via `ListSerializer`/`SetSerializer`/
+ * `MapSerializer` from `kotlinx.serialization.builtins`, threading the injected
+ * `KSerializer<T>` through. See issue #44.
+ */
+@KsService
+interface WrappedEcho<T> : RpcService {
+    @KsMethod("/list")
+    suspend fun list(items: List<T>): List<T>
+
+    @KsMethod("/set")
+    suspend fun set(items: Set<T>): Set<T>
+
+    @KsMethod("/map")
+    suspend fun map(entries: Map<String, T>): Map<String, T>
+
+    @KsMethod("/nullable")
+    suspend fun nullable(item: T?): T?
+
+    @KsMethod("/listOfNullable")
+    suspend fun listOfNullable(items: List<T?>): List<T?>
+
+    @KsMethod("/nested")
+    suspend fun nested(items: List<List<T>>): List<List<T>>
+
+    @KsMethod("/nullableList")
+    suspend fun nullableList(items: List<T>?): List<T>?
+}
+
+private class WrappedEchoStringImpl : WrappedEcho<String> {
+    override suspend fun list(items: List<String>): List<String> = items.map { "l:$it" }
+    override suspend fun set(items: Set<String>): Set<String> = items.map { "s:$it" }.toSet()
+    override suspend fun map(entries: Map<String, String>): Map<String, String> =
+        entries.mapValues { "m:${it.value}" }
+    override suspend fun nullable(item: String?): String? = item?.let { "n:$it" }
+    override suspend fun listOfNullable(items: List<String?>): List<String?> =
+        items.map { it?.let { "ln:$it" } }
+    override suspend fun nested(items: List<List<String>>): List<List<String>> =
+        items.map { row -> row.map { "nd:$it" } }
+    override suspend fun nullableList(items: List<String>?): List<String>? =
+        items?.map { "nl:$it" }
+    override suspend fun close() = Unit
+}
+
+class GenericServiceWrappedRoundTripTest :
+    RpcFunctionalityTest(
+        serializedChannel = {
+            val impl: WrappedEcho<String> = WrappedEchoStringImpl()
+            impl.serialized<WrappedEcho<String>, String>(ksrpcEnvironment { })
+        },
+        verifyOnChannel = { serializedChannel ->
+            val stub = serializedChannel.toStub<WrappedEcho<String>, String>()
+            assertEquals(listOf("l:a", "l:b"), stub.list(listOf("a", "b")))
+            assertEquals(setOf("s:a", "s:b"), stub.set(setOf("a", "b")))
+            assertEquals(mapOf("k" to "m:v"), stub.map(mapOf("k" to "v")))
+            assertEquals("n:x", stub.nullable("x"))
+            assertNull(stub.nullable(null))
+            assertEquals(
+                listOf("ln:a", null, "ln:b"),
+                stub.listOfNullable(listOf("a", null, "b"))
+            )
+            assertEquals(
+                listOf(listOf("nd:a"), listOf("nd:b", "nd:c")),
+                stub.nested(listOf(listOf("a"), listOf("b", "c")))
+            )
+            assertEquals(listOf("nl:x"), stub.nullableList(listOf("x")))
+            assertNull(stub.nullableList(null))
+        }
+    )
+
+/**
  * End-to-end round-trip tests for a generic `@KsService` with `T` and `T?` method
  * signatures. Exercises the companion's `invoke(serializer)` factory, the generated
  * `Obj<T>` RpcObject, and the Stub's ability to push method calls over a SerializedService


### PR DESCRIPTION
## Summary

Completes the generic `@KsService` story by extending the IR-level serializer composer to handle collection wrappers that reference a class-level type parameter.

Before this change the compiler plugin handled only `T` and `T?` on method signatures; any method whose signature mentioned `List<T>`, `Set<T>`, `Map<K,V>`, or their nullable/nested combinations would either fail to compile or silently resolve to a static `serializer<T>()` over an erased type parameter.

- Added `ListSerializer` / `SetSerializer` / `MapSerializer` references to `KsrpcGenerationEnvironment` next to the existing `serializer<T>()` / `nullable` hooks.
- Rewrote `GenericMethodIrBuilder.buildSerializer` as a recursive composer:
  - bare class-level `T` -> field read of the injected `KSerializer<T>`
  - `List<X>` / `Set<X>` / `Map<K,V>` -> corresponding builder call with recursively composed arg serializers
  - Types that don't reference a type parameter -> fall back to the reified `kotlinx.serialization.serializer<T>()` (same as the non-generic path).
  - Types that reference a type parameter but aren't a recognized wrapper shape (e.g. user-defined `@Serializable` generic wrappers) -> surface a `reportUserError` pointing at the offending method. Full support for user-defined generic `@Serializable` wrappers is explicitly deferred — see the non-goals in #44.
- Nullable wrapping is applied at each layer, so `List<T?>?` composes as `ListSerializer(T.nullable).nullable`.

This PR stacks on `issue-40-zero-arg-methods`.

Closes #44.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — added new cases for `List<T>`, `Set<T>`, `Map<String,T>`, nullable variants (`List<T>?`, `List<T?>`, `Map<String, T?>?`), and nesting (`List<List<T>>`, `Map<String, List<T>>`).
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test` — `GenericServiceWrappedRoundTripTest` round-trips `list` / `set` / `map` / `nullable` / `listOfNullable` / `nested` / `nullableList` over PIPE, HTTP, and websocket channels.
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test` (unchanged — no regression).
- [x] `./gradlew apiCheck`
- [x] `ktlint` on touched files

## Out of scope / follow-ups

- User-defined generic `@Serializable` wrappers referencing `T` (e.g. `class Box<T>(val v: T)`): the recursive composer raises a user-error with the offending method pointed out. Supporting these would require a serializer-factory lookup on the user type; deferred to a follow-up issue.
- `Array<T>`: not wired — callers hit the same user-error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)