### PR TITLE
Fix #45: reject @KsService on subtype of another @KsService

### DIFF
--- a/compiler/plugin/src/main/java/CompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/CompanionGeneration.kt
@@ -70,8 +70,10 @@ class CompanionGeneration(
         key: GeneratedDeclarationKey?
     ): Collection<IrDeclaration> {
         val k = key as FirCompanionDeclarationGenerator.Key
-        val cls = classes[k.type]
-            ?: error("Invalid synthetic declaration for ${k.type} in ${classes.keys}")
+        // The class may have been removed from `classes` by validation (e.g. a @KsService
+        // subtype of another @KsService — see issue #45). In that case validation has
+        // already reported an error; just skip body generation so we don't crash.
+        val cls = classes[k.type] ?: return emptyList()
         // Emit @RpcObjectKey pointing at the companion. For non-generic services the
         // companion is the `RpcObject`; for generic services it's the `RpcObjectFactory`.
         // `rpcObject<T>()` inspects the returned instance and, when it's a factory,
@@ -146,8 +148,8 @@ class CompanionGeneration(
         key: GeneratedDeclarationKey?
     ): IrBody? {
         val k = key as FirCompanionDeclarationGenerator.Key
-        val cls = classes[k.type]
-            ?: error("Invalid synthetic declaration for ${k.type} in ${classes.keys}")
+        // See generateChildrenForClass: validation may have removed the entry.
+        val cls = classes[k.type] ?: return null
         function.correspondingPropertySymbol?.owner?.name?.let { propertyName ->
             if (propertyName == FqConstants.SERVICE_NAME) {
                 return context.irBuilder(function).irSynthBody {

--- a/compiler/plugin/src/main/java/IntrospectionGeneration.kt
+++ b/compiler/plugin/src/main/java/IntrospectionGeneration.kt
@@ -46,8 +46,9 @@ class IntrospectionGeneration(
         key: GeneratedDeclarationKey?
     ): IrBody? {
         val k = key as FirKsrpcIntrospectionGenerator.Key
-        val cls = classes[k.type]
-            ?: error("Invalid synthetic declaration for ${k.type} in ${classes.keys}")
+        // Class may have been removed by validation (issue #45). Errors are already
+        // reported; skip body generation to avoid crashing.
+        val cls = classes[k.type] ?: return null
         return when (function.name) {
             FqConstants.GET_INTROSPECTION -> buildIntrospectionBody(function, cls)
             else -> null

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -97,11 +97,14 @@
  *   sides, and `@KsNotification` methods that don't return `Unit`.
  */
 
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
 package com.monkopedia.ksrpc.plugin
 
 import com.monkopedia.ksrpc.plugin.FqConstants.BYTE_READ_CHANNEL
 import com.monkopedia.ksrpc.plugin.FqConstants.FQRPC_SERVICE
 import com.monkopedia.ksrpc.plugin.FqConstants.INTROSPECTABLE_RPC_SERVICE
+import com.monkopedia.ksrpc.plugin.FqConstants.KS_SERVICE
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
@@ -114,7 +117,9 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.types.Variance
@@ -158,7 +163,29 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         val hasRpcServiceSuper = superTypeNames.contains(FQRPC_SERVICE)
         val hasIntrospectableSuper =
             superTypeNames.contains(INTROSPECTABLE_RPC_SERVICE.asSingleFqName())
-        if (!hasRpcServiceSuper && !hasIntrospectableSuper) {
+        // Reject `@KsService` applied to a subtype of another `@KsService` interface.
+        // The parent's @KsService annotation already drives codegen, and `rpcObject<Sub>()`
+        // walks supertypes to find the parent's `RpcObject`/`RpcObjectFactory` companion
+        // automatically. Allowing @KsService on the subtype would produce a duplicate
+        // companion that has no working stub/obj of its own and previously crashed
+        // CompanionGeneration with "Invalid synthetic declaration for ..." (issue #45).
+        val ksServiceSuper = irClass.superTypes
+            .mapNotNull { it.classOrNull?.owner }
+            .firstOrNull { superClass ->
+                superClass.annotations.any { it.type.classFqName == KS_SERVICE }
+            }
+        if (ksServiceSuper != null) {
+            report.error(
+                "@KsService cannot be applied to ${irClass.kotlinFqName.asString()} because " +
+                    "its supertype ${ksServiceSuper.kotlinFqName.asString()} is already " +
+                    "@KsService. Remove @KsService from " +
+                    "${irClass.kotlinFqName.asString()}; rpcObject<" +
+                    "${irClass.name.asString()}>() will find the parent's companion " +
+                    "automatically."
+            )
+            isValid = false
+        }
+        if (!hasRpcServiceSuper && !hasIntrospectableSuper && ksServiceSuper == null) {
             report.error(
                 "${irClass.kotlinFqName.asString()} does not extend ${FQRPC_SERVICE.asString()}"
             )

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -91,8 +91,9 @@ class ObjGeneration(
         key: GeneratedDeclarationKey?
     ): Collection<IrDeclaration> {
         val k = key as FirKsrpcObjGenerator.Key
-        val cls = classes[k.target]
-            ?: error("Invalid synthetic Obj for ${k.target}")
+        // Class may have been removed by validation (issue #45 — @KsService subtype of
+        // another @KsService). Errors are already reported; skip to avoid crashing.
+        val cls = classes[k.target] ?: return emptyList()
         val serializerFields =
             context.buildSerializerFieldsForTypeParams(declaration, env, attach = true)
         cls.setObjClass(declaration)

--- a/compiler/plugin/src/test/java/KsServiceSubtypeValidationTest.kt
+++ b/compiler/plugin/src/test/java/KsServiceSubtypeValidationTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Regression tests for issue #45: applying `@KsService` to a subtype of another
+ * `@KsService` interface used to crash CompanionGeneration with
+ * "Invalid synthetic declaration for ...". The plugin now rejects this with a clear
+ * compile-time diagnostic, while the supported workaround (a plain Kotlin subtype with
+ * no `@KsService`) continues to work — see `GenericServiceSubtypeJvmTest`.
+ */
+class KsServiceSubtypeValidationTest {
+
+    @Test
+    fun `KsService on subtype of generic KsService is rejected with a clear diagnostic`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface GenericEcho<T> : RpcService {
+    @KsMethod("/echo")
+    suspend fun echo(item: T): T
+}
+
+@KsService
+interface TypedGenericEcho : GenericEcho<String>
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("@KsService cannot be applied to") &&
+                result.messages.contains("TypedGenericEcho") &&
+                result.messages.contains("GenericEcho"),
+            "Expected diagnostic mentioning @KsService, TypedGenericEcho and GenericEcho, " +
+                "got: ${result.messages}"
+        )
+        // Make sure we're not seeing the old crash anymore.
+        assertTrue(
+            !result.messages.contains("Invalid synthetic declaration"),
+            "Plugin should not crash with 'Invalid synthetic declaration' anymore, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsService on subtype of non-generic KsService is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface ParentService : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String
+}
+
+@KsService
+interface ChildService : ParentService
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("@KsService cannot be applied to") &&
+                result.messages.contains("ChildService") &&
+                result.messages.contains("ParentService"),
+            "Expected diagnostic mentioning @KsService, ChildService and ParentService, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsService directly extending RpcService still compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Unrelated : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed, got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `Plain Kotlin subtype of generic KsService still compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface GenericEcho<T> : RpcService {
+    @KsMethod("/echo")
+    suspend fun echo(item: T): T
+}
+
+// No @KsService — this is the supported pattern for specializing a generic service.
+interface TypedGenericEcho : GenericEcho<String>
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed, got: ${result.messages}"
+        )
+    }
+}


### PR DESCRIPTION
Supersedes #49 (auto-closed when its base branch `issue-43-plugin-refactor` was deleted after PR #48 merge).

## Summary

- **Option A** chosen: reject at compile time with a clear diagnostic rather than attempt to generate a companion for subtypes of other `@KsService` interfaces.
- `KsrpcIrGenerationExtension.validateClass` now walks supertypes looking for `@KsService` on any supertype and emits a diagnostic naming both classes, pointing the user at the supported workaround (subtype should not itself carry `@KsService`).
- `CompanionGeneration.kt`, `ObjGeneration.kt`, `IntrospectionGeneration.kt` — replace `error("Invalid synthetic declaration ...")` with graceful early-return when the `ServiceClass` entry is missing (validation already reported the real error).

## Test plan

- [x] `KsServiceSubtypeValidationTest` — 4 cases: rejected-on-generic-parent, rejected-on-non-generic-parent, still-compiles-when-direct-RpcService, still-compiles-when-subtype-is-plain-Kotlin
- [x] Existing `GenericServiceSubtypeJvmTest` (plain subtype pattern) still passes
- [x] `:compiler:ksrpc-compiler-plugin:test` + all module tests pass
- [x] No BCV changes

## Note for future work

Diagnostic is emitted via IR-phase `MessageCollector.report(ERROR, ...)` without a precise `KtSourceElement` — points at the file rather than the `@KsService` annotation. A FIR-side `FirDeclarationChecker` would give IDE red-squiggle diagnostics; out of scope here, worth bundling into the broader error-handling polish pass.

Closes #45