### PR TITLE
Fix #65: migrate plugin user-reachable diagnostics to FIR-side checkers

### DIFF
--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -143,6 +143,10 @@ tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
         freeCompilerArgs.add("-Xjvm-default=all")
+        // Required for the FIR-phase `FirDeclarationChecker.check` overrides added
+        // in issue #65 — Kotlin 2.3+ declares `check` with `context(CheckerContext,
+        // DiagnosticReporter)` parameters, which subclasses must match.
+        freeCompilerArgs.add("-Xcontext-parameters")
     }
 }
 

--- a/compiler/plugin/src/main/java/FirKsrpcRegistrar.kt
+++ b/compiler/plugin/src/main/java/FirKsrpcRegistrar.kt
@@ -15,6 +15,7 @@
  */
 package com.monkopedia.ksrpc.plugin
 
+import com.monkopedia.ksrpc.plugin.fir.KsrpcFirCheckersComponent
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 
 class FirKsrpcRegistrar : FirExtensionRegistrar() {
@@ -23,5 +24,6 @@ class FirKsrpcRegistrar : FirExtensionRegistrar() {
         +::FirCompanionDeclarationGenerator
         +::FirKsrpcObjGenerator
         +::FirKsrpcIntrospectionGenerator
+        +::KsrpcFirCheckersComponent
     }
 }

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -91,16 +91,29 @@
  * Validation
  * ----------
  *
- *   [KsrpcIrGenerationExtension.validate] runs before transformation, rejecting
- *   services with non-RpcService supertypes, non-invariant class type parameters,
- *   method-level type parameters, duplicate endpoint names, `ByteReadChannel`-on-both-
- *   sides, and `@KsNotification` methods that don't return `Unit`. Diagnostics go
- *   through [PluginReporter.reportUserError], which resolves a source line/column
- *   from the offending IR element so the user sees a clean pointer at the declaration.
+ *   The user-reachable validation now lives in FIR-phase `FirDeclarationChecker`s
+ *   — see [com.monkopedia.ksrpc.plugin.fir.KsServiceClassChecker] and
+ *   [com.monkopedia.ksrpc.plugin.fir.KsMethodFunctionChecker]. FIR errors halt
+ *   compilation before IR runs, so the IR-phase checks below are a belt-and-braces
+ *   safety net; they fire only if the FIR extension is not registered (e.g. a
+ *   downstream consumer builds with an old plugin jar on the classpath).
  *
- *   TODO: these validations currently run in the IR phase which limits IDE
- *   integration — a FIR-phase checker with `KtSourceElement` would produce a red
- *   squiggle directly on the offending element. Tracked as a 1.0+ follow-up.
+ *   [KsrpcIrGenerationExtension.validate] rejects services with non-RpcService
+ *   supertypes, non-invariant class type parameters, method-level type parameters,
+ *   duplicate endpoint names, `ByteReadChannel`-on-both-sides, and `@KsNotification`
+ *   methods that don't return `Unit`. Diagnostics go through
+ *   [PluginReporter.reportUserError], which resolves a source line/column from the
+ *   offending IR element so the user sees a clean pointer at the declaration.
+ *
+ *   Sites that intentionally remain IR-phase-only, because they depend on
+ *   resolved IR type / constant information not readily available in FIR:
+ *
+ *    - [MetadataIrBuilder]'s "unsupported ksrpc method-metadata argument" error
+ *      — needs a resolved IR expression to classify the argument shape.
+ *    - [ObjGeneration]'s "cannot compose a KSerializer for ..." — depends on
+ *      composed serializer builders that are resolved at IR time.
+ *
+ *   See issue #65 for the migration context.
  */
 
 @file:OptIn(UnsafeDuringIrConstructionAPI::class)

