### PR TITLE
Fix #17: gate internal-package symbols with @KsrpcInternal / internal keyword

### DIFF
--- a/compiler/plugin/src/main/java/FqConstants.kt
+++ b/compiler/plugin/src/main/java/FqConstants.kt
@@ -34,7 +34,8 @@ object FqConstants {
     val INTROSPECTION_SERVICE_IMPL = ClassId(FQPKG, Name.identifier("IntrospectionServiceImpl"))
     val FQRPC_SERVICE = FqName("com.monkopedia.ksrpc.RpcService")
 
-    val SERVICE_EXECUTOR = ClassId(FQPKG, Name.identifier("ServiceExecutor"))
+    val SERVICE_EXECUTOR =
+        ClassId(FqName("com.monkopedia.ksrpc.internal"), Name.identifier("ServiceExecutor"))
     val SERIALIZER_TRANSFORMER = ClassId(FQPKG, Name.identifier("SerializerTransformer"))
 
     /**

--- a/ksrpc-bench/src/commonMain/kotlin/com/monkopedia/ksrpc/bench/PacketCodecBenchmark.kt
+++ b/ksrpc-bench/src/commonMain/kotlin/com/monkopedia/ksrpc/bench/PacketCodecBenchmark.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.bench
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.ksrpcEnvironment
 import com.monkopedia.ksrpc.packets.internal.Packet

--- a/ksrpc-bench/src/commonMain/kotlin/com/monkopedia/ksrpc/bench/PacketCodecBenchmark.kt
+++ b/ksrpc-bench/src/commonMain/kotlin/com/monkopedia/ksrpc/bench/PacketCodecBenchmark.kt
@@ -56,14 +56,17 @@ open class PacketCodecBenchmark {
         .createCallData(Packet.serializer(String.serializer()), packet)
         .readSerialized()
 
+    // Returns `Any` rather than `Packet<String>` so the kotlinx-benchmark generated
+    // descriptor classes (in `kotlinx.benchmark.generated.*`) do not need to opt in to
+    // `@KsrpcInternal` — they reference the benchmark function's return type.
     @Benchmark
-    fun decodePacket(): Packet<String> = env.serialization.decodeCallData(
+    fun decodePacket(): Any = env.serialization.decodeCallData(
         Packet.serializer(String.serializer()),
         CallData.create(encodedPacket)
     )
 
     @Benchmark
-    fun encodeThenDecodePacket(): Packet<String> = env.serialization.decodeCallData(
+    fun encodeThenDecodePacket(): Any = env.serialization.decodeCallData(
         Packet.serializer(String.serializer()),
         CallData.create(encodePacket())
     )

--- a/ksrpc-bench/src/jvmMain/kotlin/com/monkopedia/ksrpc/bench/JsonRpcHeaderBenchmark.kt
+++ b/ksrpc-bench/src/jvmMain/kotlin/com/monkopedia/ksrpc/bench/JsonRpcHeaderBenchmark.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.bench
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcTransformer
 import com.monkopedia.ksrpc.jsonrpc.internal.jsonHeader
 import com.monkopedia.ksrpc.ksrpcEnvironment

--- a/ksrpc-bench/src/jvmMain/kotlin/com/monkopedia/ksrpc/bench/JsonRpcWriterBenchmark.kt
+++ b/ksrpc-bench/src/jvmMain/kotlin/com/monkopedia/ksrpc/bench/JsonRpcWriterBenchmark.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.bench
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcRequest
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcResponse
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcTransformer

--- a/ksrpc-bench/src/jvmMain/kotlin/com/monkopedia/ksrpc/bench/MultiChannelBenchmark.kt
+++ b/ksrpc-bench/src/jvmMain/kotlin/com/monkopedia/ksrpc/bench/MultiChannelBenchmark.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.bench
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.internal.MultiChannel
 import kotlinx.benchmark.Benchmark
 import kotlinx.benchmark.Scope

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -202,17 +202,12 @@ public final class com/monkopedia/ksrpc/MethodMetadata {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/monkopedia/ksrpc/RpcChannelKt {
-	public static final field ENDPOINT_NOT_FOUND_PREFIX Ljava/lang/String;
-	public static final field ERROR_PREFIX Ljava/lang/String;
-}
-
 public class com/monkopedia/ksrpc/RpcEndpointException : java/lang/IllegalArgumentException {
 	public fun <init> (Ljava/lang/String;)V
 }
 
 public final class com/monkopedia/ksrpc/RpcMethod {
-	public fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/ServiceExecutor;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/internal/ServiceExecutor;Ljava/util/List;)V
 	public final fun call (Lcom/monkopedia/ksrpc/channels/SerializedService;Lcom/monkopedia/ksrpc/RpcService;Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/RpcCallId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun callChannel (Lcom/monkopedia/ksrpc/channels/SerializedService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun findSubserviceTransformers ()Ljava/util/List;
@@ -263,10 +258,6 @@ public final class com/monkopedia/ksrpc/SerializerTransformer : com/monkopedia/k
 	public fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
 	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract interface class com/monkopedia/ksrpc/ServiceExecutor {
-	public abstract fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/monkopedia/ksrpc/ServiceNameKt {
@@ -480,10 +471,6 @@ public abstract interface class com/monkopedia/ksrpc/channels/SingleChannelHost 
 	public abstract fun registerDefault (Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/channels/UtilsJvmKt {
-	public static final fun randomUuid ()Ljava/lang/String;
-}
-
 public final class com/monkopedia/ksrpc/internal/ClientChannelContext : kotlin/coroutines/CoroutineContext$Element {
 	public fun <init> (Lcom/monkopedia/ksrpc/channels/ChannelClient;)V
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
@@ -496,6 +483,11 @@ public final class com/monkopedia/ksrpc/internal/ClientChannelContext : kotlin/c
 
 public final class com/monkopedia/ksrpc/internal/ClientChannelContext$Key : kotlin/coroutines/CoroutineContext$Key {
 	public static final field INSTANCE Lcom/monkopedia/ksrpc/internal/ClientChannelContext$Key;
+}
+
+public final class com/monkopedia/ksrpc/internal/ErrorPrefixesKt {
+	public static final field ENDPOINT_NOT_FOUND_PREFIX Ljava/lang/String;
+	public static final field ERROR_PREFIX Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/internal/HostChannelContext : kotlin/coroutines/CoroutineContext$Element {
@@ -540,6 +532,14 @@ public final class com/monkopedia/ksrpc/internal/MultiChannel {
 	public final fun close (Ljava/util/concurrent/CancellationException;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun close$default (Lcom/monkopedia/ksrpc/internal/MultiChannel;Ljava/util/concurrent/CancellationException;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun send (Ljava/lang/String;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/internal/RandomUuidJvmKt {
+	public static final fun randomUuid ()Ljava/lang/String;
+}
+
+public abstract interface class com/monkopedia/ksrpc/internal/ServiceExecutor {
+	public abstract fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/monkopedia/ksrpc/internal/SubserviceChannel : com/monkopedia/ksrpc/channels/SerializedService {

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -127,6 +127,10 @@ abstract interface com.monkopedia.ksrpc.channels/RpcBinaryData : com.monkopedia.
 
 abstract interface com.monkopedia.ksrpc.channels/RpcCallId // com.monkopedia.ksrpc.channels/RpcCallId|null[0]
 
+abstract interface com.monkopedia.ksrpc.internal/ServiceExecutor { // com.monkopedia.ksrpc.internal/ServiceExecutor|null[0]
+    abstract suspend fun invoke(com.monkopedia.ksrpc/RpcService, kotlin/Any?): kotlin/Any? // com.monkopedia.ksrpc.internal/ServiceExecutor.invoke|invoke(com.monkopedia.ksrpc.RpcService;kotlin.Any?){}[0]
+}
+
 abstract interface com.monkopedia.ksrpc/BinaryDataTransformer // com.monkopedia.ksrpc/BinaryDataTransformer|null[0]
 
 abstract interface com.monkopedia.ksrpc/Logger { // com.monkopedia.ksrpc/Logger|null[0]
@@ -134,10 +138,6 @@ abstract interface com.monkopedia.ksrpc/Logger { // com.monkopedia.ksrpc/Logger|
     open fun error(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.error|error(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
     open fun info(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.info|info(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
     open fun warn(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.warn|warn(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
-}
-
-abstract interface com.monkopedia.ksrpc/ServiceExecutor { // com.monkopedia.ksrpc/ServiceExecutor|null[0]
-    abstract suspend fun invoke(com.monkopedia.ksrpc/RpcService, kotlin/Any?): kotlin/Any? // com.monkopedia.ksrpc/ServiceExecutor.invoke|invoke(com.monkopedia.ksrpc.RpcService;kotlin.Any?){}[0]
 }
 
 abstract interface com.monkopedia.ksrpc/SuspendCloseableObservable : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc/SuspendCloseableObservable|null[0]
@@ -149,7 +149,7 @@ abstract interface com.monkopedia.ksrpc/UnhandledMethodHandler { // com.monkoped
 }
 
 final class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?, #C: kotlin/Any?> com.monkopedia.ksrpc/RpcMethod { // com.monkopedia.ksrpc/RpcMethod|null[0]
-    constructor <init>(kotlin/String, com.monkopedia.ksrpc/Transformer<#B>, com.monkopedia.ksrpc/Transformer<#C>, com.monkopedia.ksrpc/ServiceExecutor, kotlin.collections/List<com.monkopedia.ksrpc/MethodMetadata>) // com.monkopedia.ksrpc/RpcMethod.<init>|<init>(kotlin.String;com.monkopedia.ksrpc.Transformer<1:1>;com.monkopedia.ksrpc.Transformer<1:2>;com.monkopedia.ksrpc.ServiceExecutor;kotlin.collections.List<com.monkopedia.ksrpc.MethodMetadata>){}[0]
+    constructor <init>(kotlin/String, com.monkopedia.ksrpc/Transformer<#B>, com.monkopedia.ksrpc/Transformer<#C>, com.monkopedia.ksrpc.internal/ServiceExecutor, kotlin.collections/List<com.monkopedia.ksrpc/MethodMetadata>) // com.monkopedia.ksrpc/RpcMethod.<init>|<init>(kotlin.String;com.monkopedia.ksrpc.Transformer<1:1>;com.monkopedia.ksrpc.Transformer<1:2>;com.monkopedia.ksrpc.internal.ServiceExecutor;kotlin.collections.List<com.monkopedia.ksrpc.MethodMetadata>){}[0]
 
     final val endpoint // com.monkopedia.ksrpc/RpcMethod.endpoint|{}endpoint[0]
         final fun <get-endpoint>(): kotlin/String // com.monkopedia.ksrpc/RpcMethod.endpoint.<get-endpoint>|<get-endpoint>(){}[0]
@@ -493,10 +493,10 @@ final object com.monkopedia.ksrpc/BinaryTransformer : com.monkopedia.ksrpc/Binar
     final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc/BinaryTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
 }
 
-final const val com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX // com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX|{}ENDPOINT_NOT_FOUND_PREFIX[0]
-    final fun <get-ENDPOINT_NOT_FOUND_PREFIX>(): kotlin/String // com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX.<get-ENDPOINT_NOT_FOUND_PREFIX>|<get-ENDPOINT_NOT_FOUND_PREFIX>(){}[0]
-final const val com.monkopedia.ksrpc/ERROR_PREFIX // com.monkopedia.ksrpc/ERROR_PREFIX|{}ERROR_PREFIX[0]
-    final fun <get-ERROR_PREFIX>(): kotlin/String // com.monkopedia.ksrpc/ERROR_PREFIX.<get-ERROR_PREFIX>|<get-ERROR_PREFIX>(){}[0]
+final const val com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX // com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX|{}ENDPOINT_NOT_FOUND_PREFIX[0]
+    final fun <get-ENDPOINT_NOT_FOUND_PREFIX>(): kotlin/String // com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX.<get-ENDPOINT_NOT_FOUND_PREFIX>|<get-ENDPOINT_NOT_FOUND_PREFIX>(){}[0]
+final const val com.monkopedia.ksrpc.internal/ERROR_PREFIX // com.monkopedia.ksrpc.internal/ERROR_PREFIX|{}ERROR_PREFIX[0]
+    final fun <get-ERROR_PREFIX>(): kotlin/String // com.monkopedia.ksrpc.internal/ERROR_PREFIX.<get-ERROR_PREFIX>|<get-ERROR_PREFIX>(){}[0]
 
 final val com.monkopedia.ksrpc.internal/asClient // com.monkopedia.ksrpc.internal/asClient|@com.monkopedia.ksrpc.channels.SerializedChannel<0:0>{0§<kotlin.Any?>}asClient[0]
     final fun <#A1: kotlin/Any?> (com.monkopedia.ksrpc.channels/SerializedChannel<#A1>).<get-asClient>(): com.monkopedia.ksrpc.channels/ChannelClient<#A1> // com.monkopedia.ksrpc.internal/asClient.<get-asClient>|<get-asClient>@com.monkopedia.ksrpc.channels.SerializedChannel<0:0>(){0§<kotlin.Any?>}[0]
@@ -510,7 +510,7 @@ final fun <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> (#A).com.monkop
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/onError(com.monkopedia.ksrpc/ErrorListener): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/onError|onError@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(com.monkopedia.ksrpc.ErrorListener){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/reconfigure(kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/reconfigure|reconfigure@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> com.monkopedia.ksrpc/ksrpcEnvironment(com.monkopedia.ksrpc/CallDataSerializer<#A>, kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/ksrpcEnvironment|ksrpcEnvironment(com.monkopedia.ksrpc.CallDataSerializer<0:0>;kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
-final fun com.monkopedia.ksrpc.channels/randomUuid(): kotlin/String // com.monkopedia.ksrpc.channels/randomUuid|randomUuid(){}[0]
+final fun com.monkopedia.ksrpc.internal/randomUuid(): kotlin/String // com.monkopedia.ksrpc.internal/randomUuid|randomUuid(){}[0]
 final fun com.monkopedia.ksrpc/ksrpcEnvironment(kotlinx.serialization/StringFormat = ..., kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<kotlin/String>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<kotlin/String> // com.monkopedia.ksrpc/ksrpcEnvironment|ksrpcEnvironment(kotlinx.serialization.StringFormat;kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<kotlin.String>,kotlin.Unit>){}[0]
 final fun com.monkopedia.ksrpc/resolveSerializerOrThrow(kotlin.reflect/KType, kotlin/String): kotlinx.serialization/KSerializer<kotlin/Any?> // com.monkopedia.ksrpc/resolveSerializerOrThrow|resolveSerializerOrThrow(kotlin.reflect.KType;kotlin.String){}[0]
 final fun com.monkopedia.ksrpc/serviceNameFor(kotlin.reflect/KClass<*>): kotlin/String // com.monkopedia.ksrpc/serviceNameFor|serviceNameFor(kotlin.reflect.KClass<*>){}[0]

--- a/ksrpc-core/src/commonMain/kotlin/KsrpcEnvironment.kt
+++ b/ksrpc-core/src/commonMain/kotlin/KsrpcEnvironment.kt
@@ -19,6 +19,8 @@ package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.internal.ENDPOINT_NOT_FOUND_PREFIX
+import com.monkopedia.ksrpc.internal.ERROR_PREFIX
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope

--- a/ksrpc-core/src/commonMain/kotlin/KsrpcEnvironment.kt
+++ b/ksrpc-core/src/commonMain/kotlin/KsrpcEnvironment.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope

--- a/ksrpc-core/src/commonMain/kotlin/RpcChannel.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcChannel.kt
@@ -15,6 +15,8 @@
  */
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+
 /**
  * Interface used for handling any errors that occur during hosting.
  */
@@ -30,5 +32,8 @@ fun interface ErrorListener {
 
 expect val Throwable.asString: String
 
+@KsrpcInternal
 const val ERROR_PREFIX = "ERROR:"
+
+@KsrpcInternal
 const val ENDPOINT_NOT_FOUND_PREFIX = "ENDPOINT_NOT_FOUND:"

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -24,10 +24,11 @@ import com.monkopedia.ksrpc.channels.CurrentRpcCallElement
 import com.monkopedia.ksrpc.channels.RpcBinaryData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
-import com.monkopedia.ksrpc.channels.randomUuid
 import com.monkopedia.ksrpc.channels.registerHost
+import com.monkopedia.ksrpc.internal.ServiceExecutor
 import com.monkopedia.ksrpc.internal.client
 import com.monkopedia.ksrpc.internal.host
+import com.monkopedia.ksrpc.internal.randomUuid
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -129,17 +130,6 @@ class SubserviceTransformer<T : RpcService>(private val serviceObj: RpcObject<T>
         channel.env.logger.info("Transformer", "Deserializing CallData($serviceId) to Stub")
         return serviceObj.createStub(client.wrapChannel(ChannelId(serviceId)))
     }
-}
-
-/**
- * Plumbing interface emitted by the ksrpc compiler plugin to adapt reflective
- * invocation of generated service implementations. Not part of the supported
- * API surface — user code should never implement or directly call this, and
- * the plugin emits the implementation automatically.
- */
-@KsrpcInternal
-interface ServiceExecutor {
-    suspend fun invoke(service: RpcService, input: Any?): Any?
 }
 
 /**

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.ChannelId
 import com.monkopedia.ksrpc.channels.CurrentRpcCallElement
@@ -128,6 +131,13 @@ class SubserviceTransformer<T : RpcService>(private val serviceObj: RpcObject<T>
     }
 }
 
+/**
+ * Plumbing interface emitted by the ksrpc compiler plugin to adapt reflective
+ * invocation of generated service implementations. Not part of the supported
+ * API surface — user code should never implement or directly call this, and
+ * the plugin emits the implementation automatically.
+ */
+@KsrpcInternal
 interface ServiceExecutor {
     suspend fun invoke(service: RpcService, input: Any?): Any?
 }

--- a/ksrpc-core/src/commonMain/kotlin/channels/SerializedChannel.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/SerializedChannel.kt
@@ -17,8 +17,6 @@
 
 package com.monkopedia.ksrpc.channels
 
-import com.monkopedia.ksrpc.ENDPOINT_NOT_FOUND_PREFIX
-import com.monkopedia.ksrpc.ERROR_PREFIX
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcMethod
 import com.monkopedia.ksrpc.RpcObject
@@ -27,6 +25,8 @@ import com.monkopedia.ksrpc.SuspendCloseableObservable
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.ChannelClient.Companion.DEFAULT
+import com.monkopedia.ksrpc.internal.ENDPOINT_NOT_FOUND_PREFIX
+import com.monkopedia.ksrpc.internal.ERROR_PREFIX
 import com.monkopedia.ksrpc.internal.HostSerializedServiceImpl
 import com.monkopedia.ksrpc.rpcObject
 import kotlin.coroutines.CoroutineContext
@@ -186,9 +186,6 @@ interface SerializedService<T> :
         callId: RpcCallId?
     ): CallData<T> = call(endpoint.endpoint, input, callId)
 }
