### PR TITLE
Fix #5: gate ksrpc-service-worker surface behind @ExperimentalKsrpc

### DIFF
--- a/ksrpc-service-worker-test/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/test/Main.kt
+++ b/ksrpc-service-worker-test/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/test/Main.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(ExperimentalKsrpc::class)
+
 package com.monkopedia.ksrpc.webworker.test
 
+import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.registerDefault
 import com.monkopedia.ksrpc.ksrpcEnvironment
 import com.monkopedia.ksrpc.webworker.onServiceWorkerConnection

--- a/ksrpc-service-worker/src/commonMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnections.kt
+++ b/ksrpc-service-worker/src/commonMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnections.kt
@@ -16,11 +16,17 @@
 package com.monkopedia.ksrpc.webworker
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.Connection
 
 /**
  * Creates a connection to a service worker registered at [workerScriptPath].
+ *
+ * This is an experimental API — the service-worker transport has limited test
+ * coverage and its behavior may change without notice. Opt in explicitly with
+ * `@OptIn(ExperimentalKsrpc::class)`.
  */
+@ExperimentalKsrpc
 expect fun createServiceWorkerWithConnection(
     workerScriptPath: String,
     env: KsrpcEnvironment<String>

--- a/ksrpc-service-worker/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsJs.kt
+++ b/ksrpc-service-worker/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsJs.kt
@@ -19,6 +19,7 @@ package com.monkopedia.ksrpc.webworker
 
 import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.packets.internal.Packet
@@ -34,6 +35,7 @@ import org.w3c.dom.MessageChannel
 import org.w3c.dom.MessageEvent
 import org.w3c.dom.MessagePort
 
+@ExperimentalKsrpc
 actual fun createServiceWorkerWithConnection(
     workerScriptPath: String,
     env: KsrpcEnvironment<String>
@@ -57,7 +59,11 @@ actual fun createServiceWorkerWithConnection(
 
 /**
  * Listens for "ksrpc-connect" to attach a port and provides callback to initialize a [Connection].
+ *
+ * This is an experimental API — the service-worker transport has limited test
+ * coverage and its behavior may change without notice.
  */
+@ExperimentalKsrpc
 fun onServiceWorkerConnection(
     env: KsrpcEnvironment<String>,
     onConnection: suspend (Connection<String>) -> Unit

--- a/ksrpc-service-worker/src/wasmJsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsWasm.kt
+++ b/ksrpc-service-worker/src/wasmJsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsWasm.kt
@@ -20,6 +20,7 @@ package com.monkopedia.ksrpc.webworker
 
 import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.packets.internal.Packet
@@ -32,6 +33,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.serialization.builtins.serializer
 
+@ExperimentalKsrpc
 actual fun createServiceWorkerWithConnection(
     workerScriptPath: String,
     env: KsrpcEnvironment<String>

--- a/ksrpc-test/src/jsTest/kotlin/ServiceWorkerTest.kt
+++ b/ksrpc-test/src/jsTest/kotlin/ServiceWorkerTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(ExperimentalKsrpc::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.webworker.createServiceWorkerWithConnection
 import com.monkopedia.ksrpc.webworker.test.WebWorkerTestService

--- a/ksrpc-test/src/wasmJsTest/kotlin/ServiceWorkerTest.kt
+++ b/ksrpc-test/src/wasmJsTest/kotlin/ServiceWorkerTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(ExperimentalKsrpc::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.webworker.createServiceWorkerWithConnection
 import com.monkopedia.ksrpc.webworker.test.WebWorkerTestService


### PR DESCRIPTION
## Summary

- Decision on #5: **keep experimental** at 1.0.0. Service-worker transport has limited functional coverage (#30 would extend `RpcFunctionalityTest` with a `SERVICE_WORKER` type; not a prerequisite for this change).
- Gates `createServiceWorkerWithConnection` (common + JS + WASM actuals) and `onServiceWorkerConnection` (JS) with `@ExperimentalKsrpc`.
- Adds file-level `@file:OptIn(ExperimentalKsrpc::class)` to downstream test files and the `ksrpc-service-worker-test` entrypoint so existing fixtures continue to build.

## Why

From the #5 discussion: three options (promote, keep experimental, drop). Going with **keep experimental** — pragmatic, preserves optionality, users get a clear "this might change" signal. Can promote later without a breaking change if service-worker coverage lands (#30) and shakes out cleanly.

## Test plan

- [x] `./gradlew :ksrpc-service-worker:apiCheck` passes
- [x] `./gradlew :ksrpc-service-worker:compileKotlinJs :ksrpc-service-worker:compileKotlinWasmJs` passes
- [x] `./gradlew :ksrpc-service-worker-test:compileKotlinJs` passes
- [x] `./gradlew :ksrpc-test:compileTestKotlinJs :ksrpc-test:compileTestKotlinWasmJs` passes

Closes #5