--- a/compiler/plugin/src/main/java/fir/BinaryAdapterRegistry.kt
+++ b/compiler/plugin/src/main/java/fir/BinaryAdapterRegistry.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.plugin.fir
+
+import com.monkopedia.ksrpc.plugin.FqConstants
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+
+/**
+ * Static (classpath-free) view of the plugin's binary-adapter registry. Used
+ * by FIR-phase checkers which do not have access to `KsrpcGenerationEnvironment`
+ * (that object lives in the IR phase and depends on an `IrPluginContext`).
+ *
+ * The FIR checker verifies adapter presence via the FIR symbol provider rather
+ * than a pre-resolved `IrClassSymbol` — see
+ * `KsMethodFunctionChecker` for the lookup.
+ *
+ * Keep in sync with [KsrpcGenerationEnvironment.binaryAdapters] — both derive
+ * from the same [FqConstants] entries.
+ */
+internal object BinaryAdapterRegistry {
+    data class Entry(
+        val userFqName: FqName,
+        val transformerClassId: ClassId,
+        val moduleHint: String
+    )
+
+    private val adapters: List<Entry> = listOf(
+        Entry(
+            FqConstants.BYTE_READ_CHANNEL,
+            FqConstants.BYTE_READ_CHANNEL_TRANSFORMER,
+            "ksrpc-binary-ktor"
+        ),
+        Entry(
+            FqConstants.KOTLINX_IO_SOURCE,
+            FqConstants.SOURCE_TRANSFORMER,
+            "ksrpc-binary-kotlinx-io"
+        ),
+        Entry(
+            FqConstants.OKIO_BUFFERED_SOURCE,
+            FqConstants.BUFFERED_SOURCE_TRANSFORMER,
+            "ksrpc-binary-okio"
+        )
+    )
+
+    private val userFqSet: Set<FqName> = adapters.map { it.userFqName }.toSet()
+
+    fun userFqNames(): Set<FqName> = userFqSet
+
+    fun find(fqName: FqName?): Entry? =
+        fqName?.let { name -> adapters.firstOrNull { it.userFqName == name } }
+}

