### PR TITLE
Fix #71: introduce RpcBinaryData core interface, reshape CallData.Binary / BinaryTransformer

### DIFF
--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -60,6 +60,14 @@ dependencies {
             project.rootDir.resolve("../ksrpc-flow/build/libs/ksrpc-flow-jvm-0.11.1.jar")
         )
     )
+    // Locally-built `ksrpc-packets` — hosts the stopgap `ByteReadChannelTransformer`
+    // (issue #71) that the plugin emits for `ByteReadChannel` signatures until
+    // the `ksrpc-binary-ktor` adapter module (#72) lands.
+    testImplementation(
+        files(
+            project.rootDir.resolve("../ksrpc-packets/build/libs/ksrpc-packets-jvm-0.11.1.jar")
+        )
+    )
     testImplementation(kotlin("test-junit"))
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
     testImplementation(libs.kotlin.compiletesting)

--- a/compiler/plugin/src/main/java/FqConstants.kt
+++ b/compiler/plugin/src/main/java/FqConstants.kt
@@ -36,7 +36,26 @@ object FqConstants {
 
     val SERVICE_EXECUTOR = ClassId(FQPKG, Name.identifier("ServiceExecutor"))
     val SERIALIZER_TRANSFORMER = ClassId(FQPKG, Name.identifier("SerializerTransformer"))
+
+    /**
+     * Core transport-agnostic binary transformer (operates on `RpcBinaryData`).
+     * Not emitted directly for user `ByteReadChannel` signatures — those go
+     * through [BYTE_READ_CHANNEL_TRANSFORMER] which adapts onto this one.
+     */
     val BINARY_TRANSFORMER = ClassId(FQPKG, Name.identifier("BinaryTransformer"))
+
+    /**
+     * Stopgap transformer emitted for methods with `ByteReadChannel` inputs or
+     * outputs. Lives in `ksrpc-packets` (the `ksrpc-binary-ktor` module from
+     * issue #72 will eventually replace it). Falling back through the general
+     * "cannot resolve" diagnostic is acceptable when the module isn't on the
+     * compile classpath; consumers use `ByteReadChannel` through one of the
+     * ktor transports, which all pull in `ksrpc-packets`.
+     */
+    val BYTE_READ_CHANNEL_TRANSFORMER = ClassId(
+        FqName("com.monkopedia.ksrpc.packets"),
+        Name.identifier("ByteReadChannelTransformer")
+    )
     val SUBSERVICE_TRANSFORMER = ClassId(FQPKG, Name.identifier("SubserviceTransformer"))
     val SUSPEND_CLOSEABLE = ClassId(FQPKG, Name.identifier("SuspendCloseable"))
 

--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -43,7 +43,14 @@ class KsrpcGenerationEnvironment(
     val rpcMethod = referenceClass(FqConstants.RPC_METHOD)
     val serviceExecutor = referenceClass(FqConstants.SERVICE_EXECUTOR)
     val serializerTransformer = referenceClass(FqConstants.SERIALIZER_TRANSFORMER)
-    val binaryTransformer = referenceObject(FqConstants.BINARY_TRANSFORMER)
+    // The `ByteReadChannel` adapter lives in `ksrpc-packets` (stopgap until the
+    // dedicated `ksrpc-binary-ktor` module from issue #72 ships). Resolved
+    // optionally so modules that never declare a `ByteReadChannel` service
+    // signature — including `ksrpc-core` itself, which applies this plugin —
+    // compile even when `ksrpc-packets` is not on the classpath. Callers that
+    // need this symbol emit a user-error diagnostic when the lookup misses.
+    val binaryTransformer: IrClassSymbol? =
+        maybeReferenceClass(FqConstants.BYTE_READ_CHANNEL_TRANSFORMER)
     val introspectionImpl: IrClassSymbol by lazy {
         referenceClass(FqConstants.INTROSPECTION_SERVICE_IMPL)
     }

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -326,9 +326,28 @@ internal class GenericMethodIrBuilder(
         serializerFields: List<IrField>,
         method: IrSimpleFunction
     ): IrExpression {
-        // BINARY (ByteReadChannel) transformer.
+        // BINARY (ByteReadChannel) transformer. Emits the stopgap
+        // `ByteReadChannelTransformer` from `ksrpc-packets` — future versions
+        // will dispatch via the adapter registry planned in #75.
         if (type.classFqName == FqConstants.BYTE_READ_CHANNEL) {
-            return builder.irGetObject(env.binaryTransformer)
+            val binaryTransformer = env.binaryTransformer ?: run {
+                report.reportUserError(
+                    "ByteReadChannel in @KsMethod requires `ksrpc-packets` " +
+                        "(stopgap until `ksrpc-binary-ktor` from #72 lands) " +
+                        "on the compile classpath for " +
+                        "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()}",
+                    element = method
+                )
+                // Fall back to `Unit` serializer transformer so codegen doesn't crash
+                // after reporting the diagnostic.
+                return builder.irCallConstructor(
+                    env.serializerTransformer.constructors.first(),
+                    listOf(context.irBuiltIns.unitType)
+                ).apply {
+                    this.type = env.serializerTransformer.typeWith(context.irBuiltIns.unitType)
+                }
+            }
+            return builder.irGetObject(binaryTransformer)
         }
         // Flow<T> is bridged to the KsFlowService sub-service protocol. Only reachable when
         // ksrpc-flow is on the compile classpath — otherwise we fall through to the generic

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -478,7 +478,15 @@ class StubGeneration(
         outputType: IrType,
         declarationIrBuilder: DeclarationIrBuilder
     ) = when (outputRpcType) {
-        RpcType.BINARY -> declarationIrBuilder.irGetObject(env.binaryTransformer)
+        // The paired `ObjGeneration.createTypeConverter` already emits a user
+        // diagnostic when the `ByteReadChannel` adapter is missing; by the
+        // time we reach stub generation the classpath must satisfy it.
+        RpcType.BINARY -> declarationIrBuilder.irGetObject(
+            env.binaryTransformer
+                ?: reportInternal(
+                    "ByteReadChannel adapter (ksrpc-packets) missing on the compile classpath"
+                )
+        )
 
         RpcType.FLOW -> buildFlowTransformer(outputType, declarationIrBuilder)
 

--- a/ksrpc-bench/src/jvmMain/kotlin/com/monkopedia/ksrpc/bench/BenchmarkSupport.kt
+++ b/ksrpc-bench/src/jvmMain/kotlin/com/monkopedia/ksrpc/bench/BenchmarkSupport.kt
@@ -19,6 +19,8 @@ import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.packets.asByteReadChannel
+import com.monkopedia.ksrpc.packets.asRpcBinaryData
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.toByteArray
 import java.net.InetSocketAddress
@@ -75,9 +77,9 @@ internal suspend fun callBinaryEcho(
     service: SerializedService<String>,
     payload: ByteArray
 ): ByteArray {
-    val input = CallData.createBinary<String>(ByteReadChannel(payload))
+    val input = CallData.createBinary<String>(ByteReadChannel(payload).asRpcBinaryData())
     val output = service.call("binaryEcho", input, callId = null)
-    return output.readBinary().toByteArray()
+    return output.readBinary().asByteReadChannel().toByteArray()
 }
 
 internal fun createComplexPayload(payloadSize: Int): ComplexEchoPayload {

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -1,7 +1,10 @@
-public final class com/monkopedia/ksrpc/BinaryTransformer : com/monkopedia/ksrpc/Transformer {
+public abstract interface class com/monkopedia/ksrpc/BinaryDataTransformer {
+}
+
+public final class com/monkopedia/ksrpc/BinaryTransformer : com/monkopedia/ksrpc/BinaryDataTransformer, com/monkopedia/ksrpc/Transformer {
 	public static final field INSTANCE Lcom/monkopedia/ksrpc/BinaryTransformer;
 	public fun getHasContent ()Z
-	public fun transform (Lio/ktor/utils/io/ByteReadChannel;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun transform (Lcom/monkopedia/ksrpc/channels/RpcBinaryData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
 	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -308,25 +311,25 @@ public abstract interface class com/monkopedia/ksrpc/UnhandledMethodHandler {
 public abstract class com/monkopedia/ksrpc/channels/CallData {
 	public static final field Companion Lcom/monkopedia/ksrpc/channels/CallData$Companion;
 	public abstract fun isBinary ()Z
-	public abstract fun readBinary ()Lio/ktor/utils/io/ByteReadChannel;
+	public abstract fun readBinary ()Lcom/monkopedia/ksrpc/channels/RpcBinaryData;
 	public abstract fun readSerialized ()Ljava/lang/Object;
 }
 
 public final class com/monkopedia/ksrpc/channels/CallData$Binary : com/monkopedia/ksrpc/channels/CallData {
-	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;)V
-	public final fun copy (Lio/ktor/utils/io/ByteReadChannel;)Lcom/monkopedia/ksrpc/channels/CallData$Binary;
-	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/channels/CallData$Binary;Lio/ktor/utils/io/ByteReadChannel;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/channels/CallData$Binary;
+	public fun <init> (Lcom/monkopedia/ksrpc/channels/RpcBinaryData;)V
+	public final fun copy (Lcom/monkopedia/ksrpc/channels/RpcBinaryData;)Lcom/monkopedia/ksrpc/channels/CallData$Binary;
+	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/channels/CallData$Binary;Lcom/monkopedia/ksrpc/channels/RpcBinaryData;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/channels/CallData$Binary;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun isBinary ()Z
-	public fun readBinary ()Lio/ktor/utils/io/ByteReadChannel;
+	public fun readBinary ()Lcom/monkopedia/ksrpc/channels/RpcBinaryData;
 	public fun readSerialized ()Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/channels/CallData$Companion {
 	public final fun create (Ljava/lang/Object;)Lcom/monkopedia/ksrpc/channels/CallData$Serialized;
-	public final fun createBinary (Lio/ktor/utils/io/ByteReadChannel;)Lcom/monkopedia/ksrpc/channels/CallData;
+	public final fun createBinary (Lcom/monkopedia/ksrpc/channels/RpcBinaryData;)Lcom/monkopedia/ksrpc/channels/CallData;
 	public final fun createEndpointNotFoundError (Ljava/lang/String;)Lcom/monkopedia/ksrpc/channels/CallData$Serialized;
 	public final fun createError (Ljava/lang/String;)Lcom/monkopedia/ksrpc/channels/CallData$Serialized;
 }
@@ -338,7 +341,7 @@ public final class com/monkopedia/ksrpc/channels/CallData$Serialized : com/monko
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun isBinary ()Z
-	public fun readBinary ()Lio/ktor/utils/io/ByteReadChannel;
+	public fun readBinary ()Lcom/monkopedia/ksrpc/channels/RpcBinaryData;
 	public fun readSerialized ()Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
@@ -428,6 +431,15 @@ public final class com/monkopedia/ksrpc/channels/CurrentRpcCallElement$CurrentRp
 
 public final class com/monkopedia/ksrpc/channels/CurrentRpcCallElementKt {
 	public static final fun currentRpcCall (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/monkopedia/ksrpc/channels/RpcBinaryData : com/monkopedia/ksrpc/SuspendCloseable {
+	public fun getSize ()Ljava/lang/Long;
+	public abstract fun transferTo (Lkotlin/jvm/functions/Function4;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/channels/RpcBinaryData$DefaultImpls {
+	public static fun getSize (Lcom/monkopedia/ksrpc/channels/RpcBinaryData;)Ljava/lang/Long;
 }
 
 public abstract interface class com/monkopedia/ksrpc/channels/RpcCallId {

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -118,7 +118,16 @@ abstract interface com.monkopedia.ksrpc.channels/ContextContainer { // com.monko
         open fun <get-context>(): kotlin.coroutines/CoroutineContext // com.monkopedia.ksrpc.channels/ContextContainer.context.<get-context>|<get-context>(){}[0]
 }
 
+abstract interface com.monkopedia.ksrpc.channels/RpcBinaryData : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc.channels/RpcBinaryData|null[0]
+    open val size // com.monkopedia.ksrpc.channels/RpcBinaryData.size|{}size[0]
+        open fun <get-size>(): kotlin/Long? // com.monkopedia.ksrpc.channels/RpcBinaryData.size.<get-size>|<get-size>(){}[0]
+
+    abstract suspend fun transferTo(kotlin.coroutines/SuspendFunction3<kotlin/ByteArray, kotlin/Int, kotlin/Int, kotlin/Unit>) // com.monkopedia.ksrpc.channels/RpcBinaryData.transferTo|transferTo(kotlin.coroutines.SuspendFunction3<kotlin.ByteArray,kotlin.Int,kotlin.Int,kotlin.Unit>){}[0]
+}
+
 abstract interface com.monkopedia.ksrpc.channels/RpcCallId // com.monkopedia.ksrpc.channels/RpcCallId|null[0]
+
+abstract interface com.monkopedia.ksrpc/BinaryDataTransformer // com.monkopedia.ksrpc/BinaryDataTransformer|null[0]
 
 abstract interface com.monkopedia.ksrpc/Logger { // com.monkopedia.ksrpc/Logger|null[0]
     open fun debug(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.debug|debug(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
@@ -321,19 +330,19 @@ sealed class <#A: kotlin/Any?> com.monkopedia.ksrpc.channels/CallData { // com.m
     abstract val isBinary // com.monkopedia.ksrpc.channels/CallData.isBinary|{}isBinary[0]
         abstract fun <get-isBinary>(): kotlin/Boolean // com.monkopedia.ksrpc.channels/CallData.isBinary.<get-isBinary>|<get-isBinary>(){}[0]
 
-    abstract fun readBinary(): io.ktor.utils.io/ByteReadChannel // com.monkopedia.ksrpc.channels/CallData.readBinary|readBinary(){}[0]
+    abstract fun readBinary(): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc.channels/CallData.readBinary|readBinary(){}[0]
     abstract fun readSerialized(): #A // com.monkopedia.ksrpc.channels/CallData.readSerialized|readSerialized(){}[0]
 
     final class <#A1: kotlin/Any?> Binary : com.monkopedia.ksrpc.channels/CallData<#A1> { // com.monkopedia.ksrpc.channels/CallData.Binary|null[0]
-        constructor <init>(io.ktor.utils.io/ByteReadChannel) // com.monkopedia.ksrpc.channels/CallData.Binary.<init>|<init>(io.ktor.utils.io.ByteReadChannel){}[0]
+        constructor <init>(com.monkopedia.ksrpc.channels/RpcBinaryData) // com.monkopedia.ksrpc.channels/CallData.Binary.<init>|<init>(com.monkopedia.ksrpc.channels.RpcBinaryData){}[0]
 
         final val isBinary // com.monkopedia.ksrpc.channels/CallData.Binary.isBinary|{}isBinary[0]
             final fun <get-isBinary>(): kotlin/Boolean // com.monkopedia.ksrpc.channels/CallData.Binary.isBinary.<get-isBinary>|<get-isBinary>(){}[0]
 
-        final fun copy(io.ktor.utils.io/ByteReadChannel = ...): com.monkopedia.ksrpc.channels/CallData.Binary<#A1> // com.monkopedia.ksrpc.channels/CallData.Binary.copy|copy(io.ktor.utils.io.ByteReadChannel){}[0]
+        final fun copy(com.monkopedia.ksrpc.channels/RpcBinaryData = ...): com.monkopedia.ksrpc.channels/CallData.Binary<#A1> // com.monkopedia.ksrpc.channels/CallData.Binary.copy|copy(com.monkopedia.ksrpc.channels.RpcBinaryData){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc.channels/CallData.Binary.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc.channels/CallData.Binary.hashCode|hashCode(){}[0]
-        final fun readBinary(): io.ktor.utils.io/ByteReadChannel // com.monkopedia.ksrpc.channels/CallData.Binary.readBinary|readBinary(){}[0]
+        final fun readBinary(): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc.channels/CallData.Binary.readBinary|readBinary(){}[0]
         final fun readSerialized(): #A1 // com.monkopedia.ksrpc.channels/CallData.Binary.readSerialized|readSerialized(){}[0]
         final fun toString(): kotlin/String // com.monkopedia.ksrpc.channels/CallData.Binary.toString|toString(){}[0]
     }
@@ -347,14 +356,14 @@ sealed class <#A: kotlin/Any?> com.monkopedia.ksrpc.channels/CallData { // com.m
         final fun copy(#A1 = ...): com.monkopedia.ksrpc.channels/CallData.Serialized<#A1> // com.monkopedia.ksrpc.channels/CallData.Serialized.copy|copy(1:0){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc.channels/CallData.Serialized.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc.channels/CallData.Serialized.hashCode|hashCode(){}[0]
-        final fun readBinary(): io.ktor.utils.io/ByteReadChannel // com.monkopedia.ksrpc.channels/CallData.Serialized.readBinary|readBinary(){}[0]
+        final fun readBinary(): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc.channels/CallData.Serialized.readBinary|readBinary(){}[0]
         final fun readSerialized(): #A1 // com.monkopedia.ksrpc.channels/CallData.Serialized.readSerialized|readSerialized(){}[0]
         final fun toString(): kotlin/String // com.monkopedia.ksrpc.channels/CallData.Serialized.toString|toString(){}[0]
     }
 
     final object Companion { // com.monkopedia.ksrpc.channels/CallData.Companion|null[0]
         final fun <#A2: kotlin/Any?> create(#A2): com.monkopedia.ksrpc.channels/CallData.Serialized<#A2> // com.monkopedia.ksrpc.channels/CallData.Companion.create|create(0:0){0§<kotlin.Any?>}[0]
-        final fun <#A2: kotlin/Any?> createBinary(io.ktor.utils.io/ByteReadChannel): com.monkopedia.ksrpc.channels/CallData<#A2> // com.monkopedia.ksrpc.channels/CallData.Companion.createBinary|createBinary(io.ktor.utils.io.ByteReadChannel){0§<kotlin.Any?>}[0]
+        final fun <#A2: kotlin/Any?> createBinary(com.monkopedia.ksrpc.channels/RpcBinaryData): com.monkopedia.ksrpc.channels/CallData<#A2> // com.monkopedia.ksrpc.channels/CallData.Companion.createBinary|createBinary(com.monkopedia.ksrpc.channels.RpcBinaryData){0§<kotlin.Any?>}[0]
         final fun createEndpointNotFoundError(kotlin/String): com.monkopedia.ksrpc.channels/CallData.Serialized<kotlin/String> // com.monkopedia.ksrpc.channels/CallData.Companion.createEndpointNotFoundError|createEndpointNotFoundError(kotlin.String){}[0]
         final fun createError(kotlin/String): com.monkopedia.ksrpc.channels/CallData.Serialized<kotlin/String> // com.monkopedia.ksrpc.channels/CallData.Companion.createError|createError(kotlin.String){}[0]
     }
@@ -479,9 +488,9 @@ sealed class com.monkopedia.ksrpc/MetadataValue { // com.monkopedia.ksrpc/Metada
     }
 }
 
-final object com.monkopedia.ksrpc/BinaryTransformer : com.monkopedia.ksrpc/Transformer<io.ktor.utils.io/ByteReadChannel> { // com.monkopedia.ksrpc/BinaryTransformer|null[0]
-    final suspend fun <#A1: kotlin/Any?> transform(io.ktor.utils.io/ByteReadChannel, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/BinaryTransformer.transform|transform(io.ktor.utils.io.ByteReadChannel;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
-    final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): io.ktor.utils.io/ByteReadChannel // com.monkopedia.ksrpc/BinaryTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+final object com.monkopedia.ksrpc/BinaryTransformer : com.monkopedia.ksrpc/BinaryDataTransformer, com.monkopedia.ksrpc/Transformer<com.monkopedia.ksrpc.channels/RpcBinaryData> { // com.monkopedia.ksrpc/BinaryTransformer|null[0]
+    final suspend fun <#A1: kotlin/Any?> transform(com.monkopedia.ksrpc.channels/RpcBinaryData, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/BinaryTransformer.transform|transform(com.monkopedia.ksrpc.channels.RpcBinaryData;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc/BinaryTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
 }
 
 final const val com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX // com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX|{}ENDPOINT_NOT_FOUND_PREFIX[0]

--- a/ksrpc-core/build.gradle.kts
+++ b/ksrpc-core/build.gradle.kts
@@ -24,7 +24,6 @@ ksrpcModule()
 
 kotlin {
     sourceSets["commonMain"].dependencies {
-        api(libs.ktor.io)
         api(libs.kotlinx.serialization)
         api(libs.kotlinx.serialization.json)
         api(libs.kotlinx.coroutines)

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -18,13 +18,13 @@ package com.monkopedia.ksrpc
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.ChannelId
 import com.monkopedia.ksrpc.channels.CurrentRpcCallElement
+import com.monkopedia.ksrpc.channels.RpcBinaryData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.channels.randomUuid
 import com.monkopedia.ksrpc.channels.registerHost
 import com.monkopedia.ksrpc.internal.client
 import com.monkopedia.ksrpc.internal.host
-import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -80,21 +80,31 @@ class SerializerTransformer<I>(val serializer: KSerializer<I>) : Transformer<I> 
     }
 }
 
-object BinaryTransformer : Transformer<ByteReadChannel> {
+/**
+ * Marker for transformers whose wire representation is `CallData.Binary` /
+ * [RpcBinaryData], regardless of the user-facing type they adapt. Consumers
+ * (e.g. introspection, diagnostics) should treat any implementor as "binary
+ * payload" rather than enumerating individual adapter objects.
+ */
+interface BinaryDataTransformer
+
+object BinaryTransformer :
+    Transformer<RpcBinaryData>,
+    BinaryDataTransformer {
     override suspend fun <T> transform(
-        input: ByteReadChannel,
+        input: RpcBinaryData,
         channel: SerializedService<T>
     ): CallData<T> {
-        channel.env.logger.debug("Transformer", "Serializing ByteReadChannel to CallData")
+        channel.env.logger.debug("Transformer", "Serializing RpcBinaryData to CallData")
         return CallData.createBinary(input)
     }
 
     override suspend fun <T> untransform(
         data: CallData<T>,
         channel: SerializedService<T>
-    ): ByteReadChannel {
+    ): RpcBinaryData {
         unpackError(data, channel)
-        channel.env.logger.debug("Transformer", "Deserializing ByteReadChannel to CallData")
+        channel.env.logger.debug("Transformer", "Deserializing CallData to RpcBinaryData")
         return data.readBinary()
     }
 }

--- a/ksrpc-core/src/commonMain/kotlin/channels/RpcBinaryData.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/RpcBinaryData.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.channels
+
+import com.monkopedia.ksrpc.SuspendCloseable
+
+/**
+ * Transport-agnostic binary data source. Implementations adapt user-facing
+ * types (`ByteReadChannel`, `kotlinx.io.Source`, `okio.BufferedSource`, ...)
+ * to a shape the ksrpc wire protocol can consume.
+ *
+ * Source-oriented only: in ksrpc the binary payload is always "something the
+ * receiver reads from," regardless of which side is sending.
+ */
+interface RpcBinaryData : SuspendCloseable {
+    /** Known byte length, or `null` for unknown / streaming sources. */
+    val size: Long?
+        get() = null
+
+    /**
+     * Pull all bytes from this source into [sink]. The [sink] callback may be
+     * invoked many times with different offsets / lengths into a buffer the
+     * implementation owns; callers must not retain the `bytes` array beyond
+     * the duration of the call.
+     */
+    suspend fun transferTo(sink: suspend (bytes: ByteArray, offset: Int, length: Int) -> Unit)
+}

--- a/ksrpc-core/src/commonMain/kotlin/channels/SerializedChannel.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/SerializedChannel.kt
@@ -26,8 +26,6 @@ import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.channels.ChannelClient.Companion.DEFAULT
 import com.monkopedia.ksrpc.internal.HostSerializedServiceImpl
 import com.monkopedia.ksrpc.rpcObject
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.availableForRead
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -202,20 +200,20 @@ sealed class CallData<T> private constructor() {
     abstract fun readSerialized(): T
 
     /**
-     * Get the [ByteReadChannel] for the binary data held by this call..
+     * Get the [RpcBinaryData] for the binary data held by this call.
      * If this is not binary data then throws [IllegalStateException].
      */
-    abstract fun readBinary(): ByteReadChannel
+    abstract fun readBinary(): RpcBinaryData
 
-    data class Binary<T>(private val value: ByteReadChannel) : CallData<T>() {
+    data class Binary<T>(private val value: RpcBinaryData) : CallData<T>() {
         override val isBinary: Boolean
             get() = true
 
         override fun readSerialized(): T = error("Cannot read serialization out of binary data.")
 
-        override fun readBinary(): ByteReadChannel = value
+        override fun readBinary(): RpcBinaryData = value
 
-        override fun toString(): String = "binary(${(value as? ByteReadChannel)?.availableForRead})"
+        override fun toString(): String = "binary(size=${value.size})"
     }
 
     data class Serialized<T>(private val value: T) : CallData<T>() {
@@ -224,7 +222,7 @@ sealed class CallData<T> private constructor() {
 
         override fun readSerialized(): T = value
 
-        override fun readBinary(): ByteReadChannel {
+        override fun readBinary(): RpcBinaryData {
             error("Cannot read binary data out of serialized content.")
         }
 
@@ -242,8 +240,8 @@ sealed class CallData<T> private constructor() {
         fun createEndpointNotFoundError(str: String) = Serialized(ENDPOINT_NOT_FOUND_PREFIX + str)
 
         /**
-         * Create a CallData wrapping a [ByteReadChannel] for reading binary data.
+         * Create a CallData wrapping a [RpcBinaryData] for reading binary data.
          */
-        fun <T> createBinary(binary: ByteReadChannel): CallData<T> = Binary(binary)
+        fun <T> createBinary(binary: RpcBinaryData): CallData<T> = Binary(binary)
     }
 }

--- a/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/RpcEndpointInfo.kt
+++ b/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/RpcEndpointInfo.kt
@@ -150,7 +150,7 @@ internal fun RpcMethod<*, *, *>.outputRpcDataType(): RpcDataType = outputTransfo
 internal val Transformer<*>.rpcDataType: RpcDataType
     get() {
         return when (this) {
-            BinaryTransformer -> RpcDataType.BinaryData
+            is BinaryDataTransformer -> RpcDataType.BinaryData
             is SerializerTransformer<*> -> RpcDataType.DataStructure(serializer)
             is SubserviceTransformer<*> -> RpcDataType.Service(serviceObject.serviceName)
             // Out-of-module transformers (e.g. ksrpc-flow's `FlowTransformer`) surface

--- a/ksrpc-ktor/client/build.gradle.kts
+++ b/ksrpc-ktor/client/build.gradle.kts
@@ -23,6 +23,11 @@ ksrpcModule(supportLinuxArm64 = false)
 
 kotlin {
     sourceSets["commonMain"].dependencies {
+        // ksrpc-packets carries the stopgap `ByteReadChannelTransformer` the
+        // compiler plugin emits for `ByteReadChannel` service signatures until
+        // the dedicated `ksrpc-binary-ktor` module lands (#72). Exposed as
+        // `api` so consumers of the HTTP transport don't need to declare it.
+        api(project(":ksrpc-packets"))
         implementation(libs.ktor.client)
         implementation(libs.ktor.http)
         implementation(libs.ktor.kotlinx.serialization)

--- a/ksrpc-ktor/client/src/commonMain/kotlin/HttpSerializedChannel.kt
+++ b/ksrpc-ktor/client/src/commonMain/kotlin/HttpSerializedChannel.kt
@@ -28,6 +28,8 @@ import com.monkopedia.ksrpc.channels.SerializedChannel
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.internal.ClientChannelContext
 import com.monkopedia.ksrpc.internal.SubserviceChannel
+import com.monkopedia.ksrpc.packets.asByteReadChannel
+import com.monkopedia.ksrpc.packets.asRpcBinaryData
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.accept
@@ -67,11 +69,13 @@ internal class HttpSerializedChannel(
             accept(ContentType.Application.Json)
             headers[KSRPC_BINARY] = data.isBinary.toString()
             headers[KSRPC_CHANNEL] = channelId.id
-            setBody(if (data.isBinary) data.readBinary() else data.readSerialized())
+            setBody(
+                if (data.isBinary) data.readBinary().asByteReadChannel() else data.readSerialized()
+            )
         }
         response.checkErrors()
         if (response.headers[KSRPC_BINARY]?.toBoolean() == true) {
-            return CallData.createBinary(response.body<ByteReadChannel>())
+            return CallData.createBinary(response.body<ByteReadChannel>().asRpcBinaryData())
         }
         return CallData.create(response.body<String>())
     }

--- a/ksrpc-ktor/server/build.gradle.kts
+++ b/ksrpc-ktor/server/build.gradle.kts
@@ -26,6 +26,11 @@ ksrpcModule(
 
 kotlin {
     sourceSets["commonMain"].dependencies {
+        // ksrpc-packets carries the stopgap `ByteReadChannelTransformer` the
+        // compiler plugin emits for `ByteReadChannel` service signatures until
+        // the dedicated `ksrpc-binary-ktor` module lands (#72). Exposed as
+        // `api` so consumers of the HTTP transport don't need to declare it.
+        api(project(":ksrpc-packets"))
         api(libs.ktor.server)
     }
 }

--- a/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
+++ b/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
@@ -28,6 +28,7 @@ import com.monkopedia.ksrpc.channels.ChannelId
 import com.monkopedia.ksrpc.channels.SerializedChannel
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
+import com.monkopedia.ksrpc.packets.asRpcBinaryData
 import com.monkopedia.ksrpc.serialized
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.decodeURLPart
@@ -38,7 +39,7 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.post
 import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.copyTo
+import io.ktor.utils.io.writeFully
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
@@ -88,7 +89,7 @@ fun Routing.serve(
 
 private suspend fun RoutingContext.execCall(channel: SerializedChannel<String>, method: String) {
     val content = if (call.request.headers[KSRPC_BINARY]?.toBoolean() == true) {
-        CallData.createBinary(call.receive<ByteReadChannel>())
+        CallData.createBinary(call.receive<ByteReadChannel>().asRpcBinaryData())
     } else {
         CallData.create(call.receive<String>())
     }
@@ -106,7 +107,9 @@ private suspend fun RoutingContext.execCall(channel: SerializedChannel<String>, 
         )
         call.response.headers.append(KSRPC_BINARY, "true")
         call.respondBytesWriter {
-            response.readBinary().copyTo(this)
+            response.readBinary().transferTo { bytes, offset, length ->
+                writeFully(bytes, offset, length)
+            }
         }
     } else {
         channel.env.logger.debug(

--- a/ksrpc-packets/api/ksrpc-packets.api
+++ b/ksrpc-packets/api/ksrpc-packets.api
@@ -1,3 +1,27 @@
+public final class com/monkopedia/ksrpc/packets/ByteReadChannelBinaryData : com/monkopedia/ksrpc/channels/RpcBinaryData {
+	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Long;)V
+	public synthetic fun <init> (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSize ()Ljava/lang/Long;
+	public fun transferTo (Lkotlin/jvm/functions/Function4;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/packets/ByteReadChannelBinaryDataKt {
+	public static final fun asByteReadChannel (Lcom/monkopedia/ksrpc/channels/RpcBinaryData;Lkotlinx/coroutines/CoroutineScope;)Lio/ktor/utils/io/ByteReadChannel;
+	public static synthetic fun asByteReadChannel$default (Lcom/monkopedia/ksrpc/channels/RpcBinaryData;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Lio/ktor/utils/io/ByteReadChannel;
+	public static final fun asRpcBinaryData (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Long;)Lcom/monkopedia/ksrpc/channels/RpcBinaryData;
+	public static synthetic fun asRpcBinaryData$default (Lio/ktor/utils/io/ByteReadChannel;Ljava/lang/Long;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/channels/RpcBinaryData;
+}
+
+public final class com/monkopedia/ksrpc/packets/ByteReadChannelTransformer : com/monkopedia/ksrpc/BinaryDataTransformer, com/monkopedia/ksrpc/Transformer {
+	public static final field INSTANCE Lcom/monkopedia/ksrpc/packets/ByteReadChannelTransformer;
+	public fun getHasContent ()Z
+	public fun transform (Lio/ktor/utils/io/ByteReadChannel;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
+	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/monkopedia/ksrpc/packets/internal/ConstantsKt {
 	public static final field CONTENT_LENGTH Ljava/lang/String;
 	public static final field CONTENT_TYPE Ljava/lang/String;

--- a/ksrpc-packets/api/ksrpc-packets.klib.api
+++ b/ksrpc-packets/api/ksrpc-packets.klib.api
@@ -105,7 +105,25 @@ final class com.monkopedia.ksrpc.packets.internal/PacketCallId : com.monkopedia.
     final fun toString(): kotlin/String // com.monkopedia.ksrpc.packets.internal/PacketCallId.toString|toString(){}[0]
 }
 
+final class com.monkopedia.ksrpc.packets/ByteReadChannelBinaryData : com.monkopedia.ksrpc.channels/RpcBinaryData { // com.monkopedia.ksrpc.packets/ByteReadChannelBinaryData|null[0]
+    constructor <init>(io.ktor.utils.io/ByteReadChannel, kotlin/Long? = ...) // com.monkopedia.ksrpc.packets/ByteReadChannelBinaryData.<init>|<init>(io.ktor.utils.io.ByteReadChannel;kotlin.Long?){}[0]
+
+    final val size // com.monkopedia.ksrpc.packets/ByteReadChannelBinaryData.size|{}size[0]
+        final fun <get-size>(): kotlin/Long? // com.monkopedia.ksrpc.packets/ByteReadChannelBinaryData.size.<get-size>|<get-size>(){}[0]
+
+    final suspend fun close() // com.monkopedia.ksrpc.packets/ByteReadChannelBinaryData.close|close(){}[0]
+    final suspend fun transferTo(kotlin.coroutines/SuspendFunction3<kotlin/ByteArray, kotlin/Int, kotlin/Int, kotlin/Unit>) // com.monkopedia.ksrpc.packets/ByteReadChannelBinaryData.transferTo|transferTo(kotlin.coroutines.SuspendFunction3<kotlin.ByteArray,kotlin.Int,kotlin.Int,kotlin.Unit>){}[0]
+}
+
+final object com.monkopedia.ksrpc.packets/ByteReadChannelTransformer : com.monkopedia.ksrpc/BinaryDataTransformer, com.monkopedia.ksrpc/Transformer<io.ktor.utils.io/ByteReadChannel> { // com.monkopedia.ksrpc.packets/ByteReadChannelTransformer|null[0]
+    final suspend fun <#A1: kotlin/Any?> transform(io.ktor.utils.io/ByteReadChannel, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc.packets/ByteReadChannelTransformer.transform|transform(io.ktor.utils.io.ByteReadChannel;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): io.ktor.utils.io/ByteReadChannel // com.monkopedia.ksrpc.packets/ByteReadChannelTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+}
+
 final const val com.monkopedia.ksrpc.packets.internal/CONTENT_LENGTH // com.monkopedia.ksrpc.packets.internal/CONTENT_LENGTH|{}CONTENT_LENGTH[0]
     final fun <get-CONTENT_LENGTH>(): kotlin/String // com.monkopedia.ksrpc.packets.internal/CONTENT_LENGTH.<get-CONTENT_LENGTH>|<get-CONTENT_LENGTH>(){}[0]
 final const val com.monkopedia.ksrpc.packets.internal/CONTENT_TYPE // com.monkopedia.ksrpc.packets.internal/CONTENT_TYPE|{}CONTENT_TYPE[0]
     final fun <get-CONTENT_TYPE>(): kotlin/String // com.monkopedia.ksrpc.packets.internal/CONTENT_TYPE.<get-CONTENT_TYPE>|<get-CONTENT_TYPE>(){}[0]
+
+final fun (com.monkopedia.ksrpc.channels/RpcBinaryData).com.monkopedia.ksrpc.packets/asByteReadChannel(kotlinx.coroutines/CoroutineScope = ...): io.ktor.utils.io/ByteReadChannel // com.monkopedia.ksrpc.packets/asByteReadChannel|asByteReadChannel@com.monkopedia.ksrpc.channels.RpcBinaryData(kotlinx.coroutines.CoroutineScope){}[0]
+final fun (io.ktor.utils.io/ByteReadChannel).com.monkopedia.ksrpc.packets/asRpcBinaryData(kotlin/Long? = ...): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc.packets/asRpcBinaryData|asRpcBinaryData@io.ktor.utils.io.ByteReadChannel(kotlin.Long?){}[0]

--- a/ksrpc-packets/build.gradle.kts
+++ b/ksrpc-packets/build.gradle.kts
@@ -23,6 +23,10 @@ ksrpcModule()
 
 kotlin {
     sourceSets["commonMain"].dependencies {
+        // ksrpc-packets uses ktor-io for its internal BinaryChannel. Declared
+        // here rather than relying on the (now removed) ksrpc-core transitive,
+        // until a dedicated binary adapter module ships (#72).
+        api(libs.ktor.io)
     }
     sourceSets["jvmMain"].dependencies {
 

--- a/ksrpc-packets/src/commonMain/kotlin/ByteReadChannelBinaryData.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/ByteReadChannelBinaryData.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.packets
+
+import com.monkopedia.ksrpc.channels.RpcBinaryData
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.close
+import io.ktor.utils.io.core.readBytes
+import io.ktor.utils.io.readRemaining
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Temporary stopgap bridge from ktor's [ByteReadChannel] onto the
+ * transport-agnostic [RpcBinaryData] interface. Lives here (rather than in
+ * `ksrpc-core`) so that `ksrpc-core` does not publicly depend on ktor.
+ *
+ * Will be replaced by the proper `ksrpc-binary-ktor` adapter module from
+ * issue #72.
+ */
+class ByteReadChannelBinaryData(
+    private val channel: ByteReadChannel,
+    override val size: Long? = null
+) : RpcBinaryData {
+    override suspend fun transferTo(
+        sink: suspend (bytes: ByteArray, offset: Int, length: Int) -> Unit
+    ) {
+        while (!channel.isClosedForRead) {
+            val packet = channel.readRemaining(BUFFER_SIZE).readBytes()
+            if (packet.isNotEmpty()) {
+                sink(packet, 0, packet.size)
+            }
+        }
+    }
+
+    override suspend fun close() {
+        channel.cancel(null)
+    }
+
+    internal fun unwrap(): ByteReadChannel = channel
+
+    private companion object {
+        private const val BUFFER_SIZE = 8L * 1024L
+    }
+}
+
+/**
+ * Wrap a [ByteReadChannel] as an [RpcBinaryData]. Stopgap until #72 lands.
+ */
+fun ByteReadChannel.asRpcBinaryData(size: Long? = null): RpcBinaryData =
+    ByteReadChannelBinaryData(this, size)
+
+/**
+ * Expose an [RpcBinaryData] as a [ByteReadChannel]. Unwraps directly when the
+ * underlying data is already a [ByteReadChannelBinaryData]; otherwise spins up
+ * a pump coroutine that drains [RpcBinaryData.transferTo] into a new ktor
+ * [ByteChannel].
+ *
+ * Stopgap until #72 lands.
+ */
+fun RpcBinaryData.asByteReadChannel(
+    scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+): ByteReadChannel {
+    (this as? ByteReadChannelBinaryData)?.let { return it.unwrap() }
+    val out = ByteChannel(autoFlush = true)
+    scope.launch {
+        try {
+            transferTo { bytes, offset, length ->
+                out.writeFully(bytes, offset, length)
+            }
+            out.close()
+        } catch (t: Throwable) {
+            out.close(t)
+        }
+    }
+    return out
+}

--- a/ksrpc-packets/src/commonMain/kotlin/ByteReadChannelTransformer.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/ByteReadChannelTransformer.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.packets
+
+import com.monkopedia.ksrpc.BinaryDataTransformer
+import com.monkopedia.ksrpc.BinaryTransformer
+import com.monkopedia.ksrpc.Transformer
+import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.channels.SerializedService
+import io.ktor.utils.io.ByteReadChannel
+
+/**
+ * Temporary stopgap compiler-plugin target for `ByteReadChannel` parameters.
+ * Adapts ktor's [ByteReadChannel] onto the transport-agnostic
+ * [RpcBinaryData][com.monkopedia.ksrpc.channels.RpcBinaryData] surface used by
+ * `ksrpc-core`'s [BinaryTransformer].
+ *
+ * Will be replaced by the proper `ksrpc-binary-ktor` adapter module from
+ * issue #72; until then the compiler plugin hard-wires `ByteReadChannel`
+ * signatures to this transformer so `ksrpc-core` can stay ktor-free.
+ */
+object ByteReadChannelTransformer :
+    Transformer<ByteReadChannel>,
+    BinaryDataTransformer {
+
+    override suspend fun <T> transform(
+        input: ByteReadChannel,
+        channel: SerializedService<T>
+    ): CallData<T> = BinaryTransformer.transform(input.asRpcBinaryData(), channel)
+
+    override suspend fun <T> untransform(
+        data: CallData<T>,
+        channel: SerializedService<T>
+    ): ByteReadChannel = BinaryTransformer.untransform(data, channel).asByteReadChannel()
+}

--- a/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
@@ -30,10 +30,9 @@ import com.monkopedia.ksrpc.internal.HostChannelContext
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.internal.MultiChannel
 import com.monkopedia.ksrpc.internal.SubserviceChannel
+import com.monkopedia.ksrpc.packets.asRpcBinaryData
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.close
-import io.ktor.utils.io.core.readBytes
-import io.ktor.utils.io.readRemaining
 import io.ktor.utils.io.writeFully
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CancellationException
@@ -210,11 +209,19 @@ abstract class PacketChannelBase<T>(
                 )
             )
             launch {
-                val channel = response.readBinary()
+                val binaryData = response.readBinary()
                 var id = 0
-                while (!channel.isClosedForRead) {
-                    val packet = channel.readRemaining(maxSize).readBytes()
-                    if (packet.isNotEmpty()) {
+                val packetMax = maxSize.toInt().coerceAtLeast(1)
+                binaryData.transferTo { bytes, offset, length ->
+                    if (length <= 0) return@transferTo
+                    // Re-chunk the incoming sink buffer into packets bounded by
+                    // [maxSize]. The upstream transport guarantees nothing about
+                    // per-call sizes, so split here.
+                    var remaining = length
+                    var cursor = offset
+                    while (remaining > 0) {
+                        val take = if (remaining > packetMax) packetMax else remaining
+                        val packet = bytes.copyOfRange(cursor, cursor + take)
                         send(
                             Packet(
                                 input = input,
@@ -229,6 +236,8 @@ abstract class PacketChannelBase<T>(
                                 ).readSerialized()
                             )
                         )
+                        cursor += take
+                        remaining -= take
                     }
                 }
                 send(
@@ -268,7 +277,7 @@ abstract class PacketChannelBase<T>(
     private suspend fun getCallData(packet: Packet<T>): CallData<T> = if (packet.startBinary) {
         val callData = CallData.create(packet.data)
         val decoded = env.serialization.decodeCallData(String.serializer(), callData)
-        CallData.createBinary(getByteChannel(decoded))
+        CallData.createBinary(getByteChannel(decoded).asRpcBinaryData())
     } else if (packet.binary) {
         error("Unexpected binary packet")
     } else {

--- a/ksrpc-test/build.gradle.kts
+++ b/ksrpc-test/build.gradle.kts
@@ -75,6 +75,12 @@ kotlin {
     }
     sourceSets["commonMain"].dependencies {
         implementation(project(":ksrpc-introspection"))
+        // Tests use `ByteReadChannel` directly; the dedicated `ksrpc-binary-ktor`
+        // module (#72) will bundle this transitively, but for the stopgap in #71
+        // declare it here plus `ksrpc-packets`, which carries the compiler-plugin
+        // target for `ByteReadChannel` service signatures.
+        implementation(project(":ksrpc-packets"))
+        implementation(libs.ktor.io)
     }
     sourceSets["commonTest"].dependencies {
         implementation(project(":ksrpc-core"))

--- a/ksrpc-test/src/commonTest/kotlin/BinaryTransformerTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/BinaryTransformerTest.kt
@@ -18,6 +18,8 @@ package com.monkopedia.ksrpc
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.packets.ByteReadChannelTransformer
+import com.monkopedia.ksrpc.packets.asByteReadChannel
 import io.ktor.utils.io.ByteChannel
 import kotlin.test.Test
 import kotlin.test.assertSame
@@ -43,11 +45,11 @@ class BinaryTransformerTest {
         val service = BinaryTransformerTestService(env)
         val binary = ByteChannel(autoFlush = true)
 
-        val transformed = BinaryTransformer.transform(binary, service)
-        val untransformed = BinaryTransformer.untransform(transformed, service)
+        val transformed = ByteReadChannelTransformer.transform(binary, service)
+        val untransformed = ByteReadChannelTransformer.untransform(transformed, service)
 
         assertTrue(transformed.isBinary)
-        assertSame(binary, transformed.readBinary())
+        assertSame(binary, transformed.readBinary().asByteReadChannel())
         assertSame(binary, untransformed)
     }
 }

--- a/ksrpc-test/src/commonTest/kotlin/CallDataAccessTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/CallDataAccessTest.kt
@@ -16,6 +16,8 @@
 package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.packets.asByteReadChannel
+import com.monkopedia.ksrpc.packets.asRpcBinaryData
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.core.readBytes
 import io.ktor.utils.io.readRemaining
@@ -40,10 +42,12 @@ class CallDataAccessTest {
 
     @Test
     fun binaryCallDataCanBeReadAsBinaryOnly() = runBlockingUnit {
-        val callData = CallData.createBinary<String>(ByteReadChannel("payload".encodeToByteArray()))
+        val callData = CallData.createBinary<String>(
+            ByteReadChannel("payload".encodeToByteArray()).asRpcBinaryData()
+        )
 
         assertTrue(callData.isBinary)
-        val bytes = callData.readBinary().readRemaining().readBytes()
+        val bytes = callData.readBinary().asByteReadChannel().readRemaining().readBytes()
         assertEquals("payload", bytes.decodeToString())
         assertFailsWith<IllegalStateException> {
             callData.readSerialized()

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcBinaryLimitationsTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcBinaryLimitationsTest.kt
@@ -21,6 +21,7 @@ import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcChannel
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcSerializedChannel
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcServiceWrapper
+import com.monkopedia.ksrpc.packets.asRpcBinaryData
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -65,7 +66,7 @@ class JsonRpcBinaryLimitationsTest {
             assertFailsWith<IllegalArgumentException> {
                 serializedChannel.call(
                     endpoint = "binaryEndpoint",
-                    input = CallData.createBinary(ByteReadChannel(byteArrayOf(1, 2, 3))),
+                    input = CallData.createBinary(ByteReadChannel(byteArrayOf(1, 2, 3)).asRpcBinaryData()),
                     callId = null
                 )
             }
@@ -85,7 +86,7 @@ class JsonRpcBinaryLimitationsTest {
                     endpoint: String,
                     input: CallData<String>,
                     callId: RpcCallId?
-                ): CallData<String> = CallData.createBinary(ByteReadChannel(byteArrayOf(9, 9, 9)))
+                ): CallData<String> = CallData.createBinary(ByteReadChannel(byteArrayOf(9, 9, 9)).asRpcBinaryData())
 
                 override suspend fun close() {}
 
@@ -118,7 +119,7 @@ class JsonRpcBinaryLimitationsTest {
                     endpoint: String,
                     input: CallData<String>,
                     callId: RpcCallId?
-                ): CallData<String> = CallData.createBinary(ByteReadChannel(byteArrayOf(7, 7, 7)))
+                ): CallData<String> = CallData.createBinary(ByteReadChannel(byteArrayOf(7, 7, 7)).asRpcBinaryData())
 
                 override suspend fun close() {}
 

--- a/ksrpc-test/src/commonTest/kotlin/PacketChannelBinaryOrderingTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketChannelBinaryOrderingTest.kt
@@ -16,6 +16,7 @@
 package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.channels.ChannelId
+import com.monkopedia.ksrpc.packets.asByteReadChannel
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase
 import io.ktor.utils.io.toByteArray
@@ -93,7 +94,7 @@ class PacketChannelBinaryOrderingTest {
             channel.incomingPackets.send(binaryPacket(2, ByteArray(0)))
 
             val response = responseDeferred.await()
-            val payload = response.readBinary().toByteArray()
+            val payload = response.readBinary().asByteReadChannel().toByteArray()
             assertContentEquals("firstsecond".encodeToByteArray(), payload)
         } finally {
             runCatching { channel.close() }


### PR DESCRIPTION
## Summary

First slice of the binary-stream refactor tracked in #3. Introduces a
transport-agnostic `RpcBinaryData` interface in `ksrpc-core`, reshapes
`CallData.Binary` and `BinaryTransformer` around it, and drops `ktor-io`
from `ksrpc-core`.

Closes #71.

- `ksrpc-core` now defines `RpcBinaryData` (a pull-loop `transferTo`
  binary source, `size: Long?`, `close()`). `CallData.Binary`,
  `CallData.createBinary`, and `BinaryTransformer` all operate on it.
  Introspection matches any `BinaryDataTransformer`-marker transformer.
- `ksrpc-core` drops its `api(libs.ktor.io)` dependency — core is
  fully ktor-free.
- `ksrpc-packets` hosts the stopgap `ByteReadChannel` adapter:
  `ByteReadChannelBinaryData`, `asRpcBinaryData()`,
  `asByteReadChannel()`, and the
  `ByteReadChannelTransformer : Transformer<ByteReadChannel>` that the
  compiler plugin now emits for service signatures.
- Compiler plugin points its `BINARY_TRANSFORMER` reference at the new
  `com.monkopedia.ksrpc.packets.ByteReadChannelTransformer`. Resolution
  is optional — modules with no `ByteReadChannel` signatures still
  compile without `ksrpc-packets`. Hitting a `ByteReadChannel` without
  the adapter produces a user-facing diagnostic.
- `ksrpc-ktor-client` / `ksrpc-ktor-server` now wrap through the
  stopgap helpers, and declare `ksrpc-packets` as an `api` dep so
  consumers don't need to.

The bridge is intentionally temporary — #72 (`ksrpc-binary-ktor`) will
extract it into its own adapter module once this lands, and #75 will
generalise the compiler-plugin dispatch to `kotlinx.io` / `okio` via
#73 and #74.

## BCV delta

- `ksrpc-core`: `CallData.readBinary`/`createBinary` and
  `BinaryTransformer` swap `io.ktor.utils.io.ByteReadChannel` for the
  new `com.monkopedia.ksrpc.channels.RpcBinaryData`. New interfaces:
  `RpcBinaryData` (public), `BinaryDataTransformer` marker (public).
- `ksrpc-packets`: new public surface —
  `ByteReadChannelBinaryData`, `asRpcBinaryData`, `asByteReadChannel`,
  `ByteReadChannelTransformer`.
- Other modules: unchanged public surface.

## Test plan

- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-ktor-client:jvmTest`
- [x] `./gradlew :ksrpc-ktor-server:jvmTest :ksrpc-ktor-websocket-shared:jvmTest :ksrpc-ktor-websocket-client:jvmTest :ksrpc-ktor-websocket-server:jvmTest`
- [x] `./gradlew :ksrpc-test:jvmTest` (JVM integration suite)
- [x] `./gradlew :ksrpc-test:linuxX64Test` (native integration suite; one
      known-flaky `PacketCancellationTest.cancellationBeforeResponseDoesNotLeakPendingState`
      timed out once and passed on rerun — unrelated to this change)
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test`
- [x] `./gradlew apiCheck` / `apiDump`

## Follow-ups

- #72: extract `ksrpc-binary-ktor` (move the stopgap adapter from
  `ksrpc-packets`, drop `ktor-io` from `ksrpc-packets`'s public API).
- #73, #74: adapter modules for `kotlinx.io.Source` / `okio.BufferedSource`.
- #75: compiler-plugin adapter registry + classpath detection +
  improved diagnostics covering all three user types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)