### PR TITLE
Fix #47: compiler plugin test coverage audit and small additions

### DIFF
--- a/compiler/plugin/src/test/java/GenericServiceTest.kt
+++ b/compiler/plugin/src/test/java/GenericServiceTest.kt
@@ -317,6 +317,86 @@ interface HasMethodGeneric: RpcService {
     }
 
     @Test
+    fun `generic ksservice with KsNotification on Unit method compiles`() {
+        // Sanity check that metadata sibling annotations combine with generic services.
+        // Regressions here would surface as either a companion/stub generation failure or a
+        // surprise "must return Unit" misfire on a generic method whose return type is T.
+        val annotations = SourceFile.kotlin(
+            "Annotations.kt",
+            """
+package com.monkopedia.ksrpc.annotation
+
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class KsMethodMetadata
+
+@KsMethodMetadata
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class KsNotification
+"""
+        )
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsNotification
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface GenericWithNotification<T> : RpcService {
+    @KsMethod("/publish")
+    @KsNotification
+    suspend fun publish(item: T)
+}
+"""
+        )
+        val result = compile(listOf(annotations, source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `generic ksservice with multiple type parameters compiles`() {
+        // Services with more than one invariant type parameter must generate a Stub/Obj
+        // whose primary constructors take one KSerializer per type parameter in declaration
+        // order. Catching a regression here means we verified argument-ordering between FIR
+        // stub synthesis and IR body generation doesn't drift.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.serialization.KSerializer
+
+@KsService
+interface KsPairStream<A, B> : RpcService {
+    @KsMethod("/next")
+    suspend fun next(u: Unit): Map<A, B>
+}
+
+fun <S> useStub(
+    channel: SerializedService<S>,
+    a: KSerializer<String>,
+    b: KSerializer<Int>
+): KsPairStream<String, Int> = KsPairStream.Stub<String, Int>(channel, a, b)
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
     fun `out-variance on class type params is rejected`() {
         val source = SourceFile.kotlin(
             "main.kt",

--- a/compiler/plugin/src/test/java/KsNotificationValidationTest.kt
+++ b/compiler/plugin/src/test/java/KsNotificationValidationTest.kt
@@ -44,6 +44,11 @@ annotation class KsMethodMetadata
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
 annotation class KsNotification
+
+@KsMethodMetadata
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class KsTimeout(val value: Long)
 """
     )
 
@@ -67,6 +72,39 @@ interface TestService : RpcService {
         )
         val result = compile(listOf(annotations, source))
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun `multiple KsMethodMetadata-marked annotations on a single method compile`() {
+        // The metadata IR builder walks every `@KsMethodMetadata`-marked sibling annotation
+        // on the method and emits one MethodMetadata entry per annotation. Regressions where
+        // the plugin only honors the first metadata annotation, or rejects combinations,
+        // would break composite cases like `@KsNotification @KsTimeout` on the same method.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsNotification
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsTimeout
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface MultiMetadataService : RpcService {
+    @KsMethod("/ping")
+    @KsNotification
+    @KsTimeout(500L)
+    suspend fun ping(input: String)
+}
+"""
+        )
+        val result = compile(listOf(annotations, source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed with multiple metadata annotations; " +
+                "messages: ${result.messages}"
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Audit of compiler-plugin test coverage (gap analysis + three small quick-win tests) for the 1.0 freeze. Full writeup is posted as a comment on #47: https://github.com/Monkopedia/ksrpc/issues/47#issuecomment-4292863740

- Three quick-win tests added here:
  - `GenericServiceTest`: generic service with multiple type parameters (FIR↔IR serializer-field ordering).
  - `GenericServiceTest`: generic service + `@KsNotification` on a Unit method (metadata × generic combination).
  - `KsNotificationValidationTest`: multiple `@KsMethodMetadata`-marked annotations on a single method.
- Follow-ups filed for concrete pre-1.0 gaps: #53 (`@KsService` on non-interface is silently accepted — real bug), #54 (cross-module compile harness), #55 (plugin-runtime version-skew regression tests), #56 (exhaustive metadata-argument coverage), #57 (generic-service edge cases), #58 (concurrent-modification regression test).
- Stacked on top of PR #52 (`issue-44-wrapper-serializers`).

Closes #47.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — 34 tests pass.
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:ktlintTestSourceSetCheck` — clean.
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)