--- a/compiler/plugin/src/main/java/fir/KsMethodFunctionChecker.kt
+++ b/compiler/plugin/src/main/java/fir/KsMethodFunctionChecker.kt
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(
+    org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess::class,
+    org.jetbrains.kotlin.fir.symbols.SymbolInternals::class
+)
+
+package com.monkopedia.ksrpc.plugin.fir
+
+import com.monkopedia.ksrpc.plugin.FqConstants
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirDeclarationChecker
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.declarations.utils.classId
+import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.types.classId
+import org.jetbrains.kotlin.fir.types.coneType
+import org.jetbrains.kotlin.fir.types.toRegularClassSymbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * FIR-side checker for `@KsMethod`-annotated functions. Covers the
+ * user-reachable diagnostics previously emitted in IR by
+ * `KsrpcIrGenerationExtension.validateMethod`, `validateNotification`, and
+ * `ServiceClass.visitSimpleFunction`:
+ *
+ *  - `@KsMethod` function with type parameters
+ *  - `@KsMethod` function with more than one non-dispatch parameter
+ *  - Unparseable or duplicate `@KsMethod("...")` endpoint
+ *  - Binary types (`ByteReadChannel` / `Source` / `BufferedSource`) in both
+ *    input and output position
+ *  - Binary adapter module missing on compile classpath
+ *  - `@KsNotification` on non-`Unit`-returning method
+ *  - `@KsMethod` declared outside a `@KsService` interface
+ *
+ * Duplicate-endpoint detection runs over the siblings in the enclosing class
+ * rather than per-function, so it fires only on the *second* declaration that
+ * reuses the endpoint string — preserving the existing IR-phase behaviour.
+ */
+internal object KsMethodFunctionChecker :
+    FirDeclarationChecker<FirNamedFunction>(MppCheckerKind.Common) {
+
+    private val KS_METHOD_ID =
+        ClassId(FqName("com.monkopedia.ksrpc.annotation"), Name.identifier("KsMethod"))
+    private val KS_SERVICE_ID =
+        ClassId(FqName("com.monkopedia.ksrpc.annotation"), Name.identifier("KsService"))
+    private val KS_NOTIFICATION_ID =
+        ClassId(FqName("com.monkopedia.ksrpc.annotation"), Name.identifier("KsNotification"))
+    private val FQ_INTROSPECTABLE_RPC_SERVICE =
+        FqConstants.FQ_INTROSPECTABLE_RPC_SERVICE
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirNamedFunction) {
+        val session = context.session
+        val symbol = declaration.symbol
+        if (!symbol.hasAnnotation(KS_METHOD_ID, session)) return
+
+        val containingClassSymbol = containingClassSymbol(context)
+        val containingIsKsService =
+            containingClassSymbol != null &&
+                containingClassSymbol.hasAnnotation(KS_SERVICE_ID, session)
+
+        // #9: @KsMethod outside a @KsService interface. Match the existing
+        // escape hatch — methods declared on `IntrospectableRpcService` are
+        // allowed because ksrpc's own interface carries @KsMethod annotations
+        // that the plugin should not reject.
+        if (!containingIsKsService) {
+            val containingFqName = containingClassSymbol?.classId?.asSingleFqName()
+            if (containingFqName != FQ_INTROSPECTABLE_RPC_SERVICE) {
+                val source = declaration.source ?: return
+                val receiverFqName =
+                    containingFqName?.asString() ?: "no enclosing class"
+                reporter.reportOn(
+                    source,
+                    KsrpcDiagnostics.KSMETHOD_OUTSIDE_KSSERVICE,
+                    "@KsMethod can only be applied to functions declared inside a " +
+                        "@KsService interface. ${declaration.name.asString()} is " +
+                        "declared on $receiverFqName.",
+                    context
+                )
+            }
+            return
+        }
+
+        val containingFqName = containingClassSymbol.classId.asFqNameString()
+        val methodName = declaration.name.asString()
+        val source = declaration.source ?: return
+
+        // #4: method-level type parameters.
+        if (declaration.typeParameters.isNotEmpty()) {
+            reporter.reportOn(
+                source,
+                KsrpcDiagnostics.METHOD_TYPE_PARAMETERS,
+                "$containingFqName.$methodName cannot have type parameters",
+                context
+            )
+        }
+
+        // #5: more than one non-dispatch parameter. FIR's valueParameters list
+        // excludes the dispatch receiver, matching the IR-phase filter.
+        if (declaration.valueParameters.size > 1) {
+            reporter.reportOn(
+                source,
+                KsrpcDiagnostics.METHOD_TOO_MANY_PARAMETERS,
+                "$containingFqName.$methodName cannot have more than 1 parameter",
+                context
+            )
+        }
+
+        // #6: endpoint name — unparseable or duplicate.
+        val ksMethodAnnotation = declaration.annotations.firstOrNull { ann ->
+            ann.annotationTypeRef.toRegularClassSymbol(session)?.classId == KS_METHOD_ID
+        }
+        val firstArg = ksMethodAnnotation?.argumentMapping?.mapping?.values?.firstOrNull()
+        val endpointName = (firstArg as? FirLiteralExpression)?.value as? String
+        if (endpointName == null) {
+            reporter.reportOn(
+                source,
+                KsrpcDiagnostics.UNPARSEABLE_ENDPOINT,
+                "$containingFqName.$methodName: could not parse annotation argument $firstArg",
+                context
+            )
+        } else {
+            // Walk the enclosing class's declared @KsMethod functions in source order
+            // and fire the diagnostic only on the second and subsequent declarations
+            // that reuse the endpoint string. This matches the IR-phase behaviour of
+            // `validateMethod`, which fires on insertion collisions against a mutable
+            // seen-set accumulated while iterating the methods in declaration order.
+            val classSym = containingClassSymbol as? FirRegularClassSymbol
+            val earlierUsesName = classSym != null &&
+                classEndpointUsedBefore(session, classSym, declaration, endpointName)
+            if (earlierUsesName) {
+                reporter.reportOn(
+                    source,
+                    KsrpcDiagnostics.DUPLICATE_ENDPOINT,
+                    "$containingFqName.$methodName: cannot use endpoint $endpointName, " +
+                        "it has already been used",
+                    context
+                )
+            }
+        }
+
+        // #7: binary-type shape. Use the FIR classId on the parameter/return ConeKotlinType.
+        val inputType = declaration.valueParameters.firstOrNull()
+            ?.returnTypeRef?.coneType?.classId?.asSingleFqName()
+        val outputType = declaration.returnTypeRef.coneType.classId?.asSingleFqName()
+        val binaryUserFqs = BinaryAdapterRegistry.userFqNames()
+        if (inputType in binaryUserFqs && outputType in binaryUserFqs) {
+            reporter.reportOn(
+                source,
+                KsrpcDiagnostics.BINARY_IN_BOTH_POSITIONS,
+                "$containingFqName.$methodName: binary streams not yet supported for both " +
+                    "input and output",
+                context
+            )
+        }
+        for (sideFq in listOfNotNull(inputType, outputType)) {
+            val adapter =
+                BinaryAdapterRegistry.find(sideFq) ?: continue
+            val transformerPresent = session.symbolProvider
+                .getClassLikeSymbolByClassId(adapter.transformerClassId) != null
+            if (!transformerPresent) {
+                reporter.reportOn(
+                    source,
+                    KsrpcDiagnostics.BINARY_ADAPTER_MISSING,
+                    "@KsMethod `$containingFqName.$methodName` uses " +
+                        "`${adapter.userFqName.asString()}` but the adapter module is not " +
+                        "on the compile classpath. Add " +
+                        "`implementation(\"com.monkopedia:${adapter.moduleHint}\")` to " +
+                        "your dependencies.",
+                    context
+                )
+            }
+        }
+
+        // #8: @KsNotification on non-Unit return.
+        if (symbol.hasAnnotation(KS_NOTIFICATION_ID, session)) {
+            val returnFq = declaration.returnTypeRef.coneType.classId?.asSingleFqName()
+            if (returnFq?.asString() != "kotlin.Unit") {
+                reporter.reportOn(
+                    source,
+                    KsrpcDiagnostics.NOTIFICATION_NON_UNIT,
+                    "$containingFqName.$methodName: @KsNotification methods must return Unit, " +
+                        "but returns $returnFq",
+                    context
+                )
+            }
+        }
+    }
+
+    /**
+     * True iff some declared function on [classSymbol] that occurs *before*
+     * [currentFunction] in the source file already declares [endpoint].
+     *
+     * This mirrors the IR-phase `validateMethod` loop, which walks methods in
+     * declaration order and reports the diagnostic on the second and following
+     * occurrences of the same endpoint string. The seen-set approach can't
+     * easily be mapped to FIR's per-function checker invocations (which are
+     * triggered independently), so we scan the enclosing class instead.
+     */
+    private fun classEndpointUsedBefore(
+        session: org.jetbrains.kotlin.fir.FirSession,
+        classSymbol: FirRegularClassSymbol,
+        currentFunction: FirNamedFunction,
+        endpoint: String
+    ): Boolean {
+        val currentStart = currentFunction.source?.startOffset ?: return false
+        val classDecl: FirRegularClass = classSymbol.fir
+        for (decl in classDecl.declarations) {
+            if (decl === currentFunction) continue
+            if (decl !is FirNamedFunction) continue
+            val declStart = decl.source?.startOffset ?: continue
+            if (declStart >= currentStart) continue
+            val ksMethod = decl.annotations.firstOrNull { ann ->
+                ann.annotationTypeRef.toRegularClassSymbol(session)?.classId == KS_METHOD_ID
+            } ?: continue
+            val value = ksMethod.argumentMapping.mapping.values.firstOrNull()
+            val other = (value as? FirLiteralExpression)?.value as? String ?: continue
+            if (other == endpoint) return true
+        }
+        return false
+    }
+
+    private fun containingClassSymbol(context: CheckerContext): FirClassSymbol<*>? {
+        // FIR's checker context pushes the containing symbols. The innermost
+        // containing class is the last FirClassSymbol we pushed through, which
+        // for a member function is the owning class. This matches the IR
+        // `dispatchReceiverParameter?.type` check at IR phase.
+        val containers = context.containingDeclarations
+        for (i in containers.indices.reversed()) {
+            val sym = containers[i]
+            if (sym is FirClassSymbol<*> && sym.classKind != ClassKind.ENUM_ENTRY) {
+                return sym
+            }
+        }
+        return null
+    }
+}

