### PR TITLE
Fix #75: binary adapter registry + good classpath-missing errors

### DIFF
--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -76,6 +76,31 @@ dependencies {
             )
         )
     )
+    // Locally-built `ksrpc-binary-kotlinx-io` — hosts the `SourceTransformer`
+    // the plugin emits for `kotlinx.io.Source` service signatures (issue #73).
+    testImplementation(
+        files(
+            project.rootDir.resolve(
+                "../ksrpc-binary-kotlinx-io/build/libs/" +
+                    "ksrpc-binary-kotlinx-io-jvm-0.11.1.jar"
+            )
+        )
+    )
+    // Locally-built `ksrpc-binary-okio` — hosts the `BufferedSourceTransformer`
+    // the plugin emits for `okio.BufferedSource` service signatures (issue #74).
+    testImplementation(
+        files(
+            project.rootDir.resolve(
+                "../ksrpc-binary-okio/build/libs/ksrpc-binary-okio-jvm-0.11.1.jar"
+            )
+        )
+    )
+    // User-facing binary types must be resolvable at test-compile time. The
+    // adapter jars above depend on these transitively, but BinaryAdapterDiagnosticTest
+    // intentionally strips an adapter jar from the compile classpath and still
+    // needs the user type to resolve — pull the sibling runtime jars directly.
+    testImplementation(libs.kotlinx.io)
+    testImplementation(libs.okio)
     testImplementation(kotlin("test-junit"))
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
     testImplementation(libs.kotlin.compiletesting)