-
-@KsrpcInternal
-expect fun randomUuid(): String
 
 /**
  * Wrapper around data being serialized through calls.

--- a/ksrpc-core/src/commonMain/kotlin/channels/SerializedChannel.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/SerializedChannel.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.channels
 
 import com.monkopedia.ksrpc.ENDPOINT_NOT_FOUND_PREFIX
@@ -23,6 +25,7 @@ import com.monkopedia.ksrpc.RpcObject
 import com.monkopedia.ksrpc.RpcService
 import com.monkopedia.ksrpc.SuspendCloseableObservable
 import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.ChannelClient.Companion.DEFAULT
 import com.monkopedia.ksrpc.internal.HostSerializedServiceImpl
 import com.monkopedia.ksrpc.rpcObject
@@ -184,6 +187,7 @@ interface SerializedService<T> :
     ): CallData<T> = call(endpoint.endpoint, input, callId)
 }
 
+@KsrpcInternal
 expect fun randomUuid(): String
 
 /**

--- a/ksrpc-core/src/commonMain/kotlin/internal/ChannelContext.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/ChannelContext.kt
@@ -15,12 +15,14 @@
  */
 package com.monkopedia.ksrpc.internal
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.ChannelClient
 import com.monkopedia.ksrpc.channels.ChannelHost
 import com.monkopedia.ksrpc.internal.ClientChannelContext.Key
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 
+@KsrpcInternal
 class HostChannelContext<T>(val channel: ChannelHost<T>) : CoroutineContext.Element {
     override val key: CoroutineContext.Key<*>
         get() = Key
@@ -28,6 +30,7 @@ class HostChannelContext<T>(val channel: ChannelHost<T>) : CoroutineContext.Elem
     object Key : CoroutineContext.Key<HostChannelContext<*>>
 }
 