--- a/compiler/plugin/src/main/java/fir/KsServiceClassChecker.kt
+++ b/compiler/plugin/src/main/java/fir/KsServiceClassChecker.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.plugin.fir
+
+import com.monkopedia.ksrpc.plugin.FqConstants
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirDeclarationChecker
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.FirTypeParameter
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.declarations.utils.classId
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.types.toRegularClassSymbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.Variance
+
+/**
+ * FIR-side checker for `@KsService`-annotated classes. Covers the
+ * user-reachable diagnostics previously emitted in IR by
+ * `KsrpcIrGenerationExtension.validateClass` and
+ * `ServiceClass.SubclassVisitor`:
+ *
+ *  - `@KsService` on a subtype of another `@KsService` (issue #45)
+ *  - `@KsService` class without `RpcService` (or `IntrospectableRpcService`) supertype
+ *  - Class-level variant type parameter (`out T` / `in T`) — not yet supported
+ *  - Multiple `@KsService` supertypes on a single class
+ *
+ * Emitting at FIR phase attaches the diagnostic to the offending
+ * `KtSourceElement` (the class name, a type-parameter declaration, ...) which
+ * enables IDE red-squiggle support (see issue #65).
+ */
+internal object KsServiceClassChecker :
+    FirDeclarationChecker<FirClass>(MppCheckerKind.Common) {
+
+    private val KS_SERVICE_ID =
+        ClassId(FqName("com.monkopedia.ksrpc.annotation"), Name.identifier("KsService"))
+    private val FQRPC_SERVICE = FqConstants.FQRPC_SERVICE
+    private val FQ_INTROSPECTABLE_RPC_SERVICE = FqConstants.FQ_INTROSPECTABLE_RPC_SERVICE
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirClass) {
+        val session = context.session
+        val symbol = declaration.symbol
+
+        val isKsService = symbol.hasAnnotation(KS_SERVICE_ID, session)
+        // Count @KsService supertypes even on classes without @KsService themselves,
+        // because the legacy ServiceClass.SubclassVisitor reported "multiple @KsService
+        // super types" on any implementing class. But the primary rejection for
+        // @KsService-on-@KsService-subtype is only emitted on @KsService-annotated
+        // classes.
+        val ksServiceSuperSymbols = declaration.superTypeRefs
+            .asSequence()
+            .mapNotNull { it.toRegularClassSymbol(session) }
+            .filter { it.hasAnnotation(KS_SERVICE_ID, session) }
+            .toList()
+
+        if (isKsService) {
+            checkKsServiceClass(declaration, symbol, ksServiceSuperSymbols, context, reporter)
+        } else {
+            // Non-@KsService classes are only interesting if they implement multiple
+            // @KsService interfaces (legacy SubclassVisitor behaviour).
+            if (ksServiceSuperSymbols.size > 1) {
+                val source = declaration.source ?: return
+                reporter.reportOn(
+                    source,
+                    KsrpcDiagnostics.MULTIPLE_KSSERVICE_SUPERTYPES,
+                    "${symbol.classId.asFqNameString()} has " +
+                        "multiple @KsService super types, which is not supported.",
+                    context
+                )
+            }
+        }
+    }
+
+    private fun checkKsServiceClass(
+        declaration: FirClass,
+        symbol: FirClassSymbol<*>,
+        ksServiceSuperSymbols: List<FirClassSymbol<*>>,
+        context: CheckerContext,
+        reporter: DiagnosticReporter
+    ) {
+        val source = declaration.source ?: return
+        val session = context.session
+        val superTypeFqNames = declaration.superTypeRefs
+            .mapNotNull { it.toRegularClassSymbol(session)?.classId?.asSingleFqName() }
+        val hasRpcServiceSuper = superTypeFqNames.any { it == FQRPC_SERVICE }
+        val hasIntrospectableSuper = superTypeFqNames.any { it == FQ_INTROSPECTABLE_RPC_SERVICE }
+
+        val ksServiceSuper = ksServiceSuperSymbols.firstOrNull()
+        if (ksServiceSuper != null) {
+            // #1: @KsService on a subtype of another @KsService — reject with the
+            // existing wording so the existing test suite keeps asserting on the
+            // same message.
+            val selfFqName = symbol.classId.asFqNameString()
+            val superFqName = ksServiceSuper.classId.asFqNameString()
+            val selfShortName = symbol.classId.shortClassName.asString()
+            reporter.reportOn(
+                source,
+                KsrpcDiagnostics.KSSERVICE_SUBTYPE_OF_KSSERVICE,
+                "@KsService cannot be applied to $selfFqName because " +
+                    "its supertype $superFqName is already " +
+                    "@KsService. Remove @KsService from " +
+                    "$selfFqName; rpcObject<" +
+                    "$selfShortName>() will find the parent's companion " +
+                    "automatically.",
+                context
+            )
+        }
+        if (!hasRpcServiceSuper && !hasIntrospectableSuper && ksServiceSuper == null) {
+            // #2
+            reporter.reportOn(
+                source,
+                KsrpcDiagnostics.NOT_RPC_SERVICE,
+                "${symbol.classId.asFqNameString()} does not extend ${FQRPC_SERVICE.asString()}",
+                context
+            )
+        }
+
+        // #3: class-level variant type parameters.
+        if (declaration is FirRegularClass) {
+            for (tpRef in declaration.typeParameters) {
+                val tp = tpRef as? FirTypeParameter ?: continue
+                if (tp.variance != Variance.INVARIANT) {
+                    val tpSource = tp.source ?: source
+                    reporter.reportOn(
+                        tpSource,
+                        KsrpcDiagnostics.VARIANT_TYPE_PARAMETER,
+                        "${symbol.classId.asFqNameString()}: type parameter " +
+                            "${tp.name.asString()} must be invariant " +
+                            "(got ${tp.variance.label})",
+                        context
+                    )
+                }
+            }
+        }
+    }
+}