--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -44,30 +44,48 @@ class KsrpcGenerationEnvironment(
     val serviceExecutor = referenceClass(FqConstants.SERVICE_EXECUTOR)
     val serializerTransformer = referenceClass(FqConstants.SERIALIZER_TRANSFORMER)
 
-    // The `ByteReadChannel` adapter lives in `ksrpc-binary-ktor`. Resolved
-    // optionally so modules that never declare a `ByteReadChannel` service
-    // signature — including `ksrpc-core` itself, which applies this plugin —
-    // compile even when `ksrpc-binary-ktor` is not on the classpath. Callers
-    // that need this symbol emit a user-error diagnostic when the lookup
-    // misses.
-    val binaryTransformer: IrClassSymbol? =
-        maybeReferenceClass(FqConstants.BYTE_READ_CHANNEL_TRANSFORMER)
+    /**
+     * Registry of binary adapters the plugin knows about. Each entry pairs a
+     * user-facing binary type (seen in an `@KsMethod` signature) with the
+     * adapter `Transformer` object that lives in a dedicated `ksrpc-binary-*`
+     * module. Adapter modules are optional on the compile classpath: a
+     * consumer that never declares one of these types in a service signature
+     * does not need the corresponding adapter jar. Call sites that depend on
+     * a specific adapter look it up via [findAdapterForUserType] /
+     * [findAdapterByFqName] and emit a user-error diagnostic pointing at
+     * [BinaryAdapter.moduleHint] when the adapter is missing.
+     *
+     * Adding a new binary adapter is a matter of adding a new entry here and
+     * the matching pair of FQN constants in [FqConstants] — no per-type
+     * branches elsewhere in the plugin.
+     */
+    internal val binaryAdapters: List<BinaryAdapter> = listOf(
+        BinaryAdapter(
+            userFqName = FqConstants.BYTE_READ_CHANNEL,
+            transformerFqName = FqConstants.BYTE_READ_CHANNEL_TRANSFORMER,
+            moduleHint = "ksrpc-binary-ktor",
+            transformerClass = maybeReferenceClass(FqConstants.BYTE_READ_CHANNEL_TRANSFORMER)
+        ),
+        BinaryAdapter(
+            userFqName = FqConstants.KOTLINX_IO_SOURCE,
+            transformerFqName = FqConstants.SOURCE_TRANSFORMER,
+            moduleHint = "ksrpc-binary-kotlinx-io",
+            transformerClass = maybeReferenceClass(FqConstants.SOURCE_TRANSFORMER)
+        ),
+        BinaryAdapter(
+            userFqName = FqConstants.OKIO_BUFFERED_SOURCE,
+            transformerFqName = FqConstants.BUFFERED_SOURCE_TRANSFORMER,
+            moduleHint = "ksrpc-binary-okio",
+            transformerClass = maybeReferenceClass(FqConstants.BUFFERED_SOURCE_TRANSFORMER)
+        )
+    )
 
-    // The `kotlinx.io.Source` adapter lives in `ksrpc-binary-kotlinx-io`.
-    // Same optional-resolution pattern as [binaryTransformer]: consumers
-    // that never declare a `Source` service signature don't need the
-    // adapter on their classpath; callers emit a user-error diagnostic
-    // when the lookup misses.
-    val sourceTransformer: IrClassSymbol? =
-        maybeReferenceClass(FqConstants.SOURCE_TRANSFORMER)
+    /** FQN lookup used by method-shape validation and dispatcher paths. */
+    internal val binaryUserFqNames: Set<FqName> = binaryAdapters.map { it.userFqName }.toSet()
 
-    // The `okio.BufferedSource` adapter lives in `ksrpc-binary-okio`.
-    // Same optional-resolution pattern as [binaryTransformer]: consumers
-    // that never declare a `BufferedSource` service signature don't need
-    // the adapter on their classpath; callers emit a user-error diagnostic
-    // when the lookup misses.
-    val bufferedSourceTransformer: IrClassSymbol? =
-        maybeReferenceClass(FqConstants.BUFFERED_SOURCE_TRANSFORMER)
+    /** Find the adapter for a user-facing [FqName], or null if unknown. */
+    internal fun findAdapterByFqName(fqName: FqName?): BinaryAdapter? =
+        fqName?.let { name -> binaryAdapters.firstOrNull { it.userFqName == name } }
     val introspectionImpl: IrClassSymbol by lazy {
         referenceClass(FqConstants.INTROSPECTION_SERVICE_IMPL)
     }
@@ -208,9 +226,23 @@ class KsrpcGenerationEnvironment(
         maybeReferenceClass(name) ?: reportInternal(
             "can't resolve $name on the compile classpath — ksrpc-core must be a dependency"
         )
-
-    private fun referenceObject(name: ClassId): IrClassSymbol =
-        context.referenceClass(name) ?: reportInternal(
-            "can't resolve $name on the compile classpath — ksrpc-core must be a dependency"
-        )
 }
+
+/**
+ * One entry in the plugin's binary-adapter registry.
+ *
+ * @property userFqName     User-facing type FQN (e.g. `io.ktor.utils.io.ByteReadChannel`).
+ * @property transformerFqName `Transformer` implementation FQN in the adapter module
+ *                          (e.g. `com.monkopedia.ksrpc.binary.ktor.ByteReadChannelTransformer`).
+ * @property moduleHint     The gradle-coordinate name of the adapter module, surfaced in the
+ *                          missing-on-classpath diagnostic (e.g. `"ksrpc-binary-ktor"`).
+ * @property transformerClass Resolved symbol for the transformer, or `null` when the adapter
+ *                          module is not on the compile classpath. Call sites check this
+ *                          and emit a user diagnostic pointing at [moduleHint].
+ */
+internal data class BinaryAdapter(
+    val userFqName: FqName,
+    val transformerFqName: ClassId,
+    val moduleHint: String,
+    val transformerClass: IrClassSymbol?
+)

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -107,7 +107,6 @@
 
 package com.monkopedia.ksrpc.plugin
 
-import com.monkopedia.ksrpc.plugin.FqConstants.BYTE_READ_CHANNEL
 import com.monkopedia.ksrpc.plugin.FqConstants.FQRPC_SERVICE
 import com.monkopedia.ksrpc.plugin.FqConstants.INTROSPECTABLE_RPC_SERVICE
 import com.monkopedia.ksrpc.plugin.FqConstants.KS_SERVICE
@@ -132,9 +131,9 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
 
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
         val classes = ServiceClass.findServices(report, moduleFragment)
-        classes.values.removeIf { !validate(it) }
-
         val env = KsrpcGenerationEnvironment(pluginContext, report)
+        classes.values.removeIf { !validate(it, env) }
+
         val transformers = listOf(
             StubGeneration(pluginContext, report, classes, env),
             ObjGeneration(pluginContext, report, classes, env),
@@ -146,14 +145,15 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         }
     }
 
