### PR TITLE
Fix #73: ksrpc-binary-kotlinx-io adapter module

### DIFF
--- a/compiler/plugin/src/main/java/FqConstants.kt
+++ b/compiler/plugin/src/main/java/FqConstants.kt
@@ -57,6 +57,18 @@ object FqConstants {
         FqName("com.monkopedia.ksrpc.binary.ktor"),
         Name.identifier("ByteReadChannelTransformer")
     )
+
+    /**
+     * Transformer emitted for methods with `kotlinx.io.Source` inputs or
+     * outputs. Lives in `ksrpc-binary-kotlinx-io`, the dedicated kotlinx.io
+     * adapter module. Resolved optionally: consumers who never use `Source`
+     * in a service signature do not need `ksrpc-binary-kotlinx-io` on their
+     * classpath.
+     */
+    val SOURCE_TRANSFORMER = ClassId(
+        FqName("com.monkopedia.ksrpc.binary.kxio"),
+        Name.identifier("SourceTransformer")
+    )
     val SUBSERVICE_TRANSFORMER = ClassId(FQPKG, Name.identifier("SubserviceTransformer"))
     val SUSPEND_CLOSEABLE = ClassId(FQPKG, Name.identifier("SuspendCloseable"))
 
@@ -70,6 +82,7 @@ object FqConstants {
     val THREAD_LOCAL = ClassId(FqName("kotlin.native.concurrent"), Name.identifier("ThreadLocal"))
 
     val BYTE_READ_CHANNEL = FqName("io.ktor.utils.io.ByteReadChannel")
+    val KOTLINX_IO_SOURCE = FqName("kotlinx.io.Source")
 
     val CREATE_STUB = Name.identifier("createStub")
     val FIND_ENDPOINT = Name.identifier("findEndpoint")

--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -43,6 +43,7 @@ class KsrpcGenerationEnvironment(
     val rpcMethod = referenceClass(FqConstants.RPC_METHOD)
     val serviceExecutor = referenceClass(FqConstants.SERVICE_EXECUTOR)
     val serializerTransformer = referenceClass(FqConstants.SERIALIZER_TRANSFORMER)
+
     // The `ByteReadChannel` adapter lives in `ksrpc-binary-ktor`. Resolved
     // optionally so modules that never declare a `ByteReadChannel` service
     // signature — including `ksrpc-core` itself, which applies this plugin —
@@ -51,6 +52,14 @@ class KsrpcGenerationEnvironment(
     // misses.
     val binaryTransformer: IrClassSymbol? =
         maybeReferenceClass(FqConstants.BYTE_READ_CHANNEL_TRANSFORMER)
+
+    // The `kotlinx.io.Source` adapter lives in `ksrpc-binary-kotlinx-io`.
+    // Same optional-resolution pattern as [binaryTransformer]: consumers
+    // that never declare a `Source` service signature don't need the
+    // adapter on their classpath; callers emit a user-error diagnostic
+    // when the lookup misses.
+    val sourceTransformer: IrClassSymbol? =
+        maybeReferenceClass(FqConstants.SOURCE_TRANSFORMER)
     val introspectionImpl: IrClassSymbol by lazy {
         referenceClass(FqConstants.INTROSPECTION_SERVICE_IMPL)
     }

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -261,11 +261,13 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         // user-declared input to check against ByteReadChannel.
         val inputType = valueParams.firstOrNull()?.type?.classFqName
         val outputType = method.returnType.classFqName
-        if (inputType == BYTE_READ_CHANNEL && outputType == BYTE_READ_CHANNEL) {
+        val binaryFqNames = setOf(BYTE_READ_CHANNEL, FqConstants.KOTLINX_IO_SOURCE)
+        if (inputType in binaryFqNames && outputType in binaryFqNames) {
             val fqName = irClass.kotlinFqName.asString()
             val methodName = method.name.asString()
             report.reportUserError(
-                "$fqName.$methodName: ByteReadChannel not yet supported for both input and output",
+                "$fqName.$methodName: binary streams not yet supported for both input and " +
+                    "output",
                 element = method
             )
             isValid = false

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -348,6 +348,26 @@ internal class GenericMethodIrBuilder(
             }
             return builder.irGetObject(binaryTransformer)
         }
+        // BINARY (kotlinx.io.Source) transformer. Emits the
+        // `SourceTransformer` from `ksrpc-binary-kotlinx-io` — same optional-
+        // resolution pattern as [BYTE_READ_CHANNEL] above.
+        if (type.classFqName == FqConstants.KOTLINX_IO_SOURCE) {
+            val sourceTransformer = env.sourceTransformer ?: run {
+                report.reportUserError(
+                    "kotlinx.io.Source in @KsMethod requires `ksrpc-binary-kotlinx-io` " +
+                        "on the compile classpath for " +
+                        "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()}",
+                    element = method
+                )
+                return builder.irCallConstructor(
+                    env.serializerTransformer.constructors.first(),
+                    listOf(context.irBuiltIns.unitType)
+                ).apply {
+                    this.type = env.serializerTransformer.typeWith(context.irBuiltIns.unitType)
+                }
+            }
+            return builder.irGetObject(sourceTransformer)
+        }
         // Flow<T> is bridged to the KsFlowService sub-service protocol. Only reachable when
         // ksrpc-flow is on the compile classpath — otherwise we fall through to the generic
         // serializer path, which will produce a clearer "no serializer" diagnostic.

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -479,13 +479,25 @@ class StubGeneration(
         declarationIrBuilder: DeclarationIrBuilder
     ) = when (outputRpcType) {
         // The paired `ObjGeneration.createTypeConverter` already emits a user
-        // diagnostic when the `ByteReadChannel` adapter is missing; by the
-        // time we reach stub generation the classpath must satisfy it.
+        // diagnostic when the underlying adapter is missing; by the time we
+        // reach stub generation the classpath must satisfy it. Dispatch on
+        // the user-facing type FQN to pick the correct transformer object.
         RpcType.BINARY -> declarationIrBuilder.irGetObject(
-            env.binaryTransformer
-                ?: reportInternal(
-                    "ByteReadChannel adapter (ksrpc-binary-ktor) missing on the compile classpath"
-                )
+            when (outputType.classFqName) {
+                FqConstants.KOTLINX_IO_SOURCE ->
+                    env.sourceTransformer
+                        ?: reportInternal(
+                            "kotlinx.io.Source adapter (ksrpc-binary-kotlinx-io) missing " +
+                                "on the compile classpath"
+                        )
+
+                else ->
+                    env.binaryTransformer
+                        ?: reportInternal(
+                            "ByteReadChannel adapter (ksrpc-binary-ktor) missing " +
+                                "on the compile classpath"
+                        )
+            }
         )
 
         RpcType.FLOW -> buildFlowTransformer(outputType, declarationIrBuilder)
@@ -630,6 +642,7 @@ class StubGeneration(
         env.flowSupported && type.classFqName == FqConstants.FLOW -> RpcType.FLOW
         type.extends(env.rpcService) -> RpcType.SERVICE
         type.classFqName == BYTE_READ_CHANNEL -> RpcType.BINARY
+        type.classFqName == FqConstants.KOTLINX_IO_SOURCE -> RpcType.BINARY
         else -> RpcType.DEFAULT
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.3.20"
 kotlin-coroutines = "1.10.2"
+kotlin-io = "0.9.0"
 kotlin-serialization = "1.10.0"
 ksp = "2.3.6"
 ktor = "3.4.1"
@@ -32,6 +33,7 @@ autoservice-annotations = { module = "com.google.auto.service:auto-service-annot
 ksrpctest = { module = "com.monkopedia.ksrpc:ksrpc-core", version.ref = "ksrpctest"}
 kotlin-compiletesting = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlin-compiletesting"}
 ktor-io = { module = "io.ktor:ktor-io", version.ref = "ktor" }
+kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlin-io" }
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlin-serialization"}
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlin-serialization"}
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines"}

--- a/ksrpc-binary-kotlinx-io/api/ksrpc-binary-kotlinx-io.api
+++ b/ksrpc-binary-kotlinx-io/api/ksrpc-binary-kotlinx-io.api
@@ -1,0 +1,23 @@
+public final class com/monkopedia/ksrpc/binary/kxio/SourceBinaryData : com/monkopedia/ksrpc/channels/RpcBinaryData {
+	public fun <init> (Lkotlinx/io/Source;Ljava/lang/Long;)V
+	public synthetic fun <init> (Lkotlinx/io/Source;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSize ()Ljava/lang/Long;
+	public fun transferTo (Lkotlin/jvm/functions/Function4;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/binary/kxio/SourceBinaryDataKt {
+	public static final fun asRpcBinaryData (Lkotlinx/io/Source;Ljava/lang/Long;)Lcom/monkopedia/ksrpc/channels/RpcBinaryData;
+	public static synthetic fun asRpcBinaryData$default (Lkotlinx/io/Source;Ljava/lang/Long;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/channels/RpcBinaryData;
+	public static final fun asSource (Lcom/monkopedia/ksrpc/channels/RpcBinaryData;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/binary/kxio/SourceTransformer : com/monkopedia/ksrpc/BinaryDataTransformer, com/monkopedia/ksrpc/Transformer {
+	public static final field INSTANCE Lcom/monkopedia/ksrpc/binary/kxio/SourceTransformer;
+	public fun getHasContent ()Z
+	public synthetic fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun transform (Lkotlinx/io/Source;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
+	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/ksrpc-binary-kotlinx-io/api/ksrpc-binary-kotlinx-io.klib.api
+++ b/ksrpc-binary-kotlinx-io/api/ksrpc-binary-kotlinx-io.klib.api
@@ -1,0 +1,25 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.monkopedia.ksrpc:ksrpc-binary-kotlinx-io>
+final class com.monkopedia.ksrpc.binary.kxio/SourceBinaryData : com.monkopedia.ksrpc.channels/RpcBinaryData { // com.monkopedia.ksrpc.binary.kxio/SourceBinaryData|null[0]
+    constructor <init>(kotlinx.io/Source, kotlin/Long? = ...) // com.monkopedia.ksrpc.binary.kxio/SourceBinaryData.<init>|<init>(kotlinx.io.Source;kotlin.Long?){}[0]
+
+    final val size // com.monkopedia.ksrpc.binary.kxio/SourceBinaryData.size|{}size[0]
+        final fun <get-size>(): kotlin/Long? // com.monkopedia.ksrpc.binary.kxio/SourceBinaryData.size.<get-size>|<get-size>(){}[0]
+
+    final suspend fun close() // com.monkopedia.ksrpc.binary.kxio/SourceBinaryData.close|close(){}[0]
+    final suspend fun transferTo(kotlin.coroutines/SuspendFunction3<kotlin/ByteArray, kotlin/Int, kotlin/Int, kotlin/Unit>) // com.monkopedia.ksrpc.binary.kxio/SourceBinaryData.transferTo|transferTo(kotlin.coroutines.SuspendFunction3<kotlin.ByteArray,kotlin.Int,kotlin.Int,kotlin.Unit>){}[0]
+}
+
+final object com.monkopedia.ksrpc.binary.kxio/SourceTransformer : com.monkopedia.ksrpc/BinaryDataTransformer, com.monkopedia.ksrpc/Transformer<kotlinx.io/Source> { // com.monkopedia.ksrpc.binary.kxio/SourceTransformer|null[0]
+    final suspend fun <#A1: kotlin/Any?> transform(kotlinx.io/Source, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc.binary.kxio/SourceTransformer.transform|transform(kotlinx.io.Source;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): kotlinx.io/Source // com.monkopedia.ksrpc.binary.kxio/SourceTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+}
+
+final fun (kotlinx.io/Source).com.monkopedia.ksrpc.binary.kxio/asRpcBinaryData(kotlin/Long? = ...): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc.binary.kxio/asRpcBinaryData|asRpcBinaryData@kotlinx.io.Source(kotlin.Long?){}[0]
+final suspend fun (com.monkopedia.ksrpc.channels/RpcBinaryData).com.monkopedia.ksrpc.binary.kxio/asSource(): kotlinx.io/Source // com.monkopedia.ksrpc.binary.kxio/asSource|asSource@com.monkopedia.ksrpc.channels.RpcBinaryData(){}[0]

--- a/ksrpc-binary-kotlinx-io/build.gradle.kts
+++ b/ksrpc-binary-kotlinx-io/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.monkopedia.ksrpc.local.ksrpcModule
+
+plugins {
+    kotlin("multiplatform")
+}
+
+ksrpcModule()
+
+kotlin {
+    sourceSets["commonMain"].dependencies {
+        api(libs.kotlinx.io)
+    }
+}

--- a/ksrpc-binary-kotlinx-io/src/commonMain/kotlin/SourceBinaryData.kt
+++ b/ksrpc-binary-kotlinx-io/src/commonMain/kotlin/SourceBinaryData.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.binary.kxio
+
+import com.monkopedia.ksrpc.channels.RpcBinaryData
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+
+/**
+ * Bridge from kotlinx.io's [Source] onto the transport-agnostic
+ * [RpcBinaryData] interface. Lives here (rather than in `ksrpc-core`) so that
+ * `ksrpc-core` does not publicly depend on kotlinx.io — consumers opt in to
+ * the kotlinx.io adapter by adding `ksrpc-binary-kotlinx-io` to their
+ * classpath.
+ */
+class SourceBinaryData(private val source: Source, override val size: Long? = null) :
+    RpcBinaryData {
+    override suspend fun transferTo(
+        sink: suspend (bytes: ByteArray, offset: Int, length: Int) -> Unit
+    ) {
+        val buffer = ByteArray(BUFFER_SIZE)
+        while (!source.exhausted()) {
+            val read = source.readAtMostTo(buffer, 0, buffer.size)
+            if (read > 0) {
+                sink(buffer, 0, read)
+            } else if (read < 0) {
+                break
+            }
+        }
+    }
+
+    override suspend fun close() {
+        source.close()
+    }
+
+    internal fun unwrap(): Source = source
+
+    private companion object {
+        private const val BUFFER_SIZE = 8 * 1024
+    }
+}
+
+/**
+ * Wrap a [Source] as an [RpcBinaryData].
+ */
+fun Source.asRpcBinaryData(size: Long? = null): RpcBinaryData = SourceBinaryData(this, size)
+
+/**
+ * Expose an [RpcBinaryData] as a kotlinx.io [Source]. Unwraps directly when
+ * the underlying data is already a [SourceBinaryData]; otherwise drains
+ * [RpcBinaryData.transferTo] into a [Buffer] (a full materialization) — a
+ * [Buffer] is itself a [Source], so callers can read from the returned value
+ * immediately.
+ *
+ * Streaming reconstruction (piping `transferTo` into a live [Source] without
+ * first materializing) is a follow-up — kotlinx.io's pipe primitives evolve
+ * between versions and the full-buffer path is adequate for RPC payloads
+ * currently flowing through ksrpc.
+ */
+suspend fun RpcBinaryData.asSource(): Source {
+    (this as? SourceBinaryData)?.let { return it.unwrap() }
+    val buffer = Buffer()
+    transferTo { bytes, offset, length ->
+        buffer.write(bytes, offset, offset + length)
+    }
+    return buffer
+}

--- a/ksrpc-binary-kotlinx-io/src/commonMain/kotlin/SourceTransformer.kt
+++ b/ksrpc-binary-kotlinx-io/src/commonMain/kotlin/SourceTransformer.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.binary.kxio
+
+import com.monkopedia.ksrpc.BinaryDataTransformer
+import com.monkopedia.ksrpc.BinaryTransformer
+import com.monkopedia.ksrpc.Transformer
+import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.io.Source
+
+/**
+ * Compiler-plugin target for `kotlinx.io.Source` parameters. Adapts
+ * kotlinx.io's [Source] onto the transport-agnostic
+ * [RpcBinaryData][com.monkopedia.ksrpc.channels.RpcBinaryData] surface used by
+ * `ksrpc-core`'s [BinaryTransformer].
+ *
+ * The compiler plugin emits this transformer for `Source` service signatures;
+ * users opt in to kotlinx.io binary support by adding
+ * `ksrpc-binary-kotlinx-io` to their compile classpath.
+ */
+object SourceTransformer :
+    Transformer<Source>,
+    BinaryDataTransformer {
+
+    override suspend fun <T> transform(input: Source, channel: SerializedService<T>): CallData<T> =
+        BinaryTransformer.transform(input.asRpcBinaryData(), channel)
+
+    override suspend fun <T> untransform(data: CallData<T>, channel: SerializedService<T>): Source =
+        BinaryTransformer.untransform(data, channel).asSource()
+}

--- a/ksrpc-test/build.gradle.kts
+++ b/ksrpc-test/build.gradle.kts
@@ -80,6 +80,8 @@ kotlin {
         // the extension helpers tests exercise.
         implementation(project(":ksrpc-packets"))
         implementation(project(":ksrpc-binary-ktor"))
+        // Exercises the kotlinx.io `Source` adapter alongside the ktor one.
+        implementation(project(":ksrpc-binary-kotlinx-io"))
     }
     sourceSets["commonTest"].dependencies {
         implementation(project(":ksrpc-core"))

--- a/ksrpc-test/src/commonTest/kotlin/SourceBinaryTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/SourceBinaryTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import kotlin.test.assertEquals
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+import kotlinx.io.readByteArray
+import kotlinx.io.readString
+
+@KsService
+interface KxioBinaryInterface : RpcService {
+    @KsMethod("/rpc")
+    suspend fun rpc(u: Pair<String, String>): Source
+
+    @KsMethod("/input")
+    suspend fun inputRpc(u: Source): String
+
+    @KsMethod("/ping")
+    suspend fun ping(input: String): String
+}
+
+private fun sourceOf(bytes: ByteArray): Source = Buffer().apply { write(bytes, 0, bytes.size) }
+
+class SourceBinaryTest :
+    RpcFunctionalityTest(
+        serializedChannel = {
+            val channel: KxioBinaryInterface = object : KxioBinaryInterface {
+                override suspend fun rpc(u: Pair<String, String>): Source {
+                    val str = "${u.first} ${u.second}"
+                    return sourceOf(str.encodeToByteArray())
+                }
+
+                override suspend fun inputRpc(u: Source): String {
+                    error("Not implemented")
+                }
+
+                override suspend fun ping(input: String): String {
+                    assertEquals("ping", input)
+                    return "pong"
+                }
+            }
+            channel.serialized(ksrpcEnvironment { })
+        },
+        verifyOnChannel = { serializedChannel ->
+            val stub = serializedChannel.toStub<KxioBinaryInterface, String>()
+            val response = stub.rpc("Hello" to "world")
+            assertEquals("Hello world", response.readString())
+            assertEquals("pong", stub.ping("ping"))
+        }
+    )
+
+class SourceBinaryInputTest :
+    RpcFunctionalityTest(
+        serializedChannel = {
+            val channel: KxioBinaryInterface = object : KxioBinaryInterface {
+                override suspend fun inputRpc(u: Source): String =
+                    "Input: " + u.readByteArray().decodeToString()
+
+                override suspend fun rpc(u: Pair<String, String>): Source {
+                    error("Not implemented")
+                }
+
+                override suspend fun ping(input: String): String {
+                    assertEquals("ping", input)
+                    return "pong"
+                }
+            }
+            channel.serialized(ksrpcEnvironment { })
+        },
+        verifyOnChannel = { serializedChannel ->
+            val stub = serializedChannel.toStub<KxioBinaryInterface, String>()
+            val response = stub.inputRpc(sourceOf("Hello world".encodeToByteArray()))
+            assertEquals("Input: Hello world", response)
+            assertEquals("pong", stub.ping("ping"))
+        }
+    )

--- a/ksrpc-test/src/commonTest/kotlin/SourceBinaryTransformerTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/SourceBinaryTransformerTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.binary.kxio.SourceTransformer
+import com.monkopedia.ksrpc.binary.kxio.asRpcBinaryData
+import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.channels.RpcCallId
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+
+private class SourceTransformerTestService(override val env: KsrpcEnvironment<String>) :
+    SerializedService<String> {
+    override suspend fun call(
+        endpoint: String,
+        input: CallData<String>,
+        callId: RpcCallId?
+    ): CallData<String> = input
+
+    override suspend fun close() = Unit
+
+    override suspend fun onClose(onClose: suspend () -> Unit) = Unit
+}
+
+class SourceBinaryTransformerTest {
+    @Test
+    fun sourceTransformerRoundTripsBuffer() = runBlockingUnit {
+        val env = ksrpcEnvironment { }
+        val service = SourceTransformerTestService(env)
+        val payload = "Hello kotlinx.io".encodeToByteArray()
+        val buffer = Buffer().apply { write(payload, 0, payload.size) }
+
+        val transformed = SourceTransformer.transform(buffer, service)
+        val untransformed = SourceTransformer.untransform(transformed, service)
+        assertEquals(payload.decodeToString(), untransformed.readByteArray().decodeToString())
+    }
+
+    @Test
+    fun asRpcBinaryDataExposesSourceBytes() = runBlockingUnit {
+        val payload = "Streaming".encodeToByteArray()
+        val src = Buffer().apply { write(payload, 0, payload.size) }
+        val collected = mutableListOf<Byte>()
+        src.asRpcBinaryData().transferTo { bytes, off, len ->
+            for (i in 0 until len) collected += bytes[off + i]
+        }
+        assertEquals(payload.toList(), collected)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include(":ksrpc-jsonrpc")
 
 include(":ksrpc-packets")
 include(":ksrpc-binary-ktor")
+include(":ksrpc-binary-kotlinx-io")
 include(":ksrpc-server")
 include(":ksrpc-sockets")
 include(":ksrpc-service-worker")


### PR DESCRIPTION
## Summary

- Introduces the `ksrpc-binary-kotlinx-io` adapter module that bridges kotlinx.io's `Source` onto the transport-agnostic `RpcBinaryData` surface in ksrpc-core. Mirrors the `ksrpc-binary-ktor` layout created in #84.
- Teaches the compiler plugin to detect `kotlinx.io.Source` in `@KsMethod` signatures and emit the paired `SourceTransformer`, with the same optional-classpath-resolution pattern used for `ByteReadChannel` (missing adapter → user diagnostic pointing at the module to add).
- Uses kotlinx.io 0.9.0. The reverse direction (`RpcBinaryData` → `Source`) materializes into a `Buffer` (itself a `Source`); streaming reconstruction is deferred because kotlinx.io's pipe primitives move between versions and the full-buffer path is adequate for current RPC payloads.
- Extraction of a shared type-to-transformer registry is deferred to #75 — the hard-coded branches are small enough that the refactor is cleaner once okio (#74) lands.

Closes #73

## Test plan

- [x] `./gradlew :ksrpc-binary-kotlinx-io:build` — compiles on jvm, linuxX64, mingwX64
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — existing plugin tests green with the new branches in ObjGeneration/StubGeneration
- [x] `./gradlew :ksrpc-test:jvmTest --tests "com.monkopedia.ksrpc.SourceBinary*Test"` — new `SourceBinaryTest`, `SourceBinaryInputTest`, `SourceBinaryTransformerTest` pass
- [x] `./gradlew :ksrpc-test:linuxX64Test --tests "com.monkopedia.ksrpc.SourceBinary*Test"` — native matrix passes
- [x] `./gradlew :ksrpc-binary-kotlinx-io:apiCheck` passes against the dumped api/klib.api
- [x] ktlint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)