--- a/compiler/plugin/src/main/java/fir/KsrpcDiagnostics.kt
+++ b/compiler/plugin/src/main/java/fir/KsrpcDiagnostics.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.plugin.fir
+
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactory1
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
+import org.jetbrains.kotlin.diagnostics.error1
+import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
+import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
+import org.jetbrains.kotlin.psi.KtElement
+
+/**
+ * FIR-phase diagnostic factories emitted by the ksrpc compiler plugin's
+ * `FirDeclarationChecker`s. Each factory carries a single `String` payload so
+ * the existing message text (used by the plugin's compile-testing test suite)
+ * is preserved verbatim from the IR-phase `PluginReporter.reportUserError`
+ * diagnostics they replace.
+ *
+ * Errors are attached to the offending declaration / annotation source element,
+ * producing precise `KtSourceElement` locations (file:line:column) and IDE
+ * red-squiggles on the offending element rather than the file as a whole.
+ *
+ * See issue #65 for the migration context.
+ */
+@Suppress("detekt:ObjectPropertyNaming")
+object KsrpcDiagnostics : KtDiagnosticsContainer() {
+
+    // 1: @KsService applied to a subtype of another @KsService
+    val KSSERVICE_SUBTYPE_OF_KSSERVICE: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 2: Class without RpcService supertype
+    val NOT_RPC_SERVICE: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 3: Class-level variant type parameter (out T / in T)
+    val VARIANT_TYPE_PARAMETER: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 4: @KsMethod function with type parameters
+    val METHOD_TYPE_PARAMETERS: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 5: @KsMethod function with more than 1 non-dispatch parameter
+    val METHOD_TOO_MANY_PARAMETERS: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 6a: unparseable @KsMethod("...") argument
+    val UNPARSEABLE_ENDPOINT: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 6b: duplicate @KsMethod("...") endpoint
+    val DUPLICATE_ENDPOINT: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 7a: binary types in both input and output (unsupported)
+    val BINARY_IN_BOTH_POSITIONS: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 7b: binary adapter module missing on compile classpath
+    val BINARY_ADAPTER_MISSING: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 8: @KsNotification on non-Unit-returning method
+    val NOTIFICATION_NON_UNIT: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 9: @KsMethod used outside a @KsService interface
+    val KSMETHOD_OUTSIDE_KSSERVICE: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    // 10: Multiple @KsService supertypes on a class
+    val MULTIPLE_KSSERVICE_SUPERTYPES: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
+    override fun getRendererFactory(): BaseDiagnosticRendererFactory = KsrpcDiagnosticRenderers
+}
+
+@Suppress("ktlint:standard:property-naming")
+private object KsrpcDiagnosticRenderers : BaseDiagnosticRendererFactory() {
+    override val MAP: KtDiagnosticFactoryToRendererMap by KtDiagnosticFactoryToRendererMap(
+        "ksrpc"
+    ) { map ->
+        with(KsrpcDiagnostics) {
+            map.put(KSSERVICE_SUBTYPE_OF_KSSERVICE, "{0}", CommonRenderers.STRING)
+            map.put(NOT_RPC_SERVICE, "{0}", CommonRenderers.STRING)
+            map.put(VARIANT_TYPE_PARAMETER, "{0}", CommonRenderers.STRING)
+            map.put(METHOD_TYPE_PARAMETERS, "{0}", CommonRenderers.STRING)
+            map.put(METHOD_TOO_MANY_PARAMETERS, "{0}", CommonRenderers.STRING)
+            map.put(UNPARSEABLE_ENDPOINT, "{0}", CommonRenderers.STRING)
+            map.put(DUPLICATE_ENDPOINT, "{0}", CommonRenderers.STRING)
+            map.put(BINARY_IN_BOTH_POSITIONS, "{0}", CommonRenderers.STRING)
+            map.put(BINARY_ADAPTER_MISSING, "{0}", CommonRenderers.STRING)
+            map.put(NOTIFICATION_NON_UNIT, "{0}", CommonRenderers.STRING)
+            map.put(KSMETHOD_OUTSIDE_KSSERVICE, "{0}", CommonRenderers.STRING)
+            map.put(MULTIPLE_KSSERVICE_SUPERTYPES, "{0}", CommonRenderers.STRING)
+        }
+    }
+}

