### PR TITLE
Fix #2: Flow support via ksrpc-flow module with real @KsService annotations

### DIFF
--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -69,6 +69,7 @@ import org.jetbrains.kotlin.ir.types.typeOrNull
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.addChild
+import org.jetbrains.kotlin.ir.util.companionObject
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
 import org.jetbrains.kotlin.ir.util.kotlinFqName
@@ -329,16 +330,97 @@ internal class GenericMethodIrBuilder(
         if (type.classFqName == FqConstants.BYTE_READ_CHANNEL) {
             return builder.irGetObject(env.binaryTransformer)
         }
-        // Subservice transforms are not supported for type-parameter-bearing output types,
-        // because we'd need an RpcObject<Service<T>> which requires composing a companion
-        // invoke. That's out of scope for the initial generic support. Fall through to the
-        // serializer transformer and let the runtime fail loudly if this actually happens.
+        // Sub-service transformer when `type` is itself an @KsService. Both non-generic
+        // sub-services (companion is the `RpcObject`) and generic sub-services (companion
+        // is an `RpcObjectFactory`, and we materialize a concrete `Obj<T, ...>` via the
+        // nested Obj constructor threading the outer service's serializer fields) are
+        // supported.
+        if (type.extendsRpcService()) {
+            val rpcObjectExpr = buildSubserviceRpcObject(
+                builder,
+                type,
+                serializerReceiver,
+                serializerFields,
+                method
+            )
+            return builder.irCallConstructor(
+                env.subserviceTransformer.constructors.first(),
+                listOf(type)
+            ).apply {
+                this.type = env.subserviceTransformer.typeWith(type)
+                putArgs(rpcObjectExpr)
+            }
+        }
         return builder.irCallConstructor(
             env.serializerTransformer.constructors.first(),
             listOf(type)
         ).apply {
             this.type = env.serializerTransformer.typeWith(type)
             putArgs(buildSerializer(builder, type, serializerReceiver, serializerFields, method))
+        }
+    }
+
+    /** True iff [this] has `com.monkopedia.ksrpc.RpcService` anywhere in its supertype chain. */
+    private fun IrType.extendsRpcService(): Boolean {
+        if (classFqName == FqConstants.FQRPC_SERVICE) return true
+        val cls = (this as? IrSimpleType)?.classifier as?
+            org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+        return cls?.owner?.superTypes?.any { it.extendsRpcService() } == true
+    }
+
+    /**
+     * Build an IR expression that evaluates to an `RpcObject<ServiceType>` for a sub-service
+     * parameter/return type. When the sub-service type has no type arguments that reference
+     * our outer service's type parameters, we emit `irGetObject(subservice.Companion)`
+     * (companion is already an `RpcObject<Sub>` for non-generic services, or assignable to
+     * one when the sub-service itself is non-generic). Otherwise we construct the nested
+     * `Sub.Obj<A, B, ...>(serA, serB, ...)` directly, composing each type-argument
+     * serializer via [buildSerializer].
+     */
+    private fun buildSubserviceRpcObject(
+        builder: IrBuilderWithScope,
+        type: IrType,
+        serializerReceiver: IrValueParameter,
+        serializerFields: List<IrField>,
+        method: IrSimpleFunction
+    ): IrExpression {
+        val simple = type as? IrSimpleType
+            ?: reportInternal(
+                "sub-service type ${type.render()} is not IrSimpleType — cannot build " +
+                    "RpcObject for generic service codegen"
+            )
+        val subClassSymbol = simple.classifier as?
+            org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+        val subClass = subClassSymbol?.owner ?: reportInternal(
+            "sub-service type ${type.render()} has no class classifier — cannot " +
+                "build RpcObject"
+        )
+        val companion = subClass.companionObject()
+            ?: reportInternal(
+                "sub-service ${subClass.kotlinFqName.asString()} has no companion — " +
+                    "must be an @KsService interface"
+            )
+        // No class-level type parameters: companion IS an RpcObject<Sub>.
+        if (subClass.typeParameters.isEmpty()) {
+            return builder.irGetObject(companion.symbol)
+        }
+        // Generic sub-service — find its nested Obj class and construct it with
+        // per-type-argument serializers composed from our serializer fields.
+        val objClass = subClass.declarations
+            .filterIsInstance<IrClass>()
+            .firstOrNull { it.name == FqConstants.OBJ }
+            ?: reportInternal(
+                "sub-service ${subClass.kotlinFqName.asString()} has no nested Obj class — " +
+                    "@KsService plugin did not run on the sub-service"
+            )
+        val objConstructor = objClass.constructors.first { it.isPrimary }
+        val typeArgs = simple.arguments.map { it.typeOrFail }
+        return builder.irCallConstructor(objConstructor.symbol, typeArgs).apply {
+            this.type = objClass.typeWith(typeArgs)
+            val serArgs = typeArgs.map { arg ->
+                buildSerializer(builder, arg, serializerReceiver, serializerFields, method)
+            }.toTypedArray()
+            putArgs(*serArgs)
         }
     }
 

--- a/compiler/plugin/src/test/java/GenericServiceTest.kt
+++ b/compiler/plugin/src/test/java/GenericServiceTest.kt
@@ -397,6 +397,76 @@ fun <S> useStub(
     }
 
     @Test