-    private fun validate(cls: ServiceClass): Boolean {
+    private fun validate(cls: ServiceClass, env: KsrpcGenerationEnvironment): Boolean {
         val names = mutableSetOf<String>()
         return cls.methods.fold(validateClass(cls.irClass)) { current, serviceMethod ->
             validateMethod(
                 cls.irClass,
                 serviceMethod.function,
                 serviceMethod.ksMethodAnnotation,
-                names
+                names,
+                env
             ) && validateNotification(
                 cls.irClass,
                 serviceMethod
@@ -217,7 +217,8 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         irClass: IrClass,
         method: IrFunction,
         annotation: IrConstructorCall,
-        names: MutableSet<String>
+        names: MutableSet<String>,
+        env: KsrpcGenerationEnvironment
     ): Boolean {
         var isValid = true
         if (method.typeParameters.isNotEmpty()) {
@@ -258,14 +259,10 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         }
         // valueParams may be empty for 0-arg @KsMethod functions; the RpcMethod is
         // generated with `Unit` as the input type in that case, so there is no
-        // user-declared input to check against ByteReadChannel.
+        // user-declared input to check against a binary adapter type.
         val inputType = valueParams.firstOrNull()?.type?.classFqName
         val outputType = method.returnType.classFqName
-        val binaryFqNames = setOf(
-            BYTE_READ_CHANNEL,
-            FqConstants.KOTLINX_IO_SOURCE,
-            FqConstants.OKIO_BUFFERED_SOURCE
-        )
+        val binaryFqNames = env.binaryUserFqNames
         if (inputType in binaryFqNames && outputType in binaryFqNames) {
             val fqName = irClass.kotlinFqName.asString()
             val methodName = method.name.asString()
@@ -275,6 +272,27 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
                 element = method
             )
             isValid = false
+        }
+        // Classpath-missing diagnostic: when a @KsMethod uses a known binary type but the
+        // matching ksrpc-binary-* adapter module is not on the compile classpath, surface
+        // a user-facing error pointing at the module to add. Without this diagnostic, the
+        // compilation later fails with a confusing `reportInternal` crash deep inside
+        // StubGeneration when it tries to emit the missing transformer.
+        for (sideType in listOfNotNull(inputType, outputType)) {
+            val adapter = env.findAdapterByFqName(sideType) ?: continue
+            if (adapter.transformerClass == null) {
+                val fqName = irClass.kotlinFqName.asString()
+                val methodName = method.name.asString()
+                report.reportUserError(
+                    "@KsMethod `$fqName.$methodName` uses " +
+                        "`${adapter.userFqName.asString()}` but the adapter module is not " +
+                        "on the compile classpath. Add " +
+                        "`implementation(\"com.monkopedia:${adapter.moduleHint}\")` to " +
+                        "your dependencies.",
+                    element = method
+                )
+                isValid = false
+            }
         }
         return isValid
     }

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -326,15 +326,18 @@ internal class GenericMethodIrBuilder(
         serializerFields: List<IrField>,
         method: IrSimpleFunction
     ): IrExpression {
-        // BINARY (ByteReadChannel) transformer. Emits the
-        // `ByteReadChannelTransformer` from `ksrpc-binary-ktor` — future
-        // versions will dispatch via the adapter registry planned in #75.
-        if (type.classFqName == FqConstants.BYTE_READ_CHANNEL) {
-            val binaryTransformer = env.binaryTransformer ?: run {
+        // Binary adapters (ByteReadChannel, kotlinx.io.Source, okio.BufferedSource, ...).
+        // Dispatch via the adapter registry — see [KsrpcGenerationEnvironment.binaryAdapters].
+        val binaryAdapter = env.findAdapterByFqName(type.classFqName)
+        if (binaryAdapter != null) {
+            val transformer = binaryAdapter.transformerClass ?: run {
                 report.reportUserError(
-                    "ByteReadChannel in @KsMethod requires `ksrpc-binary-ktor` " +
-                        "on the compile classpath for " +
-                        "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()}",
+                    "@KsMethod `${cls.irClass.kotlinFqName.asString()}." +
+                        "${method.name.asString()}` uses " +
+                        "`${binaryAdapter.userFqName.asString()}` but the adapter module " +
+                        "is not on the compile classpath. Add " +
+                        "`implementation(\"com.monkopedia:${binaryAdapter.moduleHint}\")` " +
+                        "to your dependencies.",
                     element = method
                 )
                 // Fall back to `Unit` serializer transformer so codegen doesn't crash
@@ -346,48 +349,7 @@ internal class GenericMethodIrBuilder(
                     this.type = env.serializerTransformer.typeWith(context.irBuiltIns.unitType)
                 }
             }
-            return builder.irGetObject(binaryTransformer)
-        }
-        // BINARY (kotlinx.io.Source) transformer. Emits the
-        // `SourceTransformer` from `ksrpc-binary-kotlinx-io` — same optional-
-        // resolution pattern as [BYTE_READ_CHANNEL] above.
-        if (type.classFqName == FqConstants.KOTLINX_IO_SOURCE) {
-            val sourceTransformer = env.sourceTransformer ?: run {
-                report.reportUserError(
-                    "kotlinx.io.Source in @KsMethod requires `ksrpc-binary-kotlinx-io` " +
-                        "on the compile classpath for " +
-                        "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()}",
-                    element = method
-                )
-                return builder.irCallConstructor(
-                    env.serializerTransformer.constructors.first(),
-                    listOf(context.irBuiltIns.unitType)
-                ).apply {
-                    this.type = env.serializerTransformer.typeWith(context.irBuiltIns.unitType)
-                }
-            }
-            return builder.irGetObject(sourceTransformer)
-        }
-        // BINARY (okio.BufferedSource) transformer. Emits the
-        // `BufferedSourceTransformer` from `ksrpc-binary-okio` — same
-        // optional-resolution pattern as [BYTE_READ_CHANNEL] and
-        // [KOTLINX_IO_SOURCE] above.
-        if (type.classFqName == FqConstants.OKIO_BUFFERED_SOURCE) {
-            val bufferedSourceTransformer = env.bufferedSourceTransformer ?: run {
-                report.reportUserError(
-                    "okio.BufferedSource in @KsMethod requires `ksrpc-binary-okio` " +
-                        "on the compile classpath for " +
-                        "${cls.irClass.kotlinFqName.asString()}.${method.name.asString()}",
-                    element = method
-                )
-                return builder.irCallConstructor(
-                    env.serializerTransformer.constructors.first(),
-                    listOf(context.irBuiltIns.unitType)
-                ).apply {
-                    this.type = env.serializerTransformer.typeWith(context.irBuiltIns.unitType)
-                }
-            }
-            return builder.irGetObject(bufferedSourceTransformer)
+            return builder.irGetObject(transformer)
         }
         // Flow<T> is bridged to the KsFlowService sub-service protocol. Only reachable when
         // ksrpc-flow is on the compile classpath — otherwise we fall through to the generic

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -17,8 +17,6 @@
 
 package com.monkopedia.ksrpc.plugin
 
-import com.monkopedia.ksrpc.plugin.FqConstants.BYTE_READ_CHANNEL
-import com.monkopedia.ksrpc.plugin.FqConstants.INVOKE
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
@@ -480,32 +478,23 @@ class StubGeneration(
     ) = when (outputRpcType) {
         // The paired `ObjGeneration.createTypeConverter` already emits a user
         // diagnostic when the underlying adapter is missing; by the time we
-        // reach stub generation the classpath must satisfy it. Dispatch on
-        // the user-facing type FQN to pick the correct transformer object.
-        RpcType.BINARY -> declarationIrBuilder.irGetObject(
-            when (outputType.classFqName) {
-                FqConstants.KOTLINX_IO_SOURCE ->
-                    env.sourceTransformer
-                        ?: reportInternal(
-                            "kotlinx.io.Source adapter (ksrpc-binary-kotlinx-io) missing " +
-                                "on the compile classpath"
-                        )
-
-                FqConstants.OKIO_BUFFERED_SOURCE ->
-                    env.bufferedSourceTransformer
-                        ?: reportInternal(
-                            "okio.BufferedSource adapter (ksrpc-binary-okio) missing " +
-                                "on the compile classpath"
-                        )
-
-                else ->
-                    env.binaryTransformer
-                        ?: reportInternal(
-                            "ByteReadChannel adapter (ksrpc-binary-ktor) missing " +
-                                "on the compile classpath"
-                        )
-            }
-        )
+        // reach stub generation the classpath must satisfy it. Dispatch via
+        // the binary-adapter registry to pick the correct transformer object.
+        RpcType.BINARY -> {
+            val adapter = env.findAdapterByFqName(outputType.classFqName)
+                ?: reportInternal(
+                    "RpcType.BINARY fired for unknown user type " +
+                        "${outputType.classFqName?.asString()} — registry and " +
+                        "determineType must agree"
+                )
+            val transformer = adapter.transformerClass
+                ?: reportInternal(
+                    "${adapter.userFqName.asString()} adapter (${adapter.moduleHint}) " +
+                        "missing on the compile classpath — ObjGeneration should have " +
+                        "reported the user-facing diagnostic before reaching stub codegen"
+                )
+            declarationIrBuilder.irGetObject(transformer)
+        }
 
         RpcType.FLOW -> buildFlowTransformer(outputType, declarationIrBuilder)
 
@@ -648,9 +637,7 @@ class StubGeneration(
     private fun determineType(type: IrType): RpcType = when {
         env.flowSupported && type.classFqName == FqConstants.FLOW -> RpcType.FLOW
         type.extends(env.rpcService) -> RpcType.SERVICE
-        type.classFqName == BYTE_READ_CHANNEL -> RpcType.BINARY
-        type.classFqName == FqConstants.KOTLINX_IO_SOURCE -> RpcType.BINARY
-        type.classFqName == FqConstants.OKIO_BUFFERED_SOURCE -> RpcType.BINARY
+        env.findAdapterByFqName(type.classFqName) != null -> RpcType.BINARY
         else -> RpcType.DEFAULT
     }
 

--- a/compiler/plugin/src/test/java/BinaryAdapterDiagnosticTest.kt
+++ b/compiler/plugin/src/test/java/BinaryAdapterDiagnosticTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import java.io.File
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Covers the classpath-missing diagnostic emitted by
+ * [KsrpcIrGenerationExtension.validateMethod] when a service uses a known binary
+ * adapter type (ByteReadChannel, kotlinx.io.Source, okio.BufferedSource) without
+ * the matching `ksrpc-binary-*` adapter module on the compile classpath.
+ *
+ * Each test compiles a service that references the offending binary type with
+ * its adapter module stripped from the test classpath, and asserts that the
+ * plugin fails compilation with a message naming both the user-facing type FQN
+ * and the adapter module hint.
+ *
+ * Also covers the happy path: a service that uses all three binary types
+ * simultaneously with every adapter module present on the classpath compiles.
+ */
+class BinaryAdapterDiagnosticTest {
+
+    @Test
+    fun `ByteReadChannel without ksrpc-binary-ktor reports missing-adapter diagnostic`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import io.ktor.utils.io.ByteReadChannel
+
+@KsService
+interface BinaryService : RpcService {
+    @KsMethod("/download")
+    suspend fun download(name: String): ByteReadChannel
+}
+"""
+        )
+        val result = compileWithoutAdapter(source, excludeJarSubstring = "ksrpc-binary-ktor")
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("io.ktor.utils.io.ByteReadChannel") &&
+                result.messages.contains("ksrpc-binary-ktor") &&
+                result.messages.contains("not on the compile classpath"),
+            "Expected classpath-missing diagnostic naming ByteReadChannel and " +
+                "ksrpc-binary-ktor, got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `kotlinx_io Source without ksrpc-binary-kotlinx-io reports missing-adapter diagnostic`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.io.Source
+
+@KsService
+interface BinaryService : RpcService {
+    @KsMethod("/download")
+    suspend fun download(name: String): Source
+}
+"""
+        )
+        val result = compileWithoutAdapter(source, excludeJarSubstring = "ksrpc-binary-kotlinx-io")
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("kotlinx.io.Source") &&
+                result.messages.contains("ksrpc-binary-kotlinx-io") &&
+                result.messages.contains("not on the compile classpath"),
+            "Expected classpath-missing diagnostic naming kotlinx.io.Source and " +
+                "ksrpc-binary-kotlinx-io, got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `okio BufferedSource without ksrpc-binary-okio reports missing-adapter diagnostic`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import okio.BufferedSource
+
+@KsService
+interface BinaryService : RpcService {
+    @KsMethod("/download")
+    suspend fun download(name: String): BufferedSource
+}
+"""
+        )
+        val result = compileWithoutAdapter(source, excludeJarSubstring = "ksrpc-binary-okio")
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("okio.BufferedSource") &&
+                result.messages.contains("ksrpc-binary-okio") &&
+                result.messages.contains("not on the compile classpath"),
+            "Expected classpath-missing diagnostic naming okio.BufferedSource and " +
+                "ksrpc-binary-okio, got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `service mixing all three binary types compiles when every adapter is present`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.io.Source
+import okio.BufferedSource
+
+@KsService
+interface BinaryService : RpcService {
+    @KsMethod("/ktor")
+    suspend fun ktor(name: String): ByteReadChannel
+
+    @KsMethod("/kxio")
+    suspend fun kxio(name: String): Source
+
+    @KsMethod("/okio")
+    suspend fun okio(name: String): BufferedSource
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertTrue(
+            result.exitCode == KotlinCompilation.ExitCode.OK,
+            "Expected compilation to succeed when all adapter modules are present; " +
+                "messages: ${result.messages}"
+        )
+    }
+
+    /**
+     * Compile [source] with the ksrpc compiler plugin, but strip every classpath
+     * entry whose path contains [excludeJarSubstring] so the compiler cannot
+     * resolve classes from the excluded adapter module. The user-facing type
+     * (e.g. `io.ktor.utils.io.ByteReadChannel`) is resolvable because the
+     * ktor-io jar remains on the classpath transitively via `ksrpc-core` or
+     * `ksrpc-packets` — only the `ksrpc-binary-*` jar containing the Transformer
+     * is removed.
+     */
+    private fun compileWithoutAdapter(
+        source: SourceFile,
+        excludeJarSubstring: String
+    ): JvmCompilationResult {
+        val filteredClasspath = System.getProperty("java.class.path")
+            .split(File.pathSeparatorChar)
+            .map(::File)
+            .filter { entry -> !entry.absolutePath.contains(excludeJarSubstring) }
+        return KotlinCompilation().apply {
+            sources = listOf(source)
+            compilerPluginRegistrars = listOf(KsrpcComponentRegistrar())
+            inheritClassPath = false
+            classpaths = filteredClasspath
+        }.compile()
+    }
+}


### PR DESCRIPTION
Closes #75.

Final piece of the #3 binary-adapter family, stacked on #86
(`ksrpc-binary-okio`). Replaces the three hand-rolled per-type branches
in the compiler plugin with a single adapter registry, and turns the
"adapter module is not on the compile classpath" case into a proper
user-facing diagnostic rather than a `reportInternal` crash.

## Summary

- `KsrpcGenerationEnvironment.binaryAdapters` — a list of
  `BinaryAdapter(userFqName, transformerFqName, moduleHint,
  transformerClass)` entries, one per user-facing binary type the
  plugin knows about (`ByteReadChannel`, `kotlinx.io.Source`,
  `okio.BufferedSource`). Adding a new adapter is now two lines in
  `FqConstants` + one registry entry — no per-type branches anywhere
  else in the plugin.
- Call sites consolidated through `findAdapterByFqName`:
  - `StubGeneration.determineType` and `createTypeConverter`
  - `ObjGeneration.createTypeConverter`
  - `KsrpcIrGenerationExtension.validateMethod` — the binary-both-sides
    check now iterates `env.binaryUserFqNames`.
- New classpath-missing diagnostic in validation:
  ```
  @KsMethod `foo` uses `io.ktor.utils.io.ByteReadChannel` but the
  adapter module is not on the compile classpath. Add
  `implementation("com.monkopedia:ksrpc-binary-ktor")` to your
  dependencies.
  ```
  Validation runs for both generic and non-generic services, so the
  non-generic stub path no longer reaches the old `reportInternal`
  crash when an adapter is missing.
- Happy-path code generation is unchanged — same transformer-object
  get for services that were already compiling.
- The K2-native compiler plugin mirrors these sources via the
  `syncSource` task (see `compiler/native/build.gradle.kts`). The
  registry is automatically mirrored at build time; no separate
  native-side edits required.

## Tests

`BinaryAdapterDiagnosticTest` in the plugin test suite:

- Three classpath-missing tests — one per adapter module. Each compiles
  a service using the user type with that one adapter jar stripped from
  the kotlin-compile-testing classpath, and asserts the diagnostic
  fires naming the user FQN and the module hint.
- One multi-type happy-path test — a service using all three binary
  types simultaneously compiles when every adapter is present.

No new integration tests — #72/#73/#74 already covered the generated
transformer round-trips.

## Verification

- [x] `./gradlew :ksrpc-compiler-plugin:test` — 46 tests, 0 failures
      (4 new + 42 pre-existing)
- [x] `./gradlew :ksrpc-test:jvmTest` — clean
- [x] `./gradlew :ksrpc-test:linuxX64Test` — clean
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test` — clean
- [x] `./gradlew apiCheck` — clean (registry is internal to the plugin)
- [x] ktlint on touched files — clean (one pre-existing BuildConfig.kt
      finding is not introduced by this PR)

## Stack

Base: `issue-74-binary-okio` (#86). Do not squash-merge until #86
lands.