--- a/compiler/plugin/src/main/java/fir/KsrpcFirCheckersComponent.kt
+++ b/compiler/plugin/src/main/java/fir/KsrpcFirCheckersComponent.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.plugin.fir
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirDeclarationChecker
+import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+
+/**
+ * Registers ksrpc's FIR-phase `FirDeclarationChecker`s with the compiler so
+ * user-reachable service / method validation runs in the FIR phase and
+ * produces diagnostics with precise `KtSourceElement` locations (see #65).
+ */
+class KsrpcFirCheckersComponent(session: FirSession) : FirAdditionalCheckersExtension(session) {
+
+    override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
+        override val classCheckers: Set<FirDeclarationChecker<FirClass>> =
+            setOf(KsServiceClassChecker)
+
+        override val simpleFunctionCheckers: Set<FirDeclarationChecker<FirNamedFunction>> =
+            setOf(KsMethodFunctionChecker)
+    }
+}


### PR DESCRIPTION
## Summary

Converts the ksrpc compiler plugin's user-reachable error diagnostics from IR-phase `MessageCollector.report(ERROR, ...)` calls to FIR-side `FirDeclarationChecker`s with precise `KtSourceElement` locations. This unlocks IDE red-squiggle support (the IR-phase diagnostics could only ever point at the file as a whole) and shortens the post-edit feedback loop.

