### PR TITLE
Fix #58: regression test for #41's ConcurrentModificationException fix

### DIFF
--- a/compiler/plugin/src/test/java/GenericServiceTest.kt
+++ b/compiler/plugin/src/test/java/GenericServiceTest.kt
@@ -467,6 +467,60 @@ interface GenericHolder<T> : RpcService {
     }
 
     @Test
+    fun `generic ksservice with many methods does not trigger ConcurrentModificationException`() {
+        // Regression test for #58 / original crash from #41. Before the fix in PR #42, a
+        // generic `@KsService` with multiple methods would throw a
+        // ConcurrentModificationException during IR generation because body-time codegen for
+        // each method (via ObjGeneration / StubGeneration) created a fresh nested executor
+        // class as a side effect while the visitor was still iterating the parent class's
+        // declarations. The fix pre-creates those executors in
+        // `generateChildrenForClass` and stashes them on `ServiceClass.genericExecutors`, so
+        // body generation only has to look them up.
+        //
+        // A refactor that moves executor creation back inline would re-introduce the CME on
+        // the exact shape below. The assertion is that compilation SUCCEEDS and the compile
+        // messages do not mention ConcurrentModificationException (the compile-testing
+        // framework surfaces IR-time exceptions through `result.messages`).
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface ManyMethods<T> : RpcService {
+    @KsMethod("/a")
+    suspend fun a(x: T): T
+
+    @KsMethod("/b")
+    suspend fun b(x: List<T>): List<T>
+
+    @KsMethod("/c")
+    suspend fun c(x: Map<String, T>): T
+
+    @KsMethod("/d")
+    suspend fun d(x: Set<T>): Set<T>
+
+    @KsMethod("/e")
+    suspend fun e(x: T?): T?
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+        assertTrue(
+            !result.messages.contains("ConcurrentModificationException"),
+            "Compile output must not mention ConcurrentModificationException (regression " +
+                "for #58 / original crash from #41). messages: ${result.messages}"
+        )
+    }
+
+    @Test
     fun `out-variance on class type params is rejected`() {
         val source = SourceFile.kotlin(
             "main.kt",


### PR DESCRIPTION
## Summary

- Adds a plugin test that pins the invariant established by PR #42's fix for the
  ConcurrentModificationException that crashed generic `@KsService` compilation in #41.
- The test declares a generic service with several methods (`T`, `List<T>`,
  `Map<String, T>`, `Set<T>`, `T?`) — the shape suggested by #58 and the shape that
  originally triggered the CME. If a future refactor moves executor creation out of
  `generateChildrenForClass` (i.e. breaks the pre-creation path that populates
  `ServiceClass.genericExecutors`), this test will fail with a CME bubbling through
  `result.messages`.
- Test-only change. No production code is touched.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test --tests com.monkopedia.ksrpc.plugin.GenericServiceTest` passes
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test` passes (no regression)
- [x] ktlint on the touched test source set passes (pre-existing main-sourceset BuildConfig.kt warning is unrelated to this change)

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)