### PR TITLE
Fix #39: compiler plugin auto-detects Flow<T> in @KsMethod signatures

### DIFF
--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -37,7 +37,29 @@ dependencies {
     ksp(libs.autoservice)
     compileOnly(libs.autoservice.annotations)
 
+    // Locally-built `ksrpc-core` jvmJar, listed BEFORE the published `ksrpctest`
+    // coordinate so the local (non-sealed) `Transformer` interface takes
+    // precedence over the published (sealed) one. The FlowSupportTest (#39) needs
+    // this because `FlowTransformer` in the locally-built `ksrpc-flow` extends
+    // `Transformer`; the published 0.11.1 sealed version would reject the
+    // extension at user-code compile time.
+    testImplementation(
+        files(
+            project.rootDir.resolve("../ksrpc-core/build/libs/ksrpc-core-jvm-0.11.1.jar")
+        )
+    )
     testImplementation(libs.ksrpctest)
+    // Locally-built `ksrpc-flow` jvmJar — see FlowSupportTest (#39). The compiler
+    // plugin sits in an included build, so `project(":ksrpc-flow")` cannot reach
+    // the main build's module; we stitch the jvmJar file onto the test classpath
+    // by path. Consumers must run `:ksrpc-flow:jvmJar` (and `:ksrpc-core:jvmJar`)
+    // in the main build before `:compiler:ksrpc-compiler-plugin:test`; CI already
+    // does this implicitly because the plugin tests run after the main build.
+    testImplementation(
+        files(
+            project.rootDir.resolve("../ksrpc-flow/build/libs/ksrpc-flow-jvm-0.11.1.jar")
+        )
+    )
     testImplementation(kotlin("test-junit"))
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
     testImplementation(libs.kotlin.compiletesting)

--- a/compiler/plugin/src/main/java/FqConstants.kt
+++ b/compiler/plugin/src/main/java/FqConstants.kt
@@ -96,4 +96,13 @@ object FqConstants {
 
     val PAIR = ClassId(FqName("kotlin"), Name.identifier("Pair"))
     val TO_FUNCTION = CallableId(FqName("kotlin"), Name.identifier("to"))
+
+    // ksrpc-flow runtime types — referenced by StubGeneration / ObjGeneration when
+    // emitting `FlowTransformer<T>(KsFlowService.Obj<T>(serializer))` IR for
+    // `Flow<T>` signatures (issue #39). Resolved optimistically; the compiler
+    // guards with `KsrpcGenerationEnvironment.flowSupported`.
+    val FLOW = FqName("kotlinx.coroutines.flow.Flow")
+    val KSRPC_FLOW_PKG = FqName("com.monkopedia.ksrpc.flow")
+    val KS_FLOW_SERVICE = ClassId(KSRPC_FLOW_PKG, Name.identifier("KsFlowService"))
+    val FLOW_TRANSFORMER = ClassId(KSRPC_FLOW_PKG, Name.identifier("FlowTransformer"))
 }

--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -118,6 +118,16 @@ class KsrpcGenerationEnvironment(
                 fn.owner.typeParameters.size == 2
         }
 
+    // ksrpc-flow runtime types — optional. When unresolved (ksrpc-flow not on the
+    // compile classpath), the plugin does not auto-wire `Flow<T>` and the
+    // surrounding error for a missing serializer will fire on the user code as
+    // usual. `flowSupported` gates the detection path.
+    val ksFlowService = maybeReferenceClass(FqConstants.KS_FLOW_SERVICE)
+    val flowTransformer = maybeReferenceClass(FqConstants.FLOW_TRANSFORMER)
+
+    /** True when `Flow<T>` signatures can be auto-wired via the ksrpc-flow runtime. */
+    val flowSupported: Boolean = ksFlowService != null && flowTransformer != null
+
     val threadLocal = referenceClass(FqConstants.THREAD_LOCAL)
     val listOfFunction =
         context.referenceFunctions(

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -330,6 +330,18 @@ internal class GenericMethodIrBuilder(
         if (type.classFqName == FqConstants.BYTE_READ_CHANNEL) {
             return builder.irGetObject(env.binaryTransformer)
         }
+        // Flow<T> is bridged to the KsFlowService sub-service protocol. Only reachable when
+        // ksrpc-flow is on the compile classpath — otherwise we fall through to the generic
+        // serializer path, which will produce a clearer "no serializer" diagnostic.
+        if (env.flowSupported && type.classFqName == FqConstants.FLOW) {
+            return buildFlowTransformer(
+                builder,
+                type,
+                serializerReceiver,
+                serializerFields,
+                method
+            )
+        }
         // Sub-service transformer when `type` is itself an @KsService. Both non-generic
         // sub-services (companion is the `RpcObject`) and generic sub-services (companion
         // is an `RpcObjectFactory`, and we materialize a concrete `Obj<T, ...>` via the
@@ -678,4 +690,63 @@ internal class GenericMethodIrBuilder(
 
     fun buildExecutor(referencedFunction: IrSimpleFunction, container: IrClass): IrClass =
         context.buildAnonymousServiceExecutor(env, referencedFunction, container)
+
+    /**
+     * Emit `FlowTransformer<T>(KsFlowService.Obj<T>(Tser))` for a `Flow<T>` parameter or
+     * return type on a method belonging to a generic `@KsService`. The element type's
+     * `KSerializer` is composed via [buildSerializer] so it can reference the outer
+     * service's type parameters. Mirrors the non-generic path in
+     * [StubGeneration.buildFlowTransformer] but threads the generic serializer
+     * composition through.
+     */
+    private fun buildFlowTransformer(
+        builder: IrBuilderWithScope,
+        flowType: IrType,
+        serializerReceiver: IrValueParameter,
+        serializerFields: List<IrField>,
+        method: IrSimpleFunction
+    ): IrExpression {
+        val simple = flowType as? IrSimpleType ?: reportInternal(
+            "Flow<T> type ${flowType.render()} is not IrSimpleType"
+        )
+        val elementType = simple.arguments.singleOrNull()?.typeOrFail
+            ?: reportInternal(
+                "Flow<T> type ${flowType.render()} has no type argument — cannot emit " +
+                    "FlowTransformer"
+            )
+        val flowTransformerSymbol = env.flowTransformer
+            ?: reportInternal(
+                "FlowTransformer symbol missing but Flow<T> detection fired — " +
+                    "ksrpc-flow must be on the compile classpath"
+            )
+        val ksFlowServiceSymbol = env.ksFlowService
+            ?: reportInternal(
+                "KsFlowService symbol missing but Flow<T> detection fired — " +
+                    "ksrpc-flow must be on the compile classpath"
+            )
+        val objClass = ksFlowServiceSymbol.owner.declarations
+            .filterIsInstance<IrClass>()
+            .firstOrNull { it.name == FqConstants.OBJ }
+            ?: reportInternal(
+                "KsFlowService has no nested Obj class — the ksrpc compiler plugin " +
+                    "must have processed ksrpc-flow"
+            )
+        val objConstructor = objClass.constructors.first { it.isPrimary }
+        val rpcObjectExpr = builder.irCallConstructor(
+            objConstructor.symbol,
+            listOf(elementType)
+        ).apply {
+            this.type = objClass.typeWith(elementType)
+            putArgs(
+                buildSerializer(builder, elementType, serializerReceiver, serializerFields, method)
+            )
+        }
+        return builder.irCallConstructor(
+            flowTransformerSymbol.constructors.first(),
+            listOf(elementType)
+        ).apply {
+            this.type = flowTransformerSymbol.typeWith(elementType)
+            putArgs(rpcObjectExpr)
+        }
+    }
 }

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -70,6 +70,7 @@ import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.types.starProjectedType
+import org.jetbrains.kotlin.ir.types.typeOrFail
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.addChild
@@ -479,13 +480,14 @@ class StubGeneration(
     ) = when (outputRpcType) {
         RpcType.BINARY -> declarationIrBuilder.irGetObject(env.binaryTransformer)
 
+        RpcType.FLOW -> buildFlowTransformer(outputType, declarationIrBuilder)
+
         RpcType.SERVICE -> declarationIrBuilder.irCallConstructor(
             env.subserviceTransformer.constructors.first(),
             listOf(outputType)
         ).apply {
             type = env.subserviceTransformer.typeWith(outputType)
-            val companionSymbol = env.companionSymbol(outputType)
-            putArgs(declarationIrBuilder.irGetObject(companionSymbol))
+            putArgs(buildNonGenericSubserviceRpcObject(outputType, declarationIrBuilder))
         }
 
         else -> declarationIrBuilder.irCallConstructor(
@@ -494,6 +496,114 @@ class StubGeneration(
         ).apply {
             type = env.serializerTransformer.typeWith(outputType)
             putArgs(getSerializer(declarationIrBuilder, outputType))
+        }
+    }
+
+    /**
+     * Emit `FlowTransformer<T>(KsFlowService.Obj<T>(Tser))` for a `Flow<T>` parameter or
+     * return type. The constructed `KsFlowService.Obj<T>` is the generic sub-service's
+     * compiler-generated `RpcObject` factory instance — mirrors
+     * [GenericMethodIrBuilder.buildSubserviceRpcObject] for the generic service path.
+     *
+     * Only reachable when [KsrpcGenerationEnvironment.flowSupported] — callers guard via
+     * [determineType] returning [RpcType.FLOW].
+     */
+    private fun buildFlowTransformer(
+        flowType: IrType,
+        declarationIrBuilder: DeclarationIrBuilder
+    ): IrExpression {
+        val elementType = (flowType as? org.jetbrains.kotlin.ir.types.IrSimpleType)
+            ?.arguments
+            ?.singleOrNull()
+            ?.typeOrFail
+            ?: reportInternal(
+                "Flow<T> type ${flowType.classFqName?.asString()} has no type argument — " +
+                    "cannot emit FlowTransformer"
+            )
+        val flowTransformerSymbol = env.flowTransformer
+            ?: reportInternal(
+                "FlowTransformer symbol missing but Flow<T> detection fired — " +
+                    "ksrpc-flow must be on the compile classpath"
+            )
+        val ksFlowServiceSymbol = env.ksFlowService
+            ?: reportInternal(
+                "KsFlowService symbol missing but Flow<T> detection fired — " +
+                    "ksrpc-flow must be on the compile classpath"
+            )
+        val rpcObjectExpr = buildKsFlowServiceRpcObject(
+            declarationIrBuilder,
+            ksFlowServiceSymbol,
+            elementType
+        )
+        return declarationIrBuilder.irCallConstructor(
+            flowTransformerSymbol.constructors.first(),
+            listOf(elementType)
+        ).apply {
+            type = flowTransformerSymbol.typeWith(elementType)
+            putArgs(rpcObjectExpr)
+        }
+    }
+
+    /**
+     * Build `KsFlowService.Obj<T>(serializer<T>())`.
+     */
+    private fun buildKsFlowServiceRpcObject(
+        builder: DeclarationIrBuilder,
+        ksFlowServiceSymbol: IrClassSymbol,
+        elementType: IrType
+    ): IrExpression {
+        val objClass = ksFlowServiceSymbol.owner.declarations
+            .filterIsInstance<IrClass>()
+            .firstOrNull { it.name == FqConstants.OBJ }
+            ?: reportInternal(
+                "KsFlowService has no nested Obj class — the ksrpc compiler plugin " +
+                    "must have processed ksrpc-flow"
+            )
+        val objConstructor = objClass.constructors.first { it.isPrimary }
+        return builder.irCallConstructor(objConstructor.symbol, listOf(elementType)).apply {
+            type = objClass.typeWith(elementType)
+            putArgs(getSerializer(builder, elementType))
+        }
+    }
+
+    /**
+     * Build an `RpcObject<Sub>` IR expression for a sub-service return/parameter on a
+     * non-generic outer service.
+     *
+     * - If the sub-service has no type parameters, its companion IS already an
+     *   `RpcObject<Sub>` and we emit `irGetObject(Sub.Companion)`.
+     * - Otherwise (the sub-service is generic, e.g. `KsFlowService<Update>` returned
+     *   by a non-generic service method), we construct `Sub.Obj<TArgs>(serializers)`
+     *   using `kotlinx.serialization.serializer<T>()` per type argument — since the
+     *   outer service is non-generic, every type argument is concrete and reified
+     *   lookup works. Mirrors [GenericMethodIrBuilder.buildSubserviceRpcObject] for
+     *   the non-generic outer path.
+     */
+    private fun buildNonGenericSubserviceRpcObject(
+        type: IrType,
+        builder: DeclarationIrBuilder
+    ): IrExpression {
+        val simple = type as? org.jetbrains.kotlin.ir.types.IrSimpleType
+            ?: return builder.irGetObject(env.companionSymbol(type))
+        val subClassSymbol = simple.classifier as? IrClassSymbol
+        val subClass = subClassSymbol?.owner
+            ?: return builder.irGetObject(env.companionSymbol(type))
+        if (subClass.typeParameters.isEmpty()) {
+            return builder.irGetObject(env.companionSymbol(type))
+        }
+        val objClass = subClass.declarations
+            .filterIsInstance<IrClass>()
+            .firstOrNull { it.name == FqConstants.OBJ }
+            ?: reportInternal(
+                "generic sub-service ${subClass.kotlinFqName.asString()} has no nested Obj " +
+                    "class — @KsService plugin did not run on the sub-service"
+            )
+        val objConstructor = objClass.constructors.first { it.isPrimary }
+        val typeArgs = simple.arguments.map { it.typeOrFail }
+        return builder.irCallConstructor(objConstructor.symbol, typeArgs).apply {
+            this.type = objClass.typeWith(typeArgs)
+            val serArgs = typeArgs.map { getSerializer(builder, it) }.toTypedArray()
+            putArgs(*serArgs)
         }
     }
 
@@ -509,6 +619,7 @@ class StubGeneration(
         }
 
     private fun determineType(type: IrType): RpcType = when {
+        env.flowSupported && type.classFqName == FqConstants.FLOW -> RpcType.FLOW
         type.extends(env.rpcService) -> RpcType.SERVICE
         type.classFqName == BYTE_READ_CHANNEL -> RpcType.BINARY
         else -> RpcType.DEFAULT
@@ -526,7 +637,8 @@ class StubGeneration(
     private enum class RpcType {
         DEFAULT,
         BINARY,
-        SERVICE
+        SERVICE,
+        FLOW
     }
 }
 

--- a/compiler/plugin/src/test/java/FlowSupportTest.kt
+++ b/compiler/plugin/src/test/java/FlowSupportTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Covers the compiler plugin's auto-detection of `Flow<T>` and `KsFlowService<T>`
+ * in `@KsMethod` signatures (issue #39).
+ *
+ * Relies on the locally-built `ksrpc-flow` jvmJar being on the test classpath
+ * (wired via the `files(...)` test dependency in `build.gradle.kts`) so the
+ * user code under test can resolve `kotlinx.coroutines.flow.Flow`,
+ * `com.monkopedia.ksrpc.flow.KsFlowService<T>`, and
+ * `com.monkopedia.ksrpc.flow.FlowTransformer<T>`.
+ */
+class FlowSupportTest {
+
+    @Test
+    fun `ksservice with Flow return compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Update(val id: String)
+
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<Update>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `ksservice with Flow parameter compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Chunk(val bytes: String)
+
+@Serializable
+data class Receipt(val ok: Boolean)
+
+@KsService
+interface UploadService : RpcService {
+    @KsMethod("/upload")
+    suspend fun upload(items: Flow<Chunk>): Receipt
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `ksservice with Flow in both positions compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Item(val v: Int)
+
+@KsService
+interface Pipe : RpcService {
+    @KsMethod("/pipe")
+    suspend fun pipe(items: Flow<Item>): Flow<Item>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `ksservice mixing Flow return, normal method, and raw KsFlowService compiles`() {
+        // Covers the "doesn't regress raw KsFlowService<T>" requirement — a service
+        // that uses `Flow<T>` in some methods and raw `KsFlowService<T>` in others
+        // must still compile, with each method getting the right transform.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.flow.KsFlowService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Event(val kind: String)
+
+@Serializable
+data class Ack(val seq: Int)
+
+@KsService
+interface Mixed : RpcService {
+    @KsMethod("/events")
+    suspend fun events(filter: String): Flow<Event>
+
+    @KsMethod("/raw")
+    suspend fun raw(u: Unit): KsFlowService<Event>
+
+    @KsMethod("/ack")
+    suspend fun ack(u: Unit): Ack
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `generic outer service with Flow return compiles`() {
+        // The element type inside Flow<T> here is the outer service's class-level
+        // type parameter — exercises the generic-path codegen that composes the
+        // element serializer from the injected KSerializer<T> field rather than
+        // from a static serializer<T>() call.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface Stream<T> : RpcService {
+    @KsMethod("/items")
+    suspend fun items(u: Unit): Flow<T>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `generic outer service with Flow parameter compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface Sink<T> : RpcService {
+    @KsMethod("/push")
+    suspend fun push(items: Flow<T>)
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+    }
+}

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -97,6 +97,15 @@ abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc/KsrpcEnvironment { // 
     }
 }
 
+abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc/Transformer { // com.monkopedia.ksrpc/Transformer|null[0]
+    open val hasContent // com.monkopedia.ksrpc/Transformer.hasContent|{}hasContent[0]
+        open fun <get-hasContent>(): kotlin/Boolean // com.monkopedia.ksrpc/Transformer.hasContent.<get-hasContent>|<get-hasContent>(){}[0]
+
+    abstract suspend fun <#A1: kotlin/Any?> transform(#A, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/Transformer.transform|transform(1:0;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    abstract suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): #A // com.monkopedia.ksrpc/Transformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    open fun <#A1: kotlin/Any?> unpackError(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>) // com.monkopedia.ksrpc/Transformer.unpackError|unpackError(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+}
+
 abstract interface com.monkopedia.ksrpc.channels/CancellationSupport { // com.monkopedia.ksrpc.channels/CancellationSupport|null[0]
     abstract fun cancelHandler(com.monkopedia.ksrpc.channels/RpcCallId, kotlin.coroutines.cancellation/CancellationException? = ...) // com.monkopedia.ksrpc.channels/CancellationSupport.cancelHandler|cancelHandler(com.monkopedia.ksrpc.channels.RpcCallId;kotlin.coroutines.cancellation.CancellationException?){}[0]
     abstract fun registerHandler(com.monkopedia.ksrpc.channels/RpcCallId, kotlinx.coroutines/Job) // com.monkopedia.ksrpc.channels/CancellationSupport.registerHandler|registerHandler(com.monkopedia.ksrpc.channels.RpcCallId;kotlinx.coroutines.Job){}[0]
@@ -128,15 +137,6 @@ abstract interface com.monkopedia.ksrpc/SuspendCloseableObservable : com.monkope
 
 abstract interface com.monkopedia.ksrpc/UnhandledMethodHandler { // com.monkopedia.ksrpc/UnhandledMethodHandler|null[0]
     abstract suspend fun <#A1: kotlin/Any?> onUnhandled(kotlin/String, com.monkopedia.ksrpc.channels/CallData<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/UnhandledMethodHandler.onUnhandled|onUnhandled(kotlin.String;com.monkopedia.ksrpc.channels.CallData<0:0>){0§<kotlin.Any?>}[0]
-}
-
-sealed interface <#A: kotlin/Any?> com.monkopedia.ksrpc/Transformer { // com.monkopedia.ksrpc/Transformer|null[0]
-    open val hasContent // com.monkopedia.ksrpc/Transformer.hasContent|{}hasContent[0]
-        open fun <get-hasContent>(): kotlin/Boolean // com.monkopedia.ksrpc/Transformer.hasContent.<get-hasContent>|<get-hasContent>(){}[0]
-
-    abstract suspend fun <#A1: kotlin/Any?> transform(#A, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/Transformer.transform|transform(1:0;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
-    abstract suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): #A // com.monkopedia.ksrpc/Transformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
-    open fun <#A1: kotlin/Any?> unpackError(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>) // com.monkopedia.ksrpc/Transformer.unpackError|unpackError(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
 }
 
 final class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?, #C: kotlin/Any?> com.monkopedia.ksrpc/RpcMethod { // com.monkopedia.ksrpc/RpcMethod|null[0]

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -48,7 +48,7 @@ val RpcMethod<*, *, *>.timeoutMillis: Long?
         return millis + seconds * 1000 + minutes * 60_000
     }
 
-sealed interface Transformer<T> {
+interface Transformer<T> {
     val hasContent: Boolean
         get() = true
 

--- a/ksrpc-flow/api/ksrpc-flow.api
+++ b/ksrpc-flow/api/ksrpc-flow.api
@@ -7,6 +7,15 @@ public final class com/monkopedia/ksrpc/flow/AutoClosingFlow : kotlinx/coroutine
 	public fun collect (Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/monkopedia/ksrpc/flow/FlowTransformer : com/monkopedia/ksrpc/Transformer {
+	public fun <init> (Lcom/monkopedia/ksrpc/RpcObject;)V
+	public fun getHasContent ()Z
+	public synthetic fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun transform (Lkotlinx/coroutines/flow/Flow;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
+	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class com/monkopedia/ksrpc/flow/KsCollectionToken : com/monkopedia/ksrpc/RpcService {
 	public static final field Companion Lcom/monkopedia/ksrpc/flow/KsCollectionToken$Companion;
 	public abstract fun cancelCollection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/ksrpc-flow/api/ksrpc-flow.klib.api
+++ b/ksrpc-flow/api/ksrpc-flow.klib.api
@@ -112,4 +112,14 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/AutoClosingFlow : kotlin
     final suspend fun collect(kotlinx.coroutines.flow/FlowCollector<#A>) // com.monkopedia.ksrpc.flow/AutoClosingFlow.collect|collect(kotlinx.coroutines.flow.FlowCollector<1:0>){}[0]
 }
 
+final class <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/FlowTransformer : com.monkopedia.ksrpc/Transformer<kotlinx.coroutines.flow/Flow<#A>> { // com.monkopedia.ksrpc.flow/FlowTransformer|null[0]
+    constructor <init>(com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowService<#A>>) // com.monkopedia.ksrpc.flow/FlowTransformer.<init>|<init>(com.monkopedia.ksrpc.RpcObject<com.monkopedia.ksrpc.flow.KsFlowService<1:0>>){}[0]
+
+    final val hasContent // com.monkopedia.ksrpc.flow/FlowTransformer.hasContent|{}hasContent[0]
+        final fun <get-hasContent>(): kotlin/Boolean // com.monkopedia.ksrpc.flow/FlowTransformer.hasContent.<get-hasContent>|<get-hasContent>(){}[0]
+
+    final suspend fun <#A1: kotlin/Any?> transform(kotlinx.coroutines.flow/Flow<#A>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc.flow/FlowTransformer.transform|transform(kotlinx.coroutines.flow.Flow<1:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): kotlinx.coroutines.flow/Flow<#A> // com.monkopedia.ksrpc.flow/FlowTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+}
+
 final fun <#A: kotlin/Any?> (kotlinx.coroutines.flow/Flow<#A>).com.monkopedia.ksrpc.flow/asKsFlow(): com.monkopedia.ksrpc.flow/KsFlowService<#A> // com.monkopedia.ksrpc.flow/asKsFlow|asKsFlow@kotlinx.coroutines.flow.Flow<0:0>(){0§<kotlin.Any?>}[0]

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/FlowTransformer.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/FlowTransformer.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.flow
+
+import com.monkopedia.ksrpc.RpcObject
+import com.monkopedia.ksrpc.SubserviceTransformer
+import com.monkopedia.ksrpc.Transformer
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Transformer emitted by the ksrpc compiler plugin for methods whose `@KsMethod`
+ * signature declares `Flow<T>` (in either a parameter or return position — #39).
+ *
+ * Bridges to the existing [KsFlowService] sub-service protocol:
+ * - On [transform] (client-out for params, host-out for returns): wraps the
+ *   user's `Flow<T>` in [KsFlowService] via [asKsFlow] and delegates to the
+ *   standard [SubserviceTransformer] to register / serialize the sub-service.
+ *   If the caller already passes a [KsFlowService] (user opted in to the raw
+ *   interface but the plugin's emit site still went through [FlowTransformer]),
+ *   the wrapper is passed through as-is.
+ * - On [untransform] (client-in for returns, host-in for params): decodes the
+ *   sub-service reference into a client-side [KsFlowService] stub and wraps it
+ *   in [AutoClosingFlow] so a single terminal operation (`collect`, `toList`,
+ *   etc.) tears down the sub-service automatically.
+ *
+ * The wrapper is symmetric — the same [FlowTransformer] instance is valid for
+ * either the `inputTransform` (parameter) or `outputTransform` (return) on a
+ * compiler-generated `RpcMethod` without per-side handling.
+ *
+ * This type is `@KsrpcInternal` — user code should not reference it. The
+ * compiler plugin emits constructor calls to it in codegen.
+ */
+@OptIn(KsrpcInternal::class)
+@KsrpcInternal
+class FlowTransformer<T>(serviceObject: RpcObject<KsFlowService<T>>) : Transformer<Flow<T>> {
+    private val delegate = SubserviceTransformer(serviceObject)
+
+    override val hasContent: Boolean
+        get() = delegate.hasContent
+
+    override suspend fun <S> transform(input: Flow<T>, channel: SerializedService<S>): CallData<S> {
+        val ksFlow = if (input is KsFlowService<*>) {
+            @Suppress("UNCHECKED_CAST")
+            input as KsFlowService<T>
+        } else {
+            input.asKsFlow()
+        }
+        return delegate.transform(ksFlow, channel)
+    }
+
+    override suspend fun <S> untransform(
+        data: CallData<S>,
+        channel: SerializedService<S>
+    ): Flow<T> {
+        val service = delegate.untransform(data, channel)
+        return AutoClosingFlow(service)
+    }
+}

--- a/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/RpcEndpointInfo.kt
+++ b/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/RpcEndpointInfo.kt
@@ -153,5 +153,11 @@ internal val Transformer<*>.rpcDataType: RpcDataType
             BinaryTransformer -> RpcDataType.BinaryData
             is SerializerTransformer<*> -> RpcDataType.DataStructure(serializer)
             is SubserviceTransformer<*> -> RpcDataType.Service(serviceObject.serviceName)
+            // Out-of-module transformers (e.g. ksrpc-flow's `FlowTransformer`) surface
+            // as a generic Service entry — they delegate to `SubserviceTransformer`
+            // under the hood and their sub-service name is not recoverable from the
+            // introspection classpath. Introspection callers that need the exact
+            // sub-service should look at the underlying `SubserviceTransformer`.
+            else -> RpcDataType.Service(this::class.simpleName ?: "Unknown")
         }
     }

--- a/ksrpc-test/src/commonTest/kotlin/FlowAutoDetectTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/FlowAutoDetectTest.kt
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.flow.KsFlowService
+import com.monkopedia.ksrpc.flow.asKsFlow
+import com.monkopedia.ksrpc.sockets.asConnection
+import io.ktor.utils.io.close
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.Serializable
+
+/**
+ * End-to-end tests for the compiler plugin's `Flow<T>` / `KsFlowService<T>`
+ * auto-detection (issue #39). The user-visible service interface uses only
+ * `Flow<T>`; the compiler plugin wires both the client stub and the host-side
+ * executor through the `KsFlowService` sub-service protocol transparently.
+ *
+ * Uses a bidirectional pipe transport — Flow support requires bidirectional
+ * channels so the server can call back into the `KsFlowCollector` sub-service.
+ */
+class FlowAutoDetectTest {
+
+    @Serializable
+    data class Update(val value: String)
+
+    @Serializable
+    data class Chunk(val bytes: String)
+
+    @Serializable
+    data class Receipt(val count: Int)
+
+    /**
+     * User-facing service: `Flow<T>` return, `Flow<T>` param, and a mixed-style
+     * raw `KsFlowService<T>` return to verify the compiler plugin still routes
+     * raw `KsFlowService<T>` signatures through the pre-#39 codegen path.
+     */
+    @KsService
+    interface StreamService : RpcService {
+        @KsMethod("/updates")
+        suspend fun updates(filter: String): Flow<Update>
+
+        @KsMethod("/upload")
+        suspend fun upload(items: Flow<Chunk>): Receipt
+
+        @KsMethod("/raw")
+        suspend fun raw(u: Unit): KsFlowService<Update>
+    }
+
+    /**
+     * Basic round-trip: server returns `Flow<Update>`, client collects via the
+     * `Flow<T>` API, items flow end-to-end and auto-close fires.
+     */
+    @Test
+    fun flowReturnRoundTrips() = executePipe(
+        serviceJob = { c ->
+            val impl = object : StreamService {
+                override suspend fun updates(filter: String): Flow<Update> = flow {
+                    emit(Update("$filter-a"))
+                    emit(Update("$filter-b"))
+                    emit(Update("$filter-c"))
+                }
+
+                override suspend fun upload(items: Flow<Chunk>): Receipt =
+                    Receipt(items.toList().size)
+
+                override suspend fun raw(u: Unit): KsFlowService<Update> =
+                    error("not exercised here")
+
+                override suspend fun close() = Unit
+            }
+            c.registerDefault(impl.serialized<StreamService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<StreamService, String>()
+            val result = stub.updates("x").toList()
+            assertEquals(listOf(Update("x-a"), Update("x-b"), Update("x-c")), result)
+        }
+    )
+
+    /**
+     * Param position: client sends `Flow<Chunk>`, server collects via the
+     * auto-injected `Flow<T>` param.
+     */
+    @Test
+    fun flowParamRoundTrips() = executePipe(
+        serviceJob = { c ->
+            val impl = object : StreamService {
+                override suspend fun updates(filter: String): Flow<Update> =
+                    error("not exercised here")
+
+                override suspend fun upload(items: Flow<Chunk>): Receipt {
+                    val collected = items.toList()
+                    return Receipt(collected.size)
+                }
+
+                override suspend fun raw(u: Unit): KsFlowService<Update> =
+                    error("not exercised here")
+
+                override suspend fun close() = Unit
+            }
+            c.registerDefault(impl.serialized<StreamService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<StreamService, String>()
+            val receipt = stub.upload(
+                flow {
+                    emit(Chunk("a"))
+                    emit(Chunk("b"))
+                    emit(Chunk("c"))
+                    emit(Chunk("d"))
+                }
+            )
+            assertEquals(Receipt(4), receipt)
+        }
+    )
+
+    /**
+     * Auto-close: a single terminal collection on the client's `Flow<T>` tears
+     * down the sub-service. Verified indirectly here by confirming a second
+     * iteration re-initiates a fresh collection on the server (each call to
+     * `updates(...)` on the stub reaches a fresh server-side flow).
+     */
+    @Test
+    fun flowAutoClosesOnCollect() = executePipe(
+        serviceJob = { c ->
+            val invocations = CompletableDeferred<Int>()
+            var counter = 0
+            val impl = object : StreamService {
+                override suspend fun updates(filter: String): Flow<Update> = flow {
+                    val n = ++counter
+                    emit(Update("$filter-$n"))
+                    if (n == 2) {
+                        invocations.complete(n)
+                    }
+                }
+
+                override suspend fun upload(items: Flow<Chunk>): Receipt =
+                    error("not exercised here")
+
+                override suspend fun raw(u: Unit): KsFlowService<Update> =
+                    error("not exercised here")
+
+                override suspend fun close() = Unit
+            }
+            c.registerDefault(impl.serialized<StreamService, String>(c.env))
+            withTimeout(5000) {
+                assertEquals(2, invocations.await())
+            }
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<StreamService, String>()
+            val first = stub.updates("x").toList()
+            assertEquals(listOf(Update("x-1")), first)
+            val second = stub.updates("x").toList()
+            assertEquals(listOf(Update("x-2")), second)
+        }
+    )
+
+    /**
+     * Error propagation through a `Flow<T>` return — server-side exception
+     * surfaces as an [RpcException] on the client's collect.
+     */
+    @Test
+    fun flowErrorPropagates() = executePipe(
+        serviceJob = { c ->
+            val impl = object : StreamService {
+                override suspend fun updates(filter: String): Flow<Update> = flow {
+                    emit(Update("ok"))
+                    throw RuntimeException("server boom")
+                }
+
+                override suspend fun upload(items: Flow<Chunk>): Receipt =
+                    error("not exercised here")
+
+                override suspend fun raw(u: Unit): KsFlowService<Update> =
+                    error("not exercised here")
+
+                override suspend fun close() = Unit
+            }
+            c.registerDefault(impl.serialized<StreamService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<StreamService, String>()
+            val got = mutableListOf<Update>()
+            val exception = assertFailsWith<RpcException> {
+                stub.updates("x").collect { got.add(it) }
+            }
+            assertEquals(listOf(Update("ok")), got)
+            assertTrue(
+                exception.message.contains("server boom"),
+                "expected server message to propagate; got: ${exception.message}"
+            )
+        }
+    )
+
+/**
+     * Raw `KsFlowService<T>` must still work after the `Flow<T>` auto-detection
+     * was added — the same service interface exposes both shapes, and each
+     * compiles through its own codegen path (#39 must not regress PR #61's
+     * raw-`KsFlowService` integration tests).
+     */
+    @Test
+    fun rawKsFlowServiceStillWorks() = executePipe(
+        serviceJob = { c ->
+            val impl = object : StreamService {
+                override suspend fun updates(filter: String): Flow<Update> =
+                    error("not exercised here")
+
+                override suspend fun upload(items: Flow<Chunk>): Receipt =
+                    error("not exercised here")
+
+                override suspend fun raw(u: Unit): KsFlowService<Update> =
+                    flow {
+                        emit(Update("r-1"))
+                        emit(Update("r-2"))
+                    }.asKsFlow()
+
+                override suspend fun close() = Unit
+            }
+            c.registerDefault(impl.serialized<StreamService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<StreamService, String>()
+            val raw = stub.raw(Unit)
+            val items = raw.toList()
+            assertEquals(listOf(Update("r-1"), Update("r-2")), items)
+            // Unlike Flow<T>, raw KsFlowService<T> does NOT auto-close after a
+            // single collection — a second collect should still succeed.
+            val again = raw.toList()
+            assertEquals(listOf(Update("r-1"), Update("r-2")), again)
+            raw.close()
+        }
+    )
+
+    private fun executePipe(
+        serviceJob: suspend (Connection<String>) -> Unit,
+        clientJob: suspend (Connection<String>) -> Unit
+    ) = runBlockingUnit {
+        val (output, input) = createPipe()
+        val (so, si) = createPipe()
+        val serviceChannel = (si to output).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { }
+            }
+        )
+        val clientChannel = (input to so).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { }
+            }
+        )
+        val bgJob = GlobalScope.launch(Dispatchers.Default) {
+            serviceJob(serviceChannel)
+        }
+        try {
+            clientJob(clientChannel)
+        } finally {
+            try { clientChannel.close() } catch (_: Throwable) {}
+            try { serviceChannel.close() } catch (_: Throwable) {}
+            try { input.cancel(null) } catch (_: Throwable) {}
+            try { si.cancel(null) } catch (_: Throwable) {}
+            output.close(null)
+            so.close(null)
+            bgJob.join()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Compiler plugin now recognises `kotlinx.coroutines.flow.Flow<T>` in `@KsMethod` parameters and returns and emits a new `FlowTransformer<T>` runtime bridge that routes through the existing `KsFlowService<T>` sub-service protocol. Users write `Flow<T>` in their `@KsService` interfaces and get sub-service bridging for free — `asKsFlow()` on the host side, `AutoClosingFlow` on the client side.
- `FlowTransformer<T>` lives in `ksrpc-flow`, delegates to `SubserviceTransformer<KsFlowService<T>>`, and is symmetric — the same instance works as `inputTransform` (param position) or `outputTransform` (return position) on the compiler-generated `RpcMethod`. Marked `@KsrpcInternal`.
- `Transformer` becomes non-sealed so `FlowTransformer` can implement it from outside `ksrpc-core`. The sealed modifier wasn't serving a user-facing contract; `RpcEndpointInfo.rpcDataType` gains an `else` branch that surfaces out-of-module transformers as a generic `RpcDataType.Service`.
- Drive-by fix in the non-generic `StubGeneration.createTypeConverter` SERVICE branch: generic sub-services (e.g. `KsFlowService<Update>` as a return type on a non-generic `@KsService`) now construct `Sub.Obj<TArgs>(serializers)` instead of `irGetObject(Sub.Companion)`, which would ClassCastException at runtime because the companion on a generic sub-service is an `RpcObjectFactory`, not an `RpcObject`.

Closes #39.

## Positions exercised

| Position                                              | Status |
| ----------------------------------------------------- | ------ |
| `Flow<T>` return                                      | works (end-to-end test) |
| `Flow<T>` parameter                                   | works (end-to-end test) |
| `Flow<T>` + raw `KsFlowService<T>` on the same service| works (end-to-end test) |
| `Flow<T>` on a generic outer `@KsService` (return)    | compiles (plugin test; no end-to-end test yet) |
| `Flow<T>` on a generic outer `@KsService` (param)     | compiles (plugin test; no end-to-end test yet) |

## Test coverage

- Compiler-plugin `FlowSupportTest` (6 tests) — return / param / both / mixed / generic-outer return / generic-outer param. Uses locally-built `ksrpc-flow` jvmJar on the test classpath.
- `ksrpc-test` `FlowAutoDetectTest` (5 tests over a bidirectional pipe) — return round-trip, param round-trip (client uploads a `Flow<Chunk>`), auto-close on collect, error propagation, raw `KsFlowService<T>` still works alongside `Flow<T>`.
- No regression to PR #61's `KsFlowServiceTest` (raw `KsFlowService<T>` is untouched; 6/6 still pass).

## Known caveats / follow-ups

- Cancellation of a client-side `Flow<T>` `collect { throw CancellationException }` surfaces as an `RpcException` on the client because the CancellationException is caught server-side in the collector coroutine and sent back via `onError`. This is a pre-existing behaviour of the `KsFlowService.collect()` runtime (not introduced by #39) — left for a follow-up on the runtime protocol rather than the compiler plugin.
- The compiler-plugin test module reaches the main build's `ksrpc-core` / `ksrpc-flow` via `files(...)` dependencies on the `build/libs/*.jar` paths. `ksrpcModule` snapshots aren't first-class consumable artifacts from an included build, and the published `ksrpctest` coordinate (0.11.1) predates both the non-sealed `Transformer` and the `ksrpc-flow` module.
- The introspection `else` branch for out-of-module transformers is minimal — it emits `RpcDataType.Service(simpleName)` which loses the underlying sub-service's qualified name. Adding a `FlowTransformer`-aware branch to `ksrpc-introspection` is a follow-up; it would require the introspection module to reach `ksrpc-flow` classes which changes dependency direction.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — all pass, 6 new Flow cases green
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-flow:jvmTest :ksrpc-flow:linuxX64Test`
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test` — 5 new Flow auto-detect cases green, 6 raw `KsFlowService` cases still green
- [x] `./gradlew apiCheck` — BCV updated for the non-sealed `Transformer` and the new `FlowTransformer` surface
- [x] ktlint on touched files — no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)