### Migrated sites (10 of 13 from the issue list)

All emitted via the new `KsrpcDiagnostics` diagnostic factories in two new checkers, registered through a `FirAdditionalCheckersExtension` in `FirKsrpcRegistrar`:

- `KsServiceClassChecker`
  1. `@KsService` subtype of another `@KsService` (issue #45)
  2. Non-`RpcService` supertype on `@KsService`
  3. Class-level variant (`out T` / `in T`) type params
  10. Multiple `@KsService` supertypes on a single class

- `KsMethodFunctionChecker`
  4. Method-level type params on `@KsMethod`
  5. More than one non-dispatch parameter on `@KsMethod`
  6. Unparseable or duplicate `@KsMethod` endpoints
  7. `ByteReadChannel` / `Source` / `BufferedSource` in both input+output position; missing adapter module on the compile classpath
  8. `@KsNotification` on non-`Unit` return
  9. `@KsMethod` outside a `@KsService` interface

Message text is preserved verbatim from the IR-phase `PluginReporter.reportUserError` wording so the existing `kotlin-compile-testing` assertions in `KsServiceSubtypeValidationTest`, `MethodShapeValidationTest`, `KsNotificationValidationTest`, and `BinaryAdapterDiagnosticTest` continue to pass unchanged.

### Kept IR-phase (with rationale)

- **11. Unsupported method-metadata argument shape** (`MetadataIrBuilder.kt`) — classifies an annotation argument by walking an IR expression and pattern-matching on `IrClassReference` / `IrVararg` / `IrGetEnumValue`. FIR's `FirAnnotationArgumentMapping` doesn't provide the same post-resolution shape without duplicating a significant chunk of metadata-classification logic. Kept as-is in IR; since FIR errors halt the compilation before IR, the IR-phase checks above act only as a belt-and-braces safety net.
- **12. `@KsService` on a non-interface** — still pending in issue #53; not implemented here.
- **13. `Flow<T>` classpath diagnostic** (issue #67 / PR #90) — the underlying IR-phase diagnostic has not landed yet. When PR #90 merges, that site should be migrated similarly as a follow-up.

### Scope notes

- `PluginReporter` stays untouched for `reportInternal` and for the sites above that intentionally remain IR-phase.
- `-Xcontext-parameters` is enabled on the plugin module because Kotlin 2.3+ declares `FirDeclarationChecker.check` with `context(CheckerContext, DiagnosticReporter)` parameters.
- The FIR phase halts compilation before IR when an error fires, so we verified (via an ad-hoc debug run) that the FIR diagnostic produces a precise source location (e.g. `main.kt:11:1`) rather than just a file pointer, and that the IR-phase duplicate doesn't also fire.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — all existing validation tests pass with the new FIR-based errors (message text unchanged)
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test`
- [x] `./gradlew apiCheck` — clean (plugin internals only)
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:ktlintTestSourceSetCheck` — clean (main-source ktlint fails on a pre-existing `BuildConfig.kt` warning unrelated to this PR)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)