### PR TITLE
Fix #67: user-facing diagnostic when Flow<T> used without ksrpc-flow on classpath

### DIFF
--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -294,6 +294,29 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
                 isValid = false
             }
         }
+        // Classpath-missing diagnostic for `Flow<T>`: when a @KsMethod references
+        // `kotlinx.coroutines.flow.Flow` in its input or output type but `ksrpc-flow`
+        // is not on the compile classpath, `determineType` falls through to
+        // `RpcType.DEFAULT` and `serializer<Flow<T>>()` fails with a confusing
+        // "Serializer for class 'Flow' not found" error from kotlinx.serialization.
+        // Surface a user-facing error pointing at the module to add instead.
+        if (!env.flowSupported) {
+            val hasFlow =
+                inputType == FqConstants.FLOW || outputType == FqConstants.FLOW
+            if (hasFlow) {
+                val fqName = irClass.kotlinFqName.asString()
+                val methodName = method.name.asString()
+                report.reportUserError(
+                    "@KsMethod `$fqName.$methodName` uses " +
+                        "`kotlinx.coroutines.flow.Flow` but ksrpc-flow is not on the " +
+                        "compile classpath. Add " +
+                        "`implementation(\"com.monkopedia:ksrpc-flow\")` to your " +
+                        "dependencies.",
+                    element = method
+                )
+                isValid = false
+            }
+        }
         return isValid
     }
 

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -737,13 +737,13 @@ internal class GenericMethodIrBuilder(
             )
         val flowTransformerSymbol = env.flowTransformer
             ?: reportInternal(
-                "FlowTransformer symbol missing but Flow<T> detection fired — " +
-                    "ksrpc-flow must be on the compile classpath"
+                "Flow detection fired despite flowSupported=false " +
+                    "(FlowTransformer symbol missing)"
             )
         val ksFlowServiceSymbol = env.ksFlowService
             ?: reportInternal(
-                "KsFlowService symbol missing but Flow<T> detection fired — " +
-                    "ksrpc-flow must be on the compile classpath"
+                "Flow detection fired despite flowSupported=false " +
+                    "(KsFlowService symbol missing)"
             )
         val objClass = ksFlowServiceSymbol.owner.declarations
             .filterIsInstance<IrClass>()

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -538,13 +538,13 @@ class StubGeneration(
             )
         val flowTransformerSymbol = env.flowTransformer
             ?: reportInternal(
-                "FlowTransformer symbol missing but Flow<T> detection fired — " +
-                    "ksrpc-flow must be on the compile classpath"
+                "Flow detection fired despite flowSupported=false " +
+                    "(FlowTransformer symbol missing)"
             )
         val ksFlowServiceSymbol = env.ksFlowService
             ?: reportInternal(
-                "KsFlowService symbol missing but Flow<T> detection fired — " +
-                    "ksrpc-flow must be on the compile classpath"
+                "Flow detection fired despite flowSupported=false " +
+                    "(KsFlowService symbol missing)"
             )
         val rpcObjectExpr = buildKsFlowServiceRpcObject(
             declarationIrBuilder,

--- a/compiler/plugin/src/test/java/FlowClasspathDiagnosticTest.kt
+++ b/compiler/plugin/src/test/java/FlowClasspathDiagnosticTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import java.io.File
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Covers the classpath-missing diagnostic emitted by
+ * [KsrpcIrGenerationExtension.validateMethod] when a service uses
+ * `kotlinx.coroutines.flow.Flow` in a `@KsMethod` signature without
+ * `ksrpc-flow` on the compile classpath (issue #67).
+ *
+ * Without this diagnostic, the compilation later fails with the cryptic
+ * `Serializer for class 'Flow' not found` error from kotlinx.serialization
+ * because `determineType` falls through to `RpcType.DEFAULT` when
+ * `flowSupported=false`. Mirrors the pattern used by
+ * [BinaryAdapterDiagnosticTest] for the ksrpc-binary-* adapter modules.
+ */
+class FlowClasspathDiagnosticTest {
+
+    @Test
+    fun `Flow return without ksrpc-flow reports missing-module diagnostic`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Update(val id: String)
+
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<Update>
+}
+"""
+        )
+        val result = compileWithoutFlow(source)
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("kotlinx.coroutines.flow.Flow") &&
+                result.messages.contains("ksrpc-flow") &&
+                result.messages.contains("not on the compile classpath"),
+            "Expected classpath-missing diagnostic naming Flow and ksrpc-flow, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `Flow parameter without ksrpc-flow reports missing-module diagnostic`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Chunk(val bytes: String)
+
+@Serializable
+data class Receipt(val ok: Boolean)
+
+@KsService
+interface UploadService : RpcService {
+    @KsMethod("/upload")
+    suspend fun upload(items: Flow<Chunk>): Receipt
+}
+"""
+        )
+        val result = compileWithoutFlow(source)
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("kotlinx.coroutines.flow.Flow") &&
+                result.messages.contains("ksrpc-flow") &&
+                result.messages.contains("not on the compile classpath"),
+            "Expected classpath-missing diagnostic naming Flow and ksrpc-flow, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    /**
+     * Compile [source] with the ksrpc compiler plugin, but strip every classpath
+     * entry whose path contains `ksrpc-flow` so the compiler cannot resolve
+     * `KsFlowService`/`FlowTransformer`. `kotlinx.coroutines.flow.Flow` itself
+     * remains resolvable because the kotlinx-coroutines jar stays on the
+     * classpath — only the `ksrpc-flow` adapter jar is removed.
+     */
+    private fun compileWithoutFlow(source: SourceFile): JvmCompilationResult {
+        val filteredClasspath = System.getProperty("java.class.path")
+            .split(File.pathSeparatorChar)
+            .map(::File)
+            .filter { entry -> !entry.absolutePath.contains("ksrpc-flow") }
+        return KotlinCompilation().apply {
+            sources = listOf(source)
+            compilerPluginRegistrars = listOf(KsrpcComponentRegistrar())
+            inheritClassPath = false
+            classpaths = filteredClasspath
+        }.compile()
+    }
+}


### PR DESCRIPTION
## Summary

- Detect `kotlinx.coroutines.flow.Flow` in `@KsMethod` input/output types during IR validation. When `env.flowSupported == false` (i.e. ksrpc-flow not on the compile classpath), emit a user-facing `reportUserError` pointing at the method with the exact dependency to add, rather than falling through to kotlinx.serialization's cryptic "Serializer for class 'Flow' not found".
- Reword the four `reportInternal` messages in `StubGeneration.buildFlowTransformer` / `ObjGeneration.buildFlowTransformer` from "ksrpc-flow must be on the compile classpath" (user-facing wording for an internal invariant) to "Flow detection fired despite flowSupported=false" so the role is unambiguous.
- Add `FlowClasspathDiagnosticTest` modelled on `BinaryAdapterDiagnosticTest` (PR #87) that compiles a service declaring `Flow<T>` in a `@KsMethod` signature with the ksrpc-flow jar stripped from the test classpath and asserts the diagnostic fires.

Diagnostic text:

> `@KsMethod `MyService.updates` uses `kotlinx.coroutines.flow.Flow` but ksrpc-flow is not on the compile classpath. Add `implementation("com.monkopedia:ksrpc-flow")` to your dependencies.`

Closes #67

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — all 11 test classes pass including the new `FlowClasspathDiagnosticTest` (2 cases: Flow return, Flow parameter)
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-test:jvmTest`
- [x] `./gradlew apiCheck`
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:runKtlintCheckOverMainSourceSet` / `ktlintTestSourceSetCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)