+@KsrpcInternal
 class ClientChannelContext<T>(val channel: ChannelClient<T>) : CoroutineContext.Element {
     override val key: CoroutineContext.Key<*>
         get() = Key
@@ -35,11 +38,13 @@ class ClientChannelContext<T>(val channel: ChannelClient<T>) : CoroutineContext.
     object Key : CoroutineContext.Key<ClientChannelContext<*>>
 }
 
+@OptIn(KsrpcInternal::class)
 internal suspend fun <T> host(): ChannelHost<T>? {
     @Suppress("UNCHECKED_CAST")
     return coroutineContext[HostChannelContext.Key]?.channel as ChannelHost<T>?
 }
 
+@OptIn(KsrpcInternal::class)
 internal suspend fun <T> client(): ChannelClient<T>? {
     @Suppress("UNCHECKED_CAST")
     return coroutineContext[Key]?.channel as ChannelClient<T>?

--- a/ksrpc-core/src/commonMain/kotlin/internal/ErrorPrefixes.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/ErrorPrefixes.kt
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.monkopedia.ksrpc.channels
+package com.monkopedia.ksrpc.internal
 
-import com.aventrix.jnanoid.jnanoid.NanoIdUtils
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 
 @KsrpcInternal
-actual fun randomUuid(): String = NanoIdUtils.randomNanoId()
+const val ERROR_PREFIX = "ERROR:"
+
+@KsrpcInternal
+const val ENDPOINT_NOT_FOUND_PREFIX = "ENDPOINT_NOT_FOUND:"

--- a/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
@@ -23,6 +25,7 @@ import com.monkopedia.ksrpc.RpcService
 import com.monkopedia.ksrpc.SuspendCloseable
 import com.monkopedia.ksrpc.TrackingService
 import com.monkopedia.ksrpc.UnhandledMethodHandler
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.asString
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.ChannelClient
@@ -38,6 +41,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.serializer
 
+@KsrpcInternal
 class HostSerializedChannelImpl<T>(
     override val env: KsrpcEnvironment<T>,
     channelContext: CoroutineContext? = null
@@ -137,6 +141,7 @@ class HostSerializedChannelImpl<T>(
         get() = (this as? HostSerializedServiceImpl<*, T>)?.service as? TrackingService
 }
 
+@KsrpcInternal
 val <T> SerializedChannel<T>.asClient: ChannelClient<T>
     get() = object : ChannelClient<T>, SerializedChannel<T> by this {
         override suspend fun wrapChannel(channelId: ChannelId): SerializedService<T> {

--- a/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
@@ -34,7 +34,6 @@ import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedChannel
 import com.monkopedia.ksrpc.channels.SerializedService
-import com.monkopedia.ksrpc.channels.randomUuid
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job

--- a/ksrpc-core/src/commonMain/kotlin/internal/MultiChannel.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/MultiChannel.kt
@@ -15,6 +15,7 @@
  */
 package com.monkopedia.ksrpc.internal
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -22,6 +23,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+@KsrpcInternal
 class MultiChannel<T> {
 
     private var isClosed: Boolean = false

--- a/ksrpc-core/src/commonMain/kotlin/internal/RandomUuid.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/RandomUuid.kt
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.monkopedia.ksrpc.channels
+package com.monkopedia.ksrpc.internal
 
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
-import nanoid.NanoIdUtils
 
 @KsrpcInternal
-actual fun randomUuid(): String = NanoIdUtils.randomNanoId()
+expect fun randomUuid(): String

--- a/ksrpc-core/src/commonMain/kotlin/internal/ServiceExecutor.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/ServiceExecutor.kt
@@ -13,19 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.monkopedia.ksrpc
+package com.monkopedia.ksrpc.internal
+
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 
 /**
- * Interface used for handling any errors that occur during hosting.
+ * Plumbing interface emitted by the ksrpc compiler plugin to adapt reflective
+ * invocation of generated service implementations. Not part of the supported
+ * API surface — user code should never implement or directly call this, and
+ * the plugin emits the implementation automatically.
  */
-fun interface ErrorListener {
-    /**
-     * Called when an error has occured during a hosted (incoming) call.
-     *
-     * The error will also be passed back to the client, this is purely for
-     * monitoring purposes.
-     */
-    fun onError(t: Throwable)
+@KsrpcInternal
+interface ServiceExecutor {
+    suspend fun invoke(service: RpcService, input: Any?): Any?
 }
-
-expect val Throwable.asString: String

--- a/ksrpc-core/src/commonMain/kotlin/internal/SubserviceChannel.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/SubserviceChannel.kt
@@ -16,6 +16,7 @@
 package com.monkopedia.ksrpc.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.ChannelClient
 import com.monkopedia.ksrpc.channels.ChannelId
@@ -23,6 +24,7 @@ import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
 import kotlin.coroutines.CoroutineContext
 
+@KsrpcInternal
 class SubserviceChannel<T>(
     private val baseChannel: ChannelClient<T>,
     private val serviceId: ChannelId

--- a/ksrpc-core/src/jsMain/kotlin/channels/UtilsJs.kt
+++ b/ksrpc-core/src/jsMain/kotlin/channels/UtilsJs.kt
@@ -15,6 +15,8 @@
  */
 package com.monkopedia.ksrpc.channels
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import nanoid.nanoid
 
+@KsrpcInternal
 actual fun randomUuid(): String = nanoid()

--- a/ksrpc-core/src/jsMain/kotlin/internal/RandomUuidJs.kt
+++ b/ksrpc-core/src/jsMain/kotlin/internal/RandomUuidJs.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.monkopedia.ksrpc.channels
+package com.monkopedia.ksrpc.internal
 
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import nanoid.nanoid

--- a/ksrpc-core/src/jvmMain/kotlin/channels/UtilsJvm.kt
+++ b/ksrpc-core/src/jvmMain/kotlin/channels/UtilsJvm.kt
@@ -16,5 +16,7 @@
 package com.monkopedia.ksrpc.channels
 
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 
+@KsrpcInternal
 actual fun randomUuid(): String = NanoIdUtils.randomNanoId()

--- a/ksrpc-core/src/jvmMain/kotlin/internal/RandomUuidJvm.kt
+++ b/ksrpc-core/src/jvmMain/kotlin/internal/RandomUuidJvm.kt
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.monkopedia.ksrpc
+package com.monkopedia.ksrpc.internal
 
-/**
- * Interface used for handling any errors that occur during hosting.
- */
-fun interface ErrorListener {
-    /**
-     * Called when an error has occured during a hosted (incoming) call.
-     *
-     * The error will also be passed back to the client, this is purely for
-     * monitoring purposes.
-     */
-    fun onError(t: Throwable)
-}
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 
-expect val Throwable.asString: String
+@KsrpcInternal
+actual fun randomUuid(): String = NanoIdUtils.randomNanoId()

--- a/ksrpc-core/src/nativeMain/kotlin/channels/UtilsNative.kt
+++ b/ksrpc-core/src/nativeMain/kotlin/channels/UtilsNative.kt
@@ -15,6 +15,8 @@
  */
 package com.monkopedia.ksrpc.channels
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import nanoid.NanoIdUtils
 
+@KsrpcInternal
 actual fun randomUuid(): String = NanoIdUtils.randomNanoId()

--- a/ksrpc-core/src/nativeMain/kotlin/internal/RandomUuidNative.kt
+++ b/ksrpc-core/src/nativeMain/kotlin/internal/RandomUuidNative.kt
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.monkopedia.ksrpc
+package com.monkopedia.ksrpc.internal
 
-/**
- * Interface used for handling any errors that occur during hosting.
- */
-fun interface ErrorListener {
-    /**
-     * Called when an error has occured during a hosted (incoming) call.
-     *
-     * The error will also be passed back to the client, this is purely for
-     * monitoring purposes.
-     */
-    fun onError(t: Throwable)
-}
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import nanoid.NanoIdUtils
 
-expect val Throwable.asString: String
+@KsrpcInternal
+actual fun randomUuid(): String = NanoIdUtils.randomNanoId()

--- a/ksrpc-core/src/wasmJsMain/kotlin/channels/UtilsJs.kt
+++ b/ksrpc-core/src/wasmJsMain/kotlin/channels/UtilsJs.kt
@@ -15,6 +15,8 @@
  */
 package com.monkopedia.ksrpc.channels
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import nanoid.nanoid
 
+@KsrpcInternal
 actual fun randomUuid(): String = nanoid()

--- a/ksrpc-core/src/wasmJsMain/kotlin/internal/RandomUuidJs.kt
+++ b/ksrpc-core/src/wasmJsMain/kotlin/internal/RandomUuidJs.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.monkopedia.ksrpc.channels
+package com.monkopedia.ksrpc.internal
 
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import nanoid.nanoid

--- a/ksrpc-flow/api/ksrpc-flow.api
+++ b/ksrpc-flow/api/ksrpc-flow.api
@@ -40,7 +40,7 @@ public final class com/monkopedia/ksrpc/flow/KsCollectionToken$Stub : com/monkop
 	public final synthetic fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/flow/KsCollectionToken$Stub$AnonymousCancelCollection : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/flow/KsCollectionToken$Stub$AnonymousCancelCollection : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -85,17 +85,17 @@ public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub : com/monkoped
 	public final synthetic fun onItem (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnComplete : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnComplete : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnError : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnError : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnItem : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub$AnonymousOnItem : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -137,7 +137,7 @@ public final class com/monkopedia/ksrpc/flow/KsFlowService$Stub : com/monkopedia
 	public final synthetic fun startCollection (Lcom/monkopedia/ksrpc/flow/KsFlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/flow/KsFlowService$Stub$AnonymousStartCollection : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/flow/KsFlowService$Stub$AnonymousStartCollection : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/ksrpc-introspection/api/ksrpc-introspection.api
+++ b/ksrpc-introspection/api/ksrpc-introspection.api
@@ -45,22 +45,22 @@ public final class com/monkopedia/ksrpc/IntrospectionService$Stub : com/monkoped
 	public final synthetic fun getServiceName (Lkotlin/Unit;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/IntrospectionService$Stub$AnonymousGetEndpointInfo : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/IntrospectionService$Stub$AnonymousGetEndpointInfo : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/IntrospectionService$Stub$AnonymousGetEndpoints : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/IntrospectionService$Stub$AnonymousGetEndpoints : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/IntrospectionService$Stub$AnonymousGetIntrospectionFor : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/IntrospectionService$Stub$AnonymousGetIntrospectionFor : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/IntrospectionService$Stub$AnonymousGetServiceName : com/monkopedia/ksrpc/ServiceExecutor {
+public final class com/monkopedia/ksrpc/IntrospectionService$Stub$AnonymousGetServiceName : com/monkopedia/ksrpc/internal/ServiceExecutor {
 	public fun <init> ()V
 	public final synthetic fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/ksrpc-jni/src/jvmMain/kotlin/com/monkopedia/ksrpc/jni/JniConnection.kt
+++ b/ksrpc-jni/src/jvmMain/kotlin/com/monkopedia/ksrpc/jni/JniConnection.kt
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.jni
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase

--- a/ksrpc-jni/src/nativeMain/kotlin/com/monkopedia/ksrpc/jni/NativeConnection.kt
+++ b/ksrpc-jni/src/nativeMain/kotlin/com/monkopedia/ksrpc/jni/NativeConnection.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+@file:OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class, KsrpcInternal::class)
 
 package com.monkopedia.ksrpc.jni
 
@@ -27,6 +27,7 @@ import com.monkopedia.jnitest.initThread
 import com.monkopedia.jnitest.threadEnv
 import com.monkopedia.jnitest.threadJni
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcChannel.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcChannel.kt
@@ -17,11 +17,13 @@ package com.monkopedia.ksrpc.jsonrpc.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment.Element
 import com.monkopedia.ksrpc.SuspendCloseable
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 
+@KsrpcInternal
 interface JsonRpcChannel :
     SuspendCloseable,
     Element<String> {
@@ -33,6 +35,7 @@ interface JsonRpcChannel :
     ): JsonElement?
 }
 
+@KsrpcInternal
 @Serializable
 data class JsonRpcRequest(
     @Required
@@ -42,6 +45,7 @@ data class JsonRpcRequest(
     val id: JsonPrimitive? = null
 )
 
+@KsrpcInternal
 @Serializable
 data class JsonRpcResponse(
     @Required
@@ -51,6 +55,7 @@ data class JsonRpcResponse(
     val id: JsonPrimitive? = null
 )
 
+@KsrpcInternal
 @Serializable
 data class JsonRpcError(val code: Int, val message: String, val data: JsonElement? = null) {
     companion object {

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcChannels.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcChannels.kt
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.jsonrpc
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.SingleChannelConnection
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcWriterBase
 import com.monkopedia.ksrpc.jsonrpc.internal.jsonHeader

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcSerializedChannel.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcSerializedChannel.kt
@@ -17,6 +17,7 @@ package com.monkopedia.ksrpc.jsonrpc.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcMethod
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
@@ -29,6 +30,7 @@ import kotlinx.serialization.json.JsonElement
 private val RpcMethod<*, *, *>.isNotification: Boolean
     get() = metadata("com.monkopedia.ksrpc.annotation.KsNotification") != null
 
+@KsrpcInternal
 class JsonRpcSerializedChannel(
     override val context: CoroutineContext,
     private val channel: JsonRpcChannel,

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcServiceWrapper.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcServiceWrapper.kt
@@ -16,6 +16,7 @@
 package com.monkopedia.ksrpc.jsonrpc.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment.Element
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.jsonrpc.JsonRpcCallId
@@ -25,6 +26,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 
+@KsrpcInternal
 class JsonRpcServiceWrapper(private val channel: SerializedService<String>) :
     JsonRpcChannel,
     Element<String> by channel {

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.jsonrpc.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.packets.internal.CONTENT_LENGTH
 import com.monkopedia.ksrpc.packets.internal.CONTENT_TYPE
 import com.monkopedia.ksrpc.sockets.internal.appendLine
@@ -30,8 +33,10 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
+@KsrpcInternal
 const val DEFAULT_CONTENT_TYPE = "application/vscode-jsonrpc; charset=utf-8"
 
+@KsrpcInternal
 abstract class JsonRpcTransformer {
     abstract val isOpen: Boolean
 
@@ -40,6 +45,7 @@ abstract class JsonRpcTransformer {
     abstract fun close(cause: Throwable?)
 }
 
+@KsrpcInternal
 fun Pair<ByteReadChannel, ByteWriteChannel>.jsonHeader(
     env: KsrpcEnvironment<String>
 ): JsonRpcTransformer = JsonRpcHeader(env, first, second)
@@ -100,6 +106,7 @@ internal class JsonRpcHeader(
     }
 }
 
+@KsrpcInternal
 fun Pair<ByteReadChannel, ByteWriteChannel>.jsonLine(
     env: KsrpcEnvironment<String>
 ): JsonRpcTransformer = JsonRpcLine(env, first, second)

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.jsonrpc.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.asString
 import com.monkopedia.ksrpc.channels.CancellationSupport
 import com.monkopedia.ksrpc.channels.RpcCallId
@@ -42,6 +45,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
 
+@KsrpcInternal
 class JsonRpcWriterBase(
     private val scope: CoroutineScope,
     private val context: CoroutineContext,

--- a/ksrpc-jsonrpc/src/jvmMain/kotlin/JsonInputOutputStreams.kt
+++ b/ksrpc-jsonrpc/src/jvmMain/kotlin/JsonInputOutputStreams.kt
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.jsonrpc
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.SingleChannelConnection
 import com.monkopedia.ksrpc.sockets.internal.swallow
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel

--- a/ksrpc-ktor/client/src/commonMain/kotlin/HttpSerializedChannel.kt
+++ b/ksrpc-ktor/client/src/commonMain/kotlin/HttpSerializedChannel.kt
@@ -17,8 +17,6 @@
 
 package com.monkopedia.ksrpc.ktor.internal
 
-import com.monkopedia.ksrpc.ENDPOINT_NOT_FOUND_PREFIX
-import com.monkopedia.ksrpc.ERROR_PREFIX
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcEndpointException
 import com.monkopedia.ksrpc.RpcFailure
@@ -32,6 +30,8 @@ import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedChannel
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.internal.ClientChannelContext
+import com.monkopedia.ksrpc.internal.ENDPOINT_NOT_FOUND_PREFIX
+import com.monkopedia.ksrpc.internal.ERROR_PREFIX
 import com.monkopedia.ksrpc.internal.SubserviceChannel
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body

--- a/ksrpc-ktor/client/src/commonMain/kotlin/HttpSerializedChannel.kt
+++ b/ksrpc-ktor/client/src/commonMain/kotlin/HttpSerializedChannel.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.ktor.internal
 
 import com.monkopedia.ksrpc.ENDPOINT_NOT_FOUND_PREFIX
@@ -20,6 +22,7 @@ import com.monkopedia.ksrpc.ERROR_PREFIX
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcEndpointException
 import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.binary.ktor.asByteReadChannel
 import com.monkopedia.ksrpc.binary.ktor.asRpcBinaryData
 import com.monkopedia.ksrpc.channels.CallData

--- a/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
+++ b/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
@@ -17,8 +17,6 @@
 
 package com.monkopedia.ksrpc.ktor
 
-import com.monkopedia.ksrpc.ENDPOINT_NOT_FOUND_PREFIX
-import com.monkopedia.ksrpc.ERROR_PREFIX
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcEndpointException
 import com.monkopedia.ksrpc.RpcFailure
@@ -31,6 +29,8 @@ import com.monkopedia.ksrpc.channels.ChannelClient
 import com.monkopedia.ksrpc.channels.ChannelId
 import com.monkopedia.ksrpc.channels.SerializedChannel
 import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.internal.ENDPOINT_NOT_FOUND_PREFIX
+import com.monkopedia.ksrpc.internal.ERROR_PREFIX
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.serialized
 import io.ktor.http.HttpStatusCode

--- a/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
+++ b/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.ktor
 
 import com.monkopedia.ksrpc.ENDPOINT_NOT_FOUND_PREFIX
@@ -21,6 +23,7 @@ import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcEndpointException
 import com.monkopedia.ksrpc.RpcFailure
 import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.asString
 import com.monkopedia.ksrpc.binary.ktor.asRpcBinaryData
 import com.monkopedia.ksrpc.channels.CallData

--- a/ksrpc-ktor/websocket/client/src/commonMain/kotlin/WebsocketClientChannels.kt
+++ b/ksrpc-ktor/websocket/client/src/commonMain/kotlin/WebsocketClientChannels.kt
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.ktor.websocket
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.ktor.websocket.internal.WebsocketPacketChannel
 import io.ktor.client.HttpClient

--- a/ksrpc-ktor/websocket/server/src/commonMain/kotlin/WebsocketServe.kt
+++ b/ksrpc-ktor/websocket/server/src/commonMain/kotlin/WebsocketServe.kt
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.ktor.websocket
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.channels.connect
 import com.monkopedia.ksrpc.ktor.websocket.internal.WebsocketPacketChannel

--- a/ksrpc-ktor/websocket/shared/src/commonMain/kotlin/WebsocketPacketChannel.kt
+++ b/ksrpc-ktor/websocket/shared/src/commonMain/kotlin/WebsocketPacketChannel.kt
@@ -16,6 +16,7 @@
 package com.monkopedia.ksrpc.ktor.websocket.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
@@ -27,6 +28,7 @@ import io.ktor.websocket.close
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.Json
 
+@KsrpcInternal
 @OptIn(InternalAPI::class)
 class WebsocketPacketChannel(
     scope: CoroutineScope,

--- a/ksrpc-ktor/websocket/shared/src/jvmTest/kotlin/com/monkopedia/ksrpc/ktor/websocket/internal/WebsocketPacketChannelTypeReferenceTest.kt
+++ b/ksrpc-ktor/websocket/shared/src/jvmTest/kotlin/com/monkopedia/ksrpc/ktor/websocket/internal/WebsocketPacketChannelTypeReferenceTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.ktor.websocket.internal
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import kotlin.test.Test
 import kotlin.test.assertNull
 

--- a/ksrpc-packets/src/commonMain/kotlin/Constants.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/Constants.kt
@@ -15,6 +15,12 @@
  */
 package com.monkopedia.ksrpc.packets.internal
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+
+@KsrpcInternal
 const val CONTENT_LENGTH = "Content-Length"
+
+@KsrpcInternal
 const val CONTENT_TYPE = "Content-Type"
+
 internal const val METHOD = "Method"

--- a/ksrpc-packets/src/commonMain/kotlin/Packet.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/Packet.kt
@@ -16,9 +16,11 @@
 package com.monkopedia.ksrpc.packets.internal
 
 import com.monkopedia.ksrpc.SuspendCloseable
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@KsrpcInternal
 @Serializable
 data class Packet<T>(
     @SerialName("t")
@@ -65,6 +67,7 @@ data class Packet<T>(
     )
 }
 
+@KsrpcInternal
 internal interface PacketChannel<T> : SuspendCloseable {
     suspend fun sendLocked(packet: Packet<T>)
     suspend fun receiveLocked(): Packet<T>

--- a/ksrpc-packets/src/commonMain/kotlin/PacketCallId.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketCallId.kt
@@ -15,6 +15,7 @@
  */
 package com.monkopedia.ksrpc.packets.internal
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.RpcCallId
 
 /**
@@ -22,4 +23,5 @@ import com.monkopedia.ksrpc.channels.RpcCallId
  * sub-service on the remote side) with the [messageId] allocated from the pending call's
  * `MultiChannel`.
  */
+@KsrpcInternal
 data class PacketCallId(val channelId: String, val messageId: String) : RpcCallId

--- a/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
@@ -28,12 +28,12 @@ import com.monkopedia.ksrpc.channels.RpcBinaryData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.channels.awaitRequestCancellable
-import com.monkopedia.ksrpc.channels.randomUuid
 import com.monkopedia.ksrpc.internal.ClientChannelContext
 import com.monkopedia.ksrpc.internal.HostChannelContext
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.internal.MultiChannel
 import com.monkopedia.ksrpc.internal.SubserviceChannel
+import com.monkopedia.ksrpc.internal.randomUuid
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred

--- a/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.packets.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.CancellationSupport
 import com.monkopedia.ksrpc.channels.ChannelHost
@@ -50,6 +53,7 @@ import kotlinx.serialization.builtins.serializer
 private const val DEFAULT_MAX_SIZE = 16 * 1024L
 private const val RECEIVE_LOOP_START_GRACE_MS = 500L
 
+@KsrpcInternal
 abstract class PacketChannelBase<T>(
     protected val scope: CoroutineScope,
     final override val env: KsrpcEnvironment<T>

--- a/ksrpc-service-worker/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsJs.kt
+++ b/ksrpc-service-worker/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsJs.kt
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 @file:Suppress("UnsafeCastFromDynamic")
+@file:OptIn(KsrpcInternal::class)
 
 package com.monkopedia.ksrpc.webworker
 
 import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.packets.internal.Packet

--- a/ksrpc-service-worker/src/wasmJsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsWasm.kt
+++ b/ksrpc-service-worker/src/wasmJsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsWasm.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(ExperimentalWasmJsInterop::class)
+@file:OptIn(ExperimentalWasmJsInterop::class, KsrpcInternal::class)
 @file:Suppress("UnsafeCastFromDynamic")
 
 package com.monkopedia.ksrpc.webworker
@@ -21,6 +21,7 @@ package com.monkopedia.ksrpc.webworker
 import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.packets.internal.Packet

--- a/ksrpc-sockets/src/commonMain/kotlin/PacketUtils.kt
+++ b/ksrpc-sockets/src/commonMain/kotlin/PacketUtils.kt
@@ -15,12 +15,14 @@
  */
 package com.monkopedia.ksrpc.sockets.internal
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
 import io.ktor.utils.io.errors.IOException
 import io.ktor.utils.io.readUTF8Line
 import io.ktor.utils.io.writeStringUtf8
 
+@KsrpcInternal
 inline fun swallow(function: () -> Unit) {
     try {
         function()
@@ -28,11 +30,13 @@ inline fun swallow(function: () -> Unit) {
     }
 }
 
+@KsrpcInternal
 suspend fun ByteWriteChannel.appendLine(s: String = "") {
     writeStringUtf8(s)
     writeStringUtf8("\r\n")
 }
 
+@KsrpcInternal
 suspend fun ByteReadChannel.readFields(): Map<String, String> {
     val fields = LinkedHashMap<String, String>()
     while (true) {

--- a/ksrpc-sockets/src/commonMain/kotlin/ReadWritePacketChannel.kt
+++ b/ksrpc-sockets/src/commonMain/kotlin/ReadWritePacketChannel.kt
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.sockets.internal
 
 import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.packets.internal.CONTENT_LENGTH
 import com.monkopedia.ksrpc.packets.internal.Packet
@@ -25,8 +28,8 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
 import io.ktor.utils.io.close
 import io.ktor.utils.io.readFully
-import io.ktor.utils.io.writeStringUtf8
 import io.ktor.utils.io.writeFully
+import io.ktor.utils.io.writeStringUtf8
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer

--- a/ksrpc-sockets/src/jvmMain/kotlin/InputOutputStreams.kt
+++ b/ksrpc-sockets/src/jvmMain/kotlin/InputOutputStreams.kt
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.sockets
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.sockets.internal.swallow
 import io.ktor.utils.io.ByteChannel

--- a/ksrpc-sockets/src/jvmMain/kotlin/ProcessStream.kt
+++ b/ksrpc-sockets/src/jvmMain/kotlin/ProcessStream.kt
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.sockets
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.sockets.internal.swallow
 import kotlinx.coroutines.Dispatchers

--- a/ksrpc-sockets/src/nativeMain/kotlin/PosixFileReadChannel.kt
+++ b/ksrpc-sockets/src/nativeMain/kotlin/PosixFileReadChannel.kt
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(ExperimentalForeignApi::class)
+@file:OptIn(ExperimentalForeignApi::class, KsrpcInternal::class)
 
 package com.monkopedia.ksrpc.sockets
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.sockets.internal.swallow
 import io.ktor.utils.io.ByteChannel

--- a/ksrpc-test/src/commonTest/kotlin/AsClientExtensionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/AsClientExtensionTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.ChannelId
 import com.monkopedia.ksrpc.channels.RpcCallId

--- a/ksrpc-test/src/commonTest/kotlin/CurrentRpcCallTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/CurrentRpcCallTest.kt
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsNotification
 import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.currentRpcCall
 import com.monkopedia.ksrpc.jsonrpc.JsonRpcCallId
 import com.monkopedia.ksrpc.jsonrpc.asJsonRpcConnection

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcBinaryLimitationsTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcBinaryLimitationsTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.binary.ktor.asRpcBinaryData
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.RpcCallId

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcErrorEnvelopeTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcErrorEnvelopeTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcNotifyRequestShapeTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcNotifyRequestShapeTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcRequest
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcTransformer
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcWriterBase

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcNullPayloadTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcNullPayloadTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcRequest
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcResponse
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcTransformer

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcOutOfOrderResponseTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcOutOfOrderResponseTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcError
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcRequest
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcResponse

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcSerializedChannelNotifyTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcSerializedChannelNotifyTest.kt
@@ -20,6 +20,7 @@ package com.monkopedia.ksrpc
 import com.monkopedia.ksrpc.MethodMetadata
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.internal.ServiceExecutor
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcChannel
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcSerializedChannel
 import kotlin.test.Test

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcSerializedChannelNotifyTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcSerializedChannelNotifyTest.kt
@@ -13,12 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.MethodMetadata
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcChannel
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcSerializedChannel
-import com.monkopedia.ksrpc.MethodMetadata
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.jsonrpc.asJsonRpcConnection
 import com.monkopedia.ksrpc.jsonrpc.internal.DEFAULT_CONTENT_TYPE

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcWriterCloseTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcWriterCloseTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcTransformer
 import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcWriterBase
 import kotlin.test.Test

--- a/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
@@ -225,9 +225,12 @@ class KsFlowServiceTest {
             assertEquals(listOf("fast-1", "fast-2", "fast-3"), items)
             assertEquals(
                 listOf(
-                    "start-fast-1", "end-fast-1",
-                    "start-fast-2", "end-fast-2",
-                    "start-fast-3", "end-fast-3"
+                    "start-fast-1",
+                    "end-fast-1",
+                    "start-fast-2",
+                    "end-fast-2",
+                    "start-fast-3",
+                    "end-fast-3"
                 ),
                 processOrder
             )
@@ -256,10 +259,18 @@ class KsFlowServiceTest {
         try {
             clientJob(clientChannel)
         } finally {
-            try { clientChannel.close() } catch (_: Throwable) {}
-            try { serviceChannel.close() } catch (_: Throwable) {}
-            try { input.cancel(null) } catch (_: Throwable) {}
-            try { si.cancel(null) } catch (_: Throwable) {}
+            try {
+                clientChannel.close()
+            } catch (_: Throwable) {}
+            try {
+                serviceChannel.close()
+            } catch (_: Throwable) {}
+            try {
+                input.cancel(null)
+            } catch (_: Throwable) {}
+            try {
+                si.cancel(null)
+            } catch (_: Throwable) {}
             output.close(null)
             so.close(null)
             bgJob.join()

--- a/ksrpc-test/src/commonTest/kotlin/KsMethodZeroArgTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsMethodZeroArgTest.kt
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.internal.asClient
 import com.monkopedia.ksrpc.sockets.asConnection

--- a/ksrpc-test/src/commonTest/kotlin/KsTimeoutTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsTimeoutTest.kt
@@ -13,12 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.MetadataValue
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
 import com.monkopedia.ksrpc.annotation.KsTimeout
-import com.monkopedia.ksrpc.MetadataValue
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.internal.asClient
 import kotlin.test.Test

--- a/ksrpc-test/src/commonTest/kotlin/MultiChannelCoreTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/MultiChannelCoreTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.internal.MultiChannel
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/ksrpc-test/src/commonTest/kotlin/PacketBitfieldTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketBitfieldTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.packets.internal.Packet
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/ksrpc-test/src/commonTest/kotlin/PacketCancellationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketCancellationTest.kt
@@ -17,9 +17,9 @@
 
 package com.monkopedia.ksrpc
 
-import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.sockets.asConnection
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/ksrpc-test/src/commonTest/kotlin/PacketCancellationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketCancellationTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
 import com.monkopedia.ksrpc.sockets.asConnection
@@ -62,6 +65,7 @@ private object PendingCallCounter {
 
 private class TrackingCancelService : CancelTestService {
     val started = CompletableDeferred<Unit>()
+
     // Plain volatile-style flags; tests run on a single-thread test dispatcher and only do
     // simple read/write so a value class slot is sufficient. Avoids hitting the atomicfu
     // transformer's restriction against `atomic(...)` outside class init in lambda scopes.

--- a/ksrpc-test/src/commonTest/kotlin/PacketChannelBaseMinimalTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketChannelBaseMinimalTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase
 import kotlin.test.Test

--- a/ksrpc-test/src/commonTest/kotlin/PacketChannelBinaryOrderingTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketChannelBinaryOrderingTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.binary.ktor.asByteReadChannel
 import com.monkopedia.ksrpc.channels.ChannelId
 import com.monkopedia.ksrpc.packets.internal.Packet

--- a/ksrpc-test/src/commonTest/kotlin/PacketConstantsTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketConstantsTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.packets.internal.CONTENT_LENGTH
 import com.monkopedia.ksrpc.packets.internal.CONTENT_TYPE
 import kotlin.test.Test

--- a/ksrpc-test/src/commonTest/kotlin/RandomUuidTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RandomUuidTest.kt
@@ -18,7 +18,7 @@
 package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
-import com.monkopedia.ksrpc.channels.randomUuid
+import com.monkopedia.ksrpc.internal.randomUuid
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue

--- a/ksrpc-test/src/commonTest/kotlin/RandomUuidTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RandomUuidTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.randomUuid
 import kotlin.test.Test
 import kotlin.test.assertNotEquals

--- a/ksrpc-test/src/commonTest/kotlin/RpcChannelConstantsTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcChannelConstantsTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/ksrpc-test/src/commonTest/kotlin/RpcChannelConstantsTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcChannelConstantsTest.kt
@@ -18,6 +18,8 @@
 package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.internal.ENDPOINT_NOT_FOUND_PREFIX
+import com.monkopedia.ksrpc.internal.ERROR_PREFIX
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/ksrpc-test/src/commonTest/kotlin/RpcFunctionalityTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcFunctionalityTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.internal.asClient

--- a/ksrpc-test/src/commonTest/kotlin/RpcMethodIntrospectionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcMethodIntrospectionTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.SerializedService
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/ksrpc-test/src/commonTest/kotlin/RpcMethodIntrospectionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcMethodIntrospectionTest.kt
@@ -19,6 +19,7 @@ package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.internal.ServiceExecutor
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/ksrpc-test/src/commonTest/kotlin/RpcSubserviceLeakTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcSubserviceLeakTest.kt
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.RpcFunctionalityTest.TestType
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.internal.asClient
 import kotlin.test.Test
@@ -123,9 +126,8 @@ private fun leakyRootImpl(): LeakTestRootInterface = object : LeakTestRootInterf
                 }
             }
 
-            override suspend fun fail(value: String): String {
+            override suspend fun fail(value: String): String =
                 throw IllegalStateException("intentional-failure:$value")
-            }
 
             override suspend fun close() {
                 LeakTracker.onClose()

--- a/ksrpc-test/src/commonTest/kotlin/SerializedChannelDefaultMethodTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/SerializedChannelDefaultMethodTest.kt
@@ -23,6 +23,7 @@ import com.monkopedia.ksrpc.channels.ChannelClient
 import com.monkopedia.ksrpc.channels.ChannelId
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.internal.ServiceExecutor
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.builtins.serializer

--- a/ksrpc-test/src/commonTest/kotlin/SerializedChannelDefaultMethodTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/SerializedChannelDefaultMethodTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.ChannelClient
 import com.monkopedia.ksrpc.channels.ChannelId

--- a/ksrpc-test/src/commonTest/kotlin/SocketPacketUtilsReadFieldsTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/SocketPacketUtilsReadFieldsTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.sockets.internal.readFields
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.writeStringUtf8

--- a/ksrpc-test/src/commonTest/kotlin/SocketPacketUtilsSwallowTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/SocketPacketUtilsSwallowTest.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.sockets.internal.swallow
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/ksrpc-test/src/jvmTest/kotlin/RpcSubserviceLeakJvmTest.kt
+++ b/ksrpc-test/src/jvmTest/kotlin/RpcSubserviceLeakJvmTest.kt
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc
 
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
 import com.monkopedia.ksrpc.internal.asClient
 import java.lang.ref.WeakReference


### PR DESCRIPTION
## Summary

Gates the public-but-not-public-API symbols living in `com.monkopedia.ksrpc.*.internal` packages (plus a few top-level helpers) behind the `@KsrpcInternal` opt-in annotation added in PR #33, so the 1.0 BCV freeze doesn't lock them in as stable API.

Closes #17

### Per-module breakdown

| Module | Gated with `@KsrpcInternal` | Stayed public / rationale |
|---|---|---|
| ksrpc-core | `HostSerializedChannelImpl`, `ClientChannelContext`, `HostChannelContext`, `MultiChannel`, `SubserviceChannel`, `SerializedChannel.asClient`, `ServiceExecutor`, `ENDPOINT_NOT_FOUND_PREFIX`, `ERROR_PREFIX`, `randomUuid()` (all expect/actual pairs) | `CallDataSerializer.{createErrorCallData, createEndpointNotFoundCallData, decodeErrorCallData, isError}` — kept public as the legitimate extension surface for transport implementers (overridden in `ksrpc-jni`, called by user tests in `ksrpc-test`). |
| ksrpc-packets | `Packet`, `PacketCallId`, `PacketChannelBase`, `CONTENT_LENGTH`, `CONTENT_TYPE`, `PacketChannel` (already `internal` keyword, also gated to propagate through `PacketChannelBase`'s supertype) | — |
| ksrpc-sockets | `swallow`, `appendLine`, `readFields` (all used cross-module by jsonrpc) | `ReadWritePacketChannel` is already `internal` (Kotlin keyword) — no change. |
| ksrpc-jsonrpc | `JsonRpcChannel`, `JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcError`, `JsonRpcSerializedChannel`, `JsonRpcServiceWrapper`, `JsonRpcWriterBase`, `JsonRpcTransformer`, `jsonHeader`, `jsonLine`, `DEFAULT_CONTENT_TYPE` | — |
| ksrpc-ktor-websocket-shared | `WebsocketPacketChannel` | — |
| ksrpc-ktor-client / server / websocket-client / websocket-server / ksrpc-jni / ksrpc-service-worker / ksrpc-sockets jvm+native | (opt-in call sites only) | These modules construct the gated symbols above; they get `@file:OptIn(KsrpcInternal::class)` at the top of each affected file. |
| ksrpc-test, ksrpc-bench | (opt-in call sites only) | Tests and benchmarks exercise the implementation primitives directly. |

### Notable decisions

- **`ServiceExecutor`** stays `public` but is annotated `@KsrpcInternal`. The compiler plugin emits IR that constructs anonymous `ServiceExecutor` classes directly; that IR is generated after the front-end opt-in check, so the opt-in annotation doesn't propagate into compiler-generated user code.
- **`CallDataSerializer` error-path methods** stay fully public. `ksrpc-jni`'s `JniSerialization` overrides them and user-observable tests call them for error handling; they're a bona-fide transport extension point rather than an implementation leak.
- **BCV dumps unchanged**: `@RequiresOptIn(BINARY)` annotations don't remove symbols from the klib / jar dumps — the symbols remain resolvable (binary-compatible), but consumers get a compile error unless they opt in. This is intentional: we still want BCV to catch accidental signature changes to these internal symbols.
- **`PacketCodecBenchmark`'s two JS benchmarks return `Any`** rather than `Packet<String>`. The kotlinx-benchmark JS plugin emits descriptor classes in `kotlinx.benchmark.generated.*` that reference the benchmark's return type and cannot themselves be annotated; keeping `Packet` out of the return signature avoids forcing those generated files to opt in.

## Test plan

- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test`
- [x] `./gradlew :ksrpc-jsonrpc:jvmTest :ksrpc-jsonrpc:linuxX64Test`
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test`
- [x] `./gradlew apiCheck` (BCV dumps unchanged — see rationale above)
- [x] Verified ktor / websocket / jsonrpc / packets transports still compile with the gated types
- [x] ktlint issues in touched files fixed; pre-existing violations in `RpcObject*.kt` / `RpcObjectKey.kt` / `KsMethod.kt` left as-is

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)