+    fun `generic ksservice with generic subservice parameter compiles`() {
+        // Exercises the ObjGeneration fix that lets a generic `@KsService` accept a
+        // generic sub-service in its method signature. Before the fix, the compiler
+        // plugin rejected `foo(sub: Sub<T>)` with "Cannot compose a KSerializer for
+        // Sub<T>" because the generic-path createTypeConverter always fell through to
+        // the KSerializer composer instead of recognizing the RpcService supertype.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Sub<T> : RpcService {
+    @KsMethod("/x")
+    suspend fun x(t: T)
+}
+
+@KsService
+interface Outer<T> : RpcService {
+    @KsMethod("/take")
+    suspend fun take(sub: Sub<T>)
+
+    @KsMethod("/give")
+    suspend fun give(u: Unit): Sub<T>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `generic ksservice with non-generic subservice parameter compiles`() {
+        // The generic-service createTypeConverter must also route non-generic sub-services
+        // through SubserviceTransformer rather than the KSerializer composer.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Token : RpcService {
+    @KsMethod("/hit")
+    suspend fun hit(u: Unit)
+}
+
+@KsService
+interface GenericHolder<T> : RpcService {
+    @KsMethod("/token")
+    suspend fun token(u: Unit): Token
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
     fun `out-variance on class type params is rejected`() {
         val source = SourceFile.kotlin(
             "main.kt",

--- a/ksrpc-flow/api/ksrpc-flow.api
+++ b/ksrpc-flow/api/ksrpc-flow.api
@@ -1,0 +1,139 @@
+public final class com/monkopedia/ksrpc/flow/AsKsFlowKt {
+	public static final fun asKsFlow (Lkotlinx/coroutines/flow/Flow;)Lcom/monkopedia/ksrpc/flow/KsFlowService;
+}
+
+public final class com/monkopedia/ksrpc/flow/AutoClosingFlow : kotlinx/coroutines/flow/Flow {
+	public fun <init> (Lcom/monkopedia/ksrpc/flow/KsFlowService;)V
+	public fun collect (Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/monkopedia/ksrpc/flow/KsCollectionToken : com/monkopedia/ksrpc/RpcService {
+	public static final field Companion Lcom/monkopedia/ksrpc/flow/KsCollectionToken$Companion;
+	public abstract fun cancelCollection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsCollectionToken$Companion : com/monkopedia/ksrpc/RpcObject {
+	public synthetic fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/RpcService;
+	public final fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/flow/KsCollectionToken;
+	public final fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
+	public final fun getEndpoints ()Ljava/util/List;
+	public final fun getServiceName ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsCollectionToken$DefaultImpls {
+	public static fun close (Lcom/monkopedia/ksrpc/flow/KsCollectionToken;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsCollectionToken$Stub : com/monkopedia/ksrpc/RpcService, com/monkopedia/ksrpc/flow/KsCollectionToken {
+	public static final field Companion Lcom/monkopedia/ksrpc/flow/KsCollectionToken$Stub$Companion;
+	public fun <init> (Lcom/monkopedia/ksrpc/channels/SerializedService;)V
+	public final synthetic fun cancelCollection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsCollectionToken$Stub$AnonymousCancelCollection : com/monkopedia/ksrpc/ServiceExecutor {
+	public fun <init> ()V
+	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final synthetic class com/monkopedia/ksrpc/flow/KsCollectionToken$Stub$Companion {
+	public fun <init> ()V
+	public final synthetic fun CancelCollection$ksrpc_flow ()Lcom/monkopedia/ksrpc/RpcMethod;
+}
+
+public abstract interface class com/monkopedia/ksrpc/flow/KsFlowCollector : com/monkopedia/ksrpc/RpcService {
+	public static final field Companion Lcom/monkopedia/ksrpc/flow/KsFlowCollector$Companion;
+	public abstract fun onComplete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onError (Lcom/monkopedia/ksrpc/RpcFailure;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onItem (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Companion : com/monkopedia/ksrpc/RpcObjectFactory {
+	public final fun create (Ljava/util/List;)Lcom/monkopedia/ksrpc/RpcObject;
+	public final fun getArity ()I
+	public final fun invoke (Lkotlinx/serialization/KSerializer;)Lcom/monkopedia/ksrpc/RpcObject;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$DefaultImpls {
+	public static fun close (Lcom/monkopedia/ksrpc/flow/KsFlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Obj : com/monkopedia/ksrpc/RpcObject {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/RpcService;
+	public final fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/flow/KsFlowCollector;
+	public final fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
+	public final fun getEndpoints ()Ljava/util/List;
+	public final fun getServiceName ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub : com/monkopedia/ksrpc/RpcService, com/monkopedia/ksrpc/flow/KsFlowCollector {
+	public static final field Companion Lcom/monkopedia/ksrpc/flow/KsFlowCollector$Stub$Companion;
+	public fun <init> (Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlinx/serialization/KSerializer;)V
+	public final synthetic fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun onComplete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun onError (Lcom/monkopedia/ksrpc/RpcFailure;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun onItem (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnComplete : com/monkopedia/ksrpc/ServiceExecutor {
+	public fun <init> ()V
+	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnError : com/monkopedia/ksrpc/ServiceExecutor {
+	public fun <init> ()V
+	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnItem : com/monkopedia/ksrpc/ServiceExecutor {
+	public fun <init> ()V
+	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final synthetic class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$Companion {
+	public fun <init> ()V
+}
+
+public abstract interface class com/monkopedia/ksrpc/flow/KsFlowService : com/monkopedia/ksrpc/RpcService, kotlinx/coroutines/flow/Flow {
+	public static final field Companion Lcom/monkopedia/ksrpc/flow/KsFlowService$Companion;
+	public fun collect (Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startCollection (Lcom/monkopedia/ksrpc/flow/KsFlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowService$Companion : com/monkopedia/ksrpc/RpcObjectFactory {
+	public final fun create (Ljava/util/List;)Lcom/monkopedia/ksrpc/RpcObject;
+	public final fun getArity ()I
+	public final fun invoke (Lkotlinx/serialization/KSerializer;)Lcom/monkopedia/ksrpc/RpcObject;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowService$DefaultImpls {
+	public static fun close (Lcom/monkopedia/ksrpc/flow/KsFlowService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun collect (Lcom/monkopedia/ksrpc/flow/KsFlowService;Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowService$Obj : com/monkopedia/ksrpc/RpcObject {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/RpcService;
+	public final fun createStub (Lcom/monkopedia/ksrpc/channels/SerializedService;)Lcom/monkopedia/ksrpc/flow/KsFlowService;
+	public final fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
+	public final fun getEndpoints ()Ljava/util/List;
+	public final fun getServiceName ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowService$Stub : com/monkopedia/ksrpc/RpcService, com/monkopedia/ksrpc/flow/KsFlowService {
+	public static final field Companion Lcom/monkopedia/ksrpc/flow/KsFlowService$Stub$Companion;
+	public fun <init> (Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlinx/serialization/KSerializer;)V
+	public final synthetic fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun startCollection (Lcom/monkopedia/ksrpc/flow/KsFlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/flow/KsFlowService$Stub$AnonymousStartCollection : com/monkopedia/ksrpc/ServiceExecutor {
+	public fun <init> ()V
+	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final synthetic class com/monkopedia/ksrpc/flow/KsFlowService$Stub$Companion {
+	public fun <init> ()V
+}
+

--- a/ksrpc-flow/api/ksrpc-flow.klib.api
+++ b/ksrpc-flow/api/ksrpc-flow.klib.api
@@ -1,0 +1,115 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.monkopedia.ksrpc:ksrpc-flow>
+abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/KsFlowCollector : com.monkopedia.ksrpc/RpcService { // com.monkopedia.ksrpc.flow/KsFlowCollector|null[0]
+    abstract suspend fun onComplete() // com.monkopedia.ksrpc.flow/KsFlowCollector.onComplete|onComplete(){}[0]
+    abstract suspend fun onError(com.monkopedia.ksrpc/RpcFailure) // com.monkopedia.ksrpc.flow/KsFlowCollector.onError|onError(com.monkopedia.ksrpc.RpcFailure){}[0]
+    abstract suspend fun onItem(#A) // com.monkopedia.ksrpc.flow/KsFlowCollector.onItem|onItem(1:0){}[0]
+
+    final class <#A1: kotlin/Any?> Obj : com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowCollector<#A1>> { // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj|null[0]
+        constructor <init>(kotlinx.serialization/KSerializer<#A1>) // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.<init>|<init>(kotlinx.serialization.KSerializer<1:0>){}[0]
+
+        final val endpoints // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.endpoints|{}endpoints[0]
+            final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
+        final val serviceName // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.serviceName|{}serviceName[0]
+            final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+
+        final fun <#A2: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A2>): com.monkopedia.ksrpc.flow/KsFlowCollector<#A1> // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+        final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.findEndpoint|findEndpoint(kotlin.String){}[0]
+    }
+
+    final class <#A1: kotlin/Any?> Stub : com.monkopedia.ksrpc.flow/KsFlowCollector<#A1>, com.monkopedia.ksrpc/RpcService { // com.monkopedia.ksrpc.flow/KsFlowCollector.Stub|null[0]
+        constructor <init>(com.monkopedia.ksrpc.channels/SerializedService<*>, kotlinx.serialization/KSerializer<#A1>) // com.monkopedia.ksrpc.flow/KsFlowCollector.Stub.<init>|<init>(com.monkopedia.ksrpc.channels.SerializedService<*>;kotlinx.serialization.KSerializer<1:0>){}[0]
+
+        final suspend fun close() // com.monkopedia.ksrpc.flow/KsFlowCollector.Stub.close|close(){}[0]
+        final suspend fun onComplete() // com.monkopedia.ksrpc.flow/KsFlowCollector.Stub.onComplete|onComplete(){}[0]
+        final suspend fun onError(com.monkopedia.ksrpc/RpcFailure) // com.monkopedia.ksrpc.flow/KsFlowCollector.Stub.onError|onError(com.monkopedia.ksrpc.RpcFailure){}[0]
+        final suspend fun onItem(#A1) // com.monkopedia.ksrpc.flow/KsFlowCollector.Stub.onItem|onItem(1:0){}[0]
+
+        final object Companion { // com.monkopedia.ksrpc.flow/KsFlowCollector.Stub.Companion|null[0]
+            constructor <init>() // com.monkopedia.ksrpc.flow/KsFlowCollector.Stub.Companion.<init>|<init>(){}[0]
+        }
+    }
+
+    final object Companion : com.monkopedia.ksrpc/RpcObjectFactory<com.monkopedia.ksrpc.flow/KsFlowCollector<*>> { // com.monkopedia.ksrpc.flow/KsFlowCollector.Companion|null[0]
+        final val arity // com.monkopedia.ksrpc.flow/KsFlowCollector.Companion.arity|{}arity[0]
+            final fun <get-arity>(): kotlin/Int // com.monkopedia.ksrpc.flow/KsFlowCollector.Companion.arity.<get-arity>|<get-arity>(){}[0]
+
+        final fun <#A2: kotlin/Any?> invoke(kotlinx.serialization/KSerializer<#A2>): com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowCollector<#A2>> // com.monkopedia.ksrpc.flow/KsFlowCollector.Companion.invoke|invoke(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
+        final fun create(kotlin.collections/List<kotlin.reflect/KType>): com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowCollector<*>> // com.monkopedia.ksrpc.flow/KsFlowCollector.Companion.create|create(kotlin.collections.List<kotlin.reflect.KType>){}[0]
+    }
+}
+
+abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/KsFlowService : com.monkopedia.ksrpc/RpcService, kotlinx.coroutines.flow/Flow<#A> { // com.monkopedia.ksrpc.flow/KsFlowService|null[0]
+    abstract suspend fun startCollection(com.monkopedia.ksrpc.flow/KsFlowCollector<#A>): com.monkopedia.ksrpc.flow/KsCollectionToken // com.monkopedia.ksrpc.flow/KsFlowService.startCollection|startCollection(com.monkopedia.ksrpc.flow.KsFlowCollector<1:0>){}[0]
+    open suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // com.monkopedia.ksrpc.flow/KsFlowService.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
+
+    final class <#A1: kotlin/Any?> Obj : com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowService<#A1>> { // com.monkopedia.ksrpc.flow/KsFlowService.Obj|null[0]
+        constructor <init>(kotlinx.serialization/KSerializer<#A1>) // com.monkopedia.ksrpc.flow/KsFlowService.Obj.<init>|<init>(kotlinx.serialization.KSerializer<1:0>){}[0]
+
+        final val endpoints // com.monkopedia.ksrpc.flow/KsFlowService.Obj.endpoints|{}endpoints[0]
+            final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsFlowService.Obj.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
+        final val serviceName // com.monkopedia.ksrpc.flow/KsFlowService.Obj.serviceName|{}serviceName[0]
+            final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsFlowService.Obj.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+
+        final fun <#A2: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A2>): com.monkopedia.ksrpc.flow/KsFlowService<#A1> // com.monkopedia.ksrpc.flow/KsFlowService.Obj.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+        final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsFlowService.Obj.findEndpoint|findEndpoint(kotlin.String){}[0]
+    }
+
+    final class <#A1: kotlin/Any?> Stub : com.monkopedia.ksrpc.flow/KsFlowService<#A1>, com.monkopedia.ksrpc/RpcService { // com.monkopedia.ksrpc.flow/KsFlowService.Stub|null[0]
+        constructor <init>(com.monkopedia.ksrpc.channels/SerializedService<*>, kotlinx.serialization/KSerializer<#A1>) // com.monkopedia.ksrpc.flow/KsFlowService.Stub.<init>|<init>(com.monkopedia.ksrpc.channels.SerializedService<*>;kotlinx.serialization.KSerializer<1:0>){}[0]
+
+        final suspend fun close() // com.monkopedia.ksrpc.flow/KsFlowService.Stub.close|close(){}[0]
+        final suspend fun startCollection(com.monkopedia.ksrpc.flow/KsFlowCollector<#A1>): com.monkopedia.ksrpc.flow/KsCollectionToken // com.monkopedia.ksrpc.flow/KsFlowService.Stub.startCollection|startCollection(com.monkopedia.ksrpc.flow.KsFlowCollector<1:0>){}[0]
+
+        final object Companion { // com.monkopedia.ksrpc.flow/KsFlowService.Stub.Companion|null[0]
+            constructor <init>() // com.monkopedia.ksrpc.flow/KsFlowService.Stub.Companion.<init>|<init>(){}[0]
+        }
+    }
+
+    final object Companion : com.monkopedia.ksrpc/RpcObjectFactory<com.monkopedia.ksrpc.flow/KsFlowService<*>> { // com.monkopedia.ksrpc.flow/KsFlowService.Companion|null[0]
+        final val arity // com.monkopedia.ksrpc.flow/KsFlowService.Companion.arity|{}arity[0]
+            final fun <get-arity>(): kotlin/Int // com.monkopedia.ksrpc.flow/KsFlowService.Companion.arity.<get-arity>|<get-arity>(){}[0]
+
+        final fun <#A2: kotlin/Any?> invoke(kotlinx.serialization/KSerializer<#A2>): com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowService<#A2>> // com.monkopedia.ksrpc.flow/KsFlowService.Companion.invoke|invoke(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
+        final fun create(kotlin.collections/List<kotlin.reflect/KType>): com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowService<*>> // com.monkopedia.ksrpc.flow/KsFlowService.Companion.create|create(kotlin.collections.List<kotlin.reflect.KType>){}[0]
+    }
+}
+
+abstract interface com.monkopedia.ksrpc.flow/KsCollectionToken : com.monkopedia.ksrpc/RpcService { // com.monkopedia.ksrpc.flow/KsCollectionToken|null[0]
+    abstract suspend fun cancelCollection() // com.monkopedia.ksrpc.flow/KsCollectionToken.cancelCollection|cancelCollection(){}[0]
+
+    final class Stub : com.monkopedia.ksrpc.flow/KsCollectionToken, com.monkopedia.ksrpc/RpcService { // com.monkopedia.ksrpc.flow/KsCollectionToken.Stub|null[0]
+        constructor <init>(com.monkopedia.ksrpc.channels/SerializedService<*>) // com.monkopedia.ksrpc.flow/KsCollectionToken.Stub.<init>|<init>(com.monkopedia.ksrpc.channels.SerializedService<*>){}[0]
+
+        final suspend fun cancelCollection() // com.monkopedia.ksrpc.flow/KsCollectionToken.Stub.cancelCollection|cancelCollection(){}[0]
+        final suspend fun close() // com.monkopedia.ksrpc.flow/KsCollectionToken.Stub.close|close(){}[0]
+
+        final object Companion { // com.monkopedia.ksrpc.flow/KsCollectionToken.Stub.Companion|null[0]
+            constructor <init>() // com.monkopedia.ksrpc.flow/KsCollectionToken.Stub.Companion.<init>|<init>(){}[0]
+        }
+    }
+
+    final object Companion : com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsCollectionToken> { // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion|null[0]
+        final val endpoints // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.endpoints|{}endpoints[0]
+            final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
+        final val serviceName // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.serviceName|{}serviceName[0]
+            final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+
+        final fun <#A2: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A2>): com.monkopedia.ksrpc.flow/KsCollectionToken // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+        final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.findEndpoint|findEndpoint(kotlin.String){}[0]
+    }
+}
+
+final class <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/AutoClosingFlow : kotlinx.coroutines.flow/Flow<#A> { // com.monkopedia.ksrpc.flow/AutoClosingFlow|null[0]
+    constructor <init>(com.monkopedia.ksrpc.flow/KsFlowService<#A>) // com.monkopedia.ksrpc.flow/AutoClosingFlow.<init>|<init>(com.monkopedia.ksrpc.flow.KsFlowService<1:0>){}[0]
+
+    final suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // com.monkopedia.ksrpc.flow/AutoClosingFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
+}
+
+final fun <#A: kotlin/Any?> (kotlinx.coroutines.flow/Flow<#A>).com.monkopedia.ksrpc.flow/asKsFlow(): com.monkopedia.ksrpc.flow/KsFlowService<#A> // com.monkopedia.ksrpc.flow/asKsFlow|asKsFlow@kotlinx.coroutines.flow.Flow<0:0>(){0§<kotlin.Any?>}[0]

--- a/ksrpc-flow/build.gradle.kts
+++ b/ksrpc-flow/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.monkopedia.ksrpc.local.ksrpcModule
+
+plugins {
+    kotlin("multiplatform")
+}
+
+ksrpcModule()
+
+kotlin {
+    sourceSets["commonMain"].dependencies {
+        api(libs.kotlinx.coroutines)
+    }
+}

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/AsKsFlow.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/AsKsFlow.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.asString
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.launch
+
+/**
+ * Wrap a standard [Flow] in a [KsFlowService] implementation suitable for
+ * hosting over ksrpc.
+ *
+ * Each call to [KsFlowService.startCollection] launches a new coroutine that
+ * collects from this flow, forwarding items to the provided
+ * [KsFlowCollector]. The returned [KsCollectionToken] can cancel that
+ * collection.
+ *
+ * The [KsFlowService] does NOT auto-close on collection completion — it
+ * stays alive until [KsFlowService.close] is called.
+ */
+fun <T> Flow<T>.asKsFlow(): KsFlowService<T> = KsFlowServiceImpl(this)
+
+private class KsFlowServiceImpl<T>(private val source: Flow<T>) : KsFlowService<T> {
+    private val parentJob = SupervisorJob()
+
+    override suspend fun startCollection(collector: KsFlowCollector<T>): KsCollectionToken {
+        val scope = CoroutineScope(coroutineContext + parentJob)
+        val job = scope.launch {
+            try {
+                source.collect { item ->
+                    collector.onItem(item)
+                }
+                collector.onComplete()
+            } catch (e: CancellationException) {
+                // Collection was cancelled — don't send onError for cancellation.
+                throw e
+            } catch (e: Throwable) {
+                collector.onError(RpcFailure(e.asString))
+            }
+        }
+        return object : KsCollectionToken {
+            override suspend fun cancelCollection() {
+                job.cancel()
+            }
+
+            override suspend fun close() = Unit
+        }
+    }
+
+    // Server-side collect delegates to the original flow. Only exercised if the
+    // server-side implementation is asked to collect locally (rare); the wire
+    // path uses startCollection.
+    override suspend fun collect(collector: FlowCollector<T>) {
+        source.collect(collector)
+    }
+
+    override suspend fun close() {
+        parentJob.cancel()
+    }
+}

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/AutoClosingFlow.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/AutoClosingFlow.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+
+/**
+ * A [Flow] wrapper that closes the underlying [KsFlowService] after
+ * collection completes or fails.
+ *
+ * Used by the compiler for `Flow<T>` return types — the client gets a
+ * single-use flow that automatically cleans up the sub-service. This is an
+ * internal implementation detail; user code should declare `Flow<T>` in
+ * service signatures and let the compiler plugin insert this wrapper (see
+ * issue #39).
+ */
+@OptIn(KsrpcInternal::class)
+@KsrpcInternal
+class AutoClosingFlow<T>(private val delegate: KsFlowService<T>) : Flow<T> {
+    override suspend fun collect(collector: FlowCollector<T>) {
+        try {
+            delegate.collect(collector)
+        } finally {
+            delegate.close()
+        }
+    }
+}

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsCollectionToken.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsCollectionToken.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsNotification
+import com.monkopedia.ksrpc.annotation.KsService
+
+/**
+ * Token returned from [KsFlowService.startCollection] that allows the caller
+ * to cancel an active collection.
+ *
+ * Calling [cancelCollection] cancels the server-side collection coroutine.
+ * This is a notification (fire-and-forget).
+ */
+@KsService
+interface KsCollectionToken : RpcService {
+    /**
+     * Cancel the active collection associated with this token.
+     *
+     * This is a notification — no response is expected.
+     */
+    @KsMethod("/cancel")
+    @KsNotification
+    suspend fun cancelCollection()
+}

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsCollectionToken.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsCollectionToken.kt
@@ -25,14 +25,16 @@ import com.monkopedia.ksrpc.annotation.KsService
  * to cancel an active collection.
  *
  * Calling [cancelCollection] cancels the server-side collection coroutine.
- * This is a notification (fire-and-forget).
+ *
+ * The `@KsNotification` annotation on [cancelCollection] is a transport-level
+ * hint — on JSON-RPC transports that honor notifications, the call is sent
+ * fire-and-forget with no response. On other transports it is a normal call
+ * whose `Unit` response is ignored.
  */
 @KsService
 interface KsCollectionToken : RpcService {
     /**
      * Cancel the active collection associated with this token.
-     *
-     * This is a notification — no response is expected.
      */
     @KsMethod("/cancel")
     @KsNotification

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowCollector.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowCollector.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsNotification
+import com.monkopedia.ksrpc.annotation.KsService
+
+/**
+ * Sub-service interface for receiving flow items, errors, and completion signals.
+ *
+ * Each active collection gets its own [KsFlowCollector] instance. The server
+ * calls [onItem] for each element, [onComplete] when the flow finishes
+ * normally, and [onError] when it finishes with an exception.
+ *
+ * [onError] and [onComplete] are terminal — after either is called, no more
+ * [onItem] calls will be made on this collector.
+ */
+@KsService
+interface KsFlowCollector<T> : RpcService {
+    /**
+     * Deliver an item from the flow to the collector.
+     *
+     * This is a suspend call through the sub-service path, providing natural
+     * back-pressure — the server blocks until the client processes the item.
+     */
+    @KsMethod("/onItem")
+    suspend fun onItem(item: T)
+
+    /**
+     * Signal that the flow terminated with an error.
+     *
+     * This is a notification (fire-and-forget). Terminal for this collection.
+     */
+    @KsMethod("/onError")
+    @KsNotification
+    suspend fun onError(error: RpcFailure)
+
+    /**
+     * Signal that the flow completed normally.
+     *
+     * This is a notification (fire-and-forget). Terminal for this collection.
+     */
+    @KsMethod("/onComplete")
+    @KsNotification
+    suspend fun onComplete()
+}

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowCollector.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowCollector.kt
@@ -30,6 +30,11 @@ import com.monkopedia.ksrpc.annotation.KsService
  *
  * [onError] and [onComplete] are terminal — after either is called, no more
  * [onItem] calls will be made on this collector.
+ *
+ * The `@KsNotification` annotation on [onError] and [onComplete] is a
+ * transport-level hint — on JSON-RPC transports that honor notifications, the
+ * call is sent fire-and-forget. On other transports it is a normal call whose
+ * `Unit` response is ignored.
  */
 @KsService
 interface KsFlowCollector<T> : RpcService {
@@ -43,18 +48,14 @@ interface KsFlowCollector<T> : RpcService {
     suspend fun onItem(item: T)
 
     /**
-     * Signal that the flow terminated with an error.
-     *
-     * This is a notification (fire-and-forget). Terminal for this collection.
+     * Signal that the flow terminated with an error. Terminal for this collection.
      */
     @KsMethod("/onError")
     @KsNotification
     suspend fun onError(error: RpcFailure)
 
     /**
-     * Signal that the flow completed normally.
-     *
-     * This is a notification (fire-and-forget). Terminal for this collection.
+     * Signal that the flow completed normally. Terminal for this collection.
      */
     @KsMethod("/onComplete")
     @KsNotification

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowService.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowService.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+
+/**
+ * Sub-service interface that bridges a [Flow] over the ksrpc sub-service
+ * protocol.
+ *
+ * Extends both [Flow] (so it can be collected with standard coroutines APIs)
+ * and [RpcService] (for sub-service lifecycle management).
+ *
+ * **Common case (`Flow<T>` in signature):** The compiler wraps returns in
+ * [AutoClosingFlow] so the sub-service is closed after collection. Single-use.
+ *
+ * **Advanced case (`KsFlowService<T>` in signature):** The client gets the
+ * raw service, can call [collect] multiple times, and must call [close]
+ * explicitly when done.
+ *
+ * [KsFlowService] does NOT auto-close on collection completion — it stays
+ * alive until [close] is called explicitly or its parent connection closes.
+ */
+@KsService
+interface KsFlowService<T> :
+    Flow<T>,
+    RpcService {
+    /**
+     * Start collecting from this flow service.
+     *
+     * The caller provides a [KsFlowCollector] sub-service that will receive
+     * items, completion, and error signals. Returns a [KsCollectionToken] that
+     * can be used to cancel the collection.
+     *
+     * Multiple calls are allowed — each gets its own collection job and token.
+     */
+    @KsMethod("/collect")
+    suspend fun startCollection(collector: KsFlowCollector<T>): KsCollectionToken
+
+    /**
+     * Default [Flow.collect] implementation: wraps [collector] in a
+     * [KsFlowCollector], calls [startCollection], and suspends until
+     * `onComplete` or `onError`. On coroutine cancellation, cancels the
+     * underlying collection via [KsCollectionToken.cancelCollection].
+     */
+    override suspend fun collect(collector: FlowCollector<T>) {
+        val completion = CompletableDeferred<Unit>()
+        val collectorImpl = object : KsFlowCollector<T> {
+            override suspend fun onItem(item: T) {
+                collector.emit(item)
+            }
+
+            override suspend fun onError(error: RpcFailure) {
+                completion.completeExceptionally(error.toException())
+            }
+
+            override suspend fun onComplete() {
+                completion.complete(Unit)
+            }
+
+            override suspend fun close() = Unit
+        }
+        val token = startCollection(collectorImpl)
+        try {
+            completion.await()
+        } catch (e: CancellationException) {
+            try {
+                token.cancelCollection()
+            } catch (_: Throwable) {
+                // best effort — we're cancelling anyway
+            }
+            throw e
+        }
+    }
+}

--- a/ksrpc-test/build.gradle.kts
+++ b/ksrpc-test/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
     }
     sourceSets["commonTest"].dependencies {
         implementation(project(":ksrpc-core"))
+        implementation(project(":ksrpc-flow"))
         implementation(project(":ksrpc-jsonrpc"))
         implementation(project(":ksrpc-ktor-client"))
         implementation(project(":ksrpc-ktor-websocket-client"))

--- a/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.flow.AutoClosingFlow
+import com.monkopedia.ksrpc.flow.KsCollectionToken
+import com.monkopedia.ksrpc.flow.KsFlowCollector
+import com.monkopedia.ksrpc.flow.KsFlowService
+import com.monkopedia.ksrpc.flow.asKsFlow
+import com.monkopedia.ksrpc.sockets.asConnection
+import io.ktor.utils.io.close
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+/**
+ * End-to-end tests for the KsFlowService sub-service protocol. Exercises the
+ * compiler-generated `RpcObject` / `Stub` / `Obj` for generic `@KsService`
+ * interfaces containing generic sub-services in method signatures
+ * (`KsFlowService<T>.startCollection(KsFlowCollector<T>): KsCollectionToken`).
+ *
+ * Uses a bidirectional pipe transport since flow support requires
+ * bidirectional channels (the server needs to call back into the collector
+ * sub-service).
+ */
+class KsFlowServiceTest {
+
+    /**
+     * Protocol test: items flow from server to client through the sub-service
+     * protocol over a bidirectional pipe.
+     */
+    @Test
+    fun testBasicFlowCollection() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow {
+                emit("a")
+                emit("b")
+                emit("c")
+            }.asKsFlow()
+            c.registerDefault(flowService.serialized<KsFlowService<String>, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<KsFlowService<String>, String>()
+            val items = stub.toList()
+            assertEquals(listOf("a", "b", "c"), items)
+        }
+    )
+
+    /**
+     * AutoClosingFlow: closes the sub-service after collection completes.
+     */
+    @OptIn(KsrpcInternal::class)
+    @Test
+    fun testAutoClosingFlow() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow {
+                emit("x")
+                emit("y")
+            }.asKsFlow()
+            c.registerDefault(flowService.serialized<KsFlowService<String>, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<KsFlowService<String>, String>()
+            val autoClosing = AutoClosingFlow(stub)
+            val items = autoClosing.toList()
+            assertEquals(listOf("x", "y"), items)
+        }
+    )
+
+    /**
+     * Multi-collection: the raw `KsFlowService` allows multiple sequential
+     * collections without auto-closing between them.
+     */
+    @Test
+    fun testMultipleCollections() = executePipe(
+        serviceJob = { c ->
+            val backing = object : KsFlowService<String> {
+                private var counter = 0
+                override suspend fun startCollection(
+                    collector: KsFlowCollector<String>
+                ): KsCollectionToken {
+                    val batch = counter++
+                    return flow {
+                        emit("batch$batch-1")
+                        emit("batch$batch-2")
+                    }.asKsFlow().startCollection(collector)
+                }
+
+                override suspend fun close() = Unit
+            }
+            c.registerDefault(backing.serialized<KsFlowService<String>, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<KsFlowService<String>, String>()
+            val first = stub.toList()
+            assertEquals(listOf("batch0-1", "batch0-2"), first)
+            val second = stub.toList()
+            assertEquals(listOf("batch1-1", "batch1-2"), second)
+        }
+    )
+
+    /**
+     * Error propagation: server-side flow throws, onError fires, client-side
+     * collect throws an [RpcException].
+     */
+    @Test
+    fun testErrorPropagation() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow<String> {
+                emit("ok")
+                throw RuntimeException("test error from server")
+            }.asKsFlow()
+            c.registerDefault(flowService.serialized<KsFlowService<String>, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<KsFlowService<String>, String>()
+            val items = mutableListOf<String>()
+            val exception = assertFailsWith<RpcException> {
+                stub.collect { item ->
+                    items.add(item)
+                }
+            }
+            assertEquals(listOf("ok"), items)
+            assertTrue(
+                exception.message.contains("test error from server"),
+                "expected exception to propagate server message; got ${exception.message}"
+            )
+        }
+    )
+
+    /**
+     * Cancellation: client calls `cancelCollection`, server-side collection
+     * job is cancelled.
+     */
+    @Test
+    fun testCancellation() = executePipe(
+        serviceJob = { c ->
+            val serverCancelled = CompletableDeferred<Boolean>()
+            val flowService = flow<String> {
+                try {
+                    emit("1")
+                    emit("2")
+                    delay(10_000)
+                    emit("3")
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    serverCancelled.complete(true)
+                    throw e
+                }
+            }.asKsFlow()
+            c.registerDefault(flowService.serialized<KsFlowService<String>, String>(c.env))
+            withTimeout(5000) {
+                assertTrue(serverCancelled.await())
+            }
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<KsFlowService<String>, String>()
+            val items = mutableListOf<String>()
+            val collectorImpl = object : KsFlowCollector<String> {
+                override suspend fun onItem(item: String) {
+                    items.add(item)
+                }
+
+                override suspend fun onError(error: RpcFailure) = Unit
+
+                override suspend fun onComplete() = Unit
+
+                override suspend fun close() = Unit
+            }
+            val token = stub.startCollection(collectorImpl)
+            delay(500)
+            token.cancelCollection()
+            assertEquals(listOf("1", "2"), items)
+        }
+    )
+
+    /**
+     * Back-pressure: server blocks on `onItem` until the client processes
+     * each item (since `onItem` is a suspend call over the sub-service).
+     */
+    @Test
+    fun testBackPressure() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow {
+                emit("fast-1")
+                emit("fast-2")
+                emit("fast-3")
+            }.asKsFlow()
+            c.registerDefault(flowService.serialized<KsFlowService<String>, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<KsFlowService<String>, String>()
+            val items = mutableListOf<String>()
+            val processOrder = mutableListOf<String>()
+            stub.collect { item ->
+                processOrder.add("start-$item")
+                delay(100)
+                processOrder.add("end-$item")
+                items.add(item)
+            }
+            assertEquals(listOf("fast-1", "fast-2", "fast-3"), items)
+            assertEquals(
+                listOf(
+                    "start-fast-1", "end-fast-1",
+                    "start-fast-2", "end-fast-2",
+                    "start-fast-3", "end-fast-3"
+                ),
+                processOrder
+            )
+        }
+    )
+
+    private fun executePipe(
+        serviceJob: suspend (Connection<String>) -> Unit,
+        clientJob: suspend (Connection<String>) -> Unit
+    ) = runBlockingUnit {
+        val (output, input) = createPipe()
+        val (so, si) = createPipe()
+        val serviceChannel = (si to output).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { }
+            }
+        )
+        val clientChannel = (input to so).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { }
+            }
+        )
+        val bgJob = GlobalScope.launch(Dispatchers.Default) {
+            serviceJob(serviceChannel)
+        }
+        try {
+            clientJob(clientChannel)
+        } finally {
+            try { clientChannel.close() } catch (_: Throwable) {}
+            try { serviceChannel.close() } catch (_: Throwable) {}
+            try { input.cancel(null) } catch (_: Throwable) {}
+            try { si.cancel(null) } catch (_: Throwable) {}
+            output.close(null)
+            so.close(null)
+            bgJob.join()
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ pluginManagement {
 rootProject.name = "ksrpc"
 include(":ksrpc-api")
 include(":ksrpc-core")
+include(":ksrpc-flow")
 include(":ksrpc-introspection")
 
 include(":ksrpc-jsonrpc")


### PR DESCRIPTION
## Summary

- New `ksrpc-flow` module containing three `@KsService` interfaces — `KsFlowService<T>`, `KsFlowCollector<T>`, `KsCollectionToken` — that drive the Flow/streaming sub-service protocol. The compiler plugin generates all Stub/Obj/Companion code; no hand-written `RpcObject`s.
- Compiler plugin fix: `ObjGeneration`'s generic-path `createTypeConverter` now recognizes `RpcService` sub-services in method signatures. Before, a generic `@KsService` couldn't accept another generic `@KsService` as an input/output (the prerequisite for `KsFlowService<T>.startCollection(KsFlowCollector<T>)`).
- `KsFlowService<T>` extends `Flow<T>` and ships a default `collect` implementation that bridges standard Flow collection through `startCollection`, with suspend-until-complete semantics and cancel-on-cancel behaviour.
- Host-side `Flow<T>.asKsFlow(): KsFlowService<T>` spawns an independent collector coroutine per `startCollection`, with per-collection `KsCollectionToken` cancellation.
- Client-side `AutoClosingFlow<T>` (`@KsrpcInternal`) exists as the wrapper the compiler plugin will emit for user-declared `Flow<T>` signatures (#39); not exposed as public surface yet.
- Six end-to-end tests over a bidirectional pipe transport in `ksrpc-test`: basic collection, AutoClosingFlow lifecycle, multi-collection, error propagation, cancellation, back-pressure.

Closes #2.

## Notes on the compiler-plugin fix

PR #38 landed the runtime types in `ksrpc-core` with three hand-written `RpcObject` classes because the plugin at the time didn't support generic `@KsService`. #41/#42 unblocked generic services in general, but the specific shape needed for Flow — a generic `@KsService` whose method signature references another generic `@KsService` — still hit:

> Cannot compose a KSerializer for `com.monkopedia.ksrpc.flow.KsFlowCollector<T>` on `com.monkopedia.ksrpc.flow.KsFlowService.startCollection` — only List/Set/Map wrappers of a service type parameter are supported.

`ObjGeneration.createTypeConverter` (shared between `Obj.findEndpoint` and the generic-stub body generator) only had three branches: `ByteReadChannel`, or fall through to a `SerializerTransformer` + `buildSerializer` composer — the composer rejected a non-wrapper generic type that mentioned `T`.

The fix adds an `extendsRpcService()` branch that wraps in `SubserviceTransformer` with either the sub-service's companion object (non-generic sub-service) or a freshly-constructed `Sub.Obj<A, B, ...>(serA, serB, ...)` (generic sub-service, composing each argument serializer via the existing `buildSerializer` recursion). Two new compiler-plugin tests cover both shapes.

## Test plan

- [x] `./gradlew :ksrpc-flow:compileKotlinJvm :ksrpc-flow:compileKotlinLinuxX64`
- [x] `./gradlew :ksrpc-test:jvmTest` (all tests including new `KsFlowServiceTest` — 6/6 pass)
- [x] `./gradlew :ksrpc-test:linuxX64Test` (6/6 pass)
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` (all plugin tests pass, including two new generic-sub-service compile tests)
- [x] `./gradlew :ksrpc-core:jvmTest`
- [x] `./gradlew apiDump && apiCheck` — new `ksrpc-flow` API file generated and checked clean
- [x] ktlint on touched files

## Don't / Follow-ups

- #39 (compiler auto-detection of `Flow<T>` in user signatures) is intentionally out of scope. This PR only provides the runtime types and the plugin plumbing that unblocks it.
- No hand-written `RpcObject`s needed — the plugin fix absorbs the missing support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)