### PR TITLE
Fix #53: reject @KsService on non-interface types

### DIFF
--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -126,6 +126,7 @@ import com.monkopedia.ksrpc.plugin.FqConstants.KS_SERVICE
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.ir.backend.js.utils.isDispatchReceiver
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
@@ -176,6 +177,25 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
 
     private fun validateClass(irClass: IrClass): Boolean {
         var isValid = true
+        // `@KsService` is contractually interface-only. Generated code (Stub, companion,
+        // Obj) assumes the annotated declaration is an interface: the Stub's primary
+        // constructor delegates to the owning supertype, which requires the owner to be
+        // implementable without invoking a no-arg constructor. Classes (abstract or
+        // concrete), objects, enum classes, and annotation classes all produce malformed
+        // generated code. Reject them here with a user-facing error so IDEs show a clean
+        // diagnostic instead of confusing generated-code crashes downstream (#53).
+        if (irClass.kind != ClassKind.INTERFACE) {
+            val fqName = irClass.kotlinFqName.asString()
+            val simpleName = irClass.name.asString()
+            report.reportUserError(
+                "@KsService can only be applied to interfaces. Change `$simpleName` to an " +
+                    "interface.",
+                element = irClass
+            )
+            // Bail out early — downstream validations (supertypes, type parameters) assume
+            // the declaration is an interface and would emit noisy secondary diagnostics.
+            return false
+        }
         val superTypeNames = irClass.superTypes.map { it.classFqName }
         val hasRpcServiceSuper = superTypeNames.contains(FQRPC_SERVICE)
         val hasIntrospectableSuper =

--- a/compiler/plugin/src/test/java/KsServiceInterfaceValidationTest.kt
+++ b/compiler/plugin/src/test/java/KsServiceInterfaceValidationTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Regression tests for issue #53: `@KsService` applied to a class (abstract or concrete),
+ * object, enum, or annotation type used to compile without any diagnostic, even though the
+ * generated companion/Stub code only works for interfaces. The plugin now rejects these
+ * with a clear compile-time error pointing at the offending declaration.
+ */
+class KsServiceInterfaceValidationTest {
+
+    @Test
+    fun `KsService on an interface still compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Foo : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected compilation to succeed, got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsService on an abstract class is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+abstract class Foo : RpcService {
+    @KsMethod("/op")
+    abstract suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains(
+                "@KsService can only be applied to interfaces"
+            ) && result.messages.contains("Foo"),
+            "Expected diagnostic mentioning @KsService interface-only rule and Foo, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsService on a concrete class is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+class Foo : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String = input
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains(
+                "@KsService can only be applied to interfaces"
+            ) && result.messages.contains("Foo"),
+            "Expected diagnostic mentioning @KsService interface-only rule and Foo, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `KsService on an object is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+object Foo : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String = input
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains(
+                "@KsService can only be applied to interfaces"
+            ) && result.messages.contains("Foo"),
+            "Expected diagnostic mentioning @KsService interface-only rule and Foo, " +
+                "got: ${result.messages}"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Reject `@KsService` applied to non-interface declarations (class, abstract class, object, enum, annotation) at compile time with a clear user-facing diagnostic instead of letting the plugin emit malformed Stub/companion code.
- The check lives in `KsrpcIrGenerationExtension.validateClass` and fires before any other class-level validation, so users see a single targeted error pointing at the offending class.
- Adds `KsServiceInterfaceValidationTest` with four cases: interface (still compiles), abstract class (rejected), concrete class (rejected), object (rejected).

Diagnostic wording: ``@KsService can only be applied to interfaces. Change `<SimpleName>` to an interface.``

Closes #53

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test`
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test`
- [x] `./gradlew apiCheck` (no surface changes)
- [x] ktlint on touched files (only preexisting generated `BuildConfig.kt` warning)