### PR TITLE
Fix #70: extensible packet format with TLV metadata section

### DIFF
--- a/ksrpc-packets/api/ksrpc-packets.api
+++ b/ksrpc-packets/api/ksrpc-packets.api
@@ -5,17 +5,18 @@ public final class com/monkopedia/ksrpc/packets/internal/ConstantsKt {
 
 public final class com/monkopedia/ksrpc/packets/internal/Packet {
 	public static final field Companion Lcom/monkopedia/ksrpc/packets/internal/Packet$Companion;
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
-	public synthetic fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;)V
+	public synthetic fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/Object;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Lcom/monkopedia/ksrpc/packets/internal/Packet;
-	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/packets/internal/Packet;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/packets/internal/Packet;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;)Lcom/monkopedia/ksrpc/packets/internal/Packet;
+	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/packets/internal/Packet;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/packets/internal/Packet;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBinary ()Z
 	public final fun getCancel ()Z
@@ -24,6 +25,7 @@ public final class com/monkopedia/ksrpc/packets/internal/Packet {
 	public final fun getId ()Ljava/lang/String;
 	public final fun getInput ()Z
 	public final fun getMessageId ()Ljava/lang/String;
+	public final fun getMetadata ()Ljava/util/Map;
 	public final fun getStartBinary ()Z
 	public final fun getType ()I
 	public fun hashCode ()I
@@ -79,5 +81,11 @@ public abstract class com/monkopedia/ksrpc/packets/internal/PacketChannelBase : 
 	protected final fun startReceiveLoop ()V
 	public fun unregisterHandler (Lcom/monkopedia/ksrpc/channels/RpcCallId;)V
 	public fun wrapChannel (Lcom/monkopedia/ksrpc/channels/ChannelId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/packets/internal/PacketTlv {
+	public static final field CONTEXT_MAP I
+	public static final field INSTANCE Lcom/monkopedia/ksrpc/packets/internal/PacketTlv;
+	public static final field MAX_TAG I
 }
 

--- a/ksrpc-packets/api/ksrpc-packets.klib.api
+++ b/ksrpc-packets/api/ksrpc-packets.klib.api
@@ -35,8 +35,8 @@ abstract class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/PacketCha
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/Packet { // com.monkopedia.ksrpc.packets.internal/Packet|null[0]
-    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/String, kotlin/String, kotlin/String, #A) // com.monkopedia.ksrpc.packets.internal/Packet.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.String;kotlin.String;kotlin.String;1:0){}[0]
-    constructor <init>(kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, #A) // com.monkopedia.ksrpc.packets.internal/Packet.<init>|<init>(kotlin.Int;kotlin.String;kotlin.String;kotlin.String;1:0){}[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/String, kotlin/String, kotlin/String, #A, kotlin.collections/Map<kotlin/Int, kotlin/ByteArray> = ...) // com.monkopedia.ksrpc.packets.internal/Packet.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.String;kotlin.String;kotlin.String;1:0;kotlin.collections.Map<kotlin.Int,kotlin.ByteArray>){}[0]
+    constructor <init>(kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, #A, kotlin.collections/Map<kotlin/Int, kotlin/ByteArray> = ...) // com.monkopedia.ksrpc.packets.internal/Packet.<init>|<init>(kotlin.Int;kotlin.String;kotlin.String;kotlin.String;1:0;kotlin.collections.Map<kotlin.Int,kotlin.ByteArray>){}[0]
 
     final val binary // com.monkopedia.ksrpc.packets.internal/Packet.binary|{}binary[0]
         final fun <get-binary>(): kotlin/Boolean // com.monkopedia.ksrpc.packets.internal/Packet.binary.<get-binary>|<get-binary>(){}[0]
@@ -52,6 +52,8 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/Packet { // 
         final fun <get-input>(): kotlin/Boolean // com.monkopedia.ksrpc.packets.internal/Packet.input.<get-input>|<get-input>(){}[0]
     final val messageId // com.monkopedia.ksrpc.packets.internal/Packet.messageId|{}messageId[0]
         final fun <get-messageId>(): kotlin/String // com.monkopedia.ksrpc.packets.internal/Packet.messageId.<get-messageId>|<get-messageId>(){}[0]
+    final val metadata // com.monkopedia.ksrpc.packets.internal/Packet.metadata|{}metadata[0]
+        final fun <get-metadata>(): kotlin.collections/Map<kotlin/Int, kotlin/ByteArray> // com.monkopedia.ksrpc.packets.internal/Packet.metadata.<get-metadata>|<get-metadata>(){}[0]
     final val startBinary // com.monkopedia.ksrpc.packets.internal/Packet.startBinary|{}startBinary[0]
         final fun <get-startBinary>(): kotlin/Boolean // com.monkopedia.ksrpc.packets.internal/Packet.startBinary.<get-startBinary>|<get-startBinary>(){}[0]
     final val type // com.monkopedia.ksrpc.packets.internal/Packet.type|{}type[0]
@@ -62,7 +64,8 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/Packet { // 
     final fun component3(): kotlin/String // com.monkopedia.ksrpc.packets.internal/Packet.component3|component3(){}[0]
     final fun component4(): kotlin/String // com.monkopedia.ksrpc.packets.internal/Packet.component4|component4(){}[0]
     final fun component5(): #A // com.monkopedia.ksrpc.packets.internal/Packet.component5|component5(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., #A = ...): com.monkopedia.ksrpc.packets.internal/Packet<#A> // com.monkopedia.ksrpc.packets.internal/Packet.copy|copy(kotlin.Int;kotlin.String;kotlin.String;kotlin.String;1:0){}[0]
+    final fun component6(): kotlin.collections/Map<kotlin/Int, kotlin/ByteArray> // com.monkopedia.ksrpc.packets.internal/Packet.component6|component6(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., #A = ..., kotlin.collections/Map<kotlin/Int, kotlin/ByteArray> = ...): com.monkopedia.ksrpc.packets.internal/Packet<#A> // com.monkopedia.ksrpc.packets.internal/Packet.copy|copy(kotlin.Int;kotlin.String;kotlin.String;kotlin.String;1:0;kotlin.collections.Map<kotlin.Int,kotlin.ByteArray>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc.packets.internal/Packet.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc.packets.internal/Packet.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.monkopedia.ksrpc.packets.internal/Packet.toString|toString(){}[0]
@@ -83,6 +86,7 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/Packet { // 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.monkopedia.ksrpc.packets.internal/Packet.Companion|null[0]
         final val $cachedDescriptor // com.monkopedia.ksrpc.packets.internal/Packet.Companion.$cachedDescriptor|{}$cachedDescriptor[0]
             final fun <get-$cachedDescriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.monkopedia.ksrpc.packets.internal/Packet.Companion.$cachedDescriptor.<get-$cachedDescriptor>|<get-$cachedDescriptor>(){}[0]
+        final val $childSerializers // com.monkopedia.ksrpc.packets.internal/Packet.Companion.$childSerializers|{}$childSerializers[0]
 
         final fun <#A2: kotlin/Any?> serializer(kotlinx.serialization/KSerializer<#A2>): kotlinx.serialization/KSerializer<com.monkopedia.ksrpc.packets.internal/Packet<#A2>> // com.monkopedia.ksrpc.packets.internal/Packet.Companion.serializer|serializer(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
         final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.monkopedia.ksrpc.packets.internal/Packet.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -103,6 +107,13 @@ final class com.monkopedia.ksrpc.packets.internal/PacketCallId : com.monkopedia.
     final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc.packets.internal/PacketCallId.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc.packets.internal/PacketCallId.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.monkopedia.ksrpc.packets.internal/PacketCallId.toString|toString(){}[0]
+}
+
+final object com.monkopedia.ksrpc.packets.internal/PacketTlv { // com.monkopedia.ksrpc.packets.internal/PacketTlv|null[0]
+    final const val CONTEXT_MAP // com.monkopedia.ksrpc.packets.internal/PacketTlv.CONTEXT_MAP|{}CONTEXT_MAP[0]
+        final fun <get-CONTEXT_MAP>(): kotlin/Int // com.monkopedia.ksrpc.packets.internal/PacketTlv.CONTEXT_MAP.<get-CONTEXT_MAP>|<get-CONTEXT_MAP>(){}[0]
+    final const val MAX_TAG // com.monkopedia.ksrpc.packets.internal/PacketTlv.MAX_TAG|{}MAX_TAG[0]
+        final fun <get-MAX_TAG>(): kotlin/Int // com.monkopedia.ksrpc.packets.internal/PacketTlv.MAX_TAG.<get-MAX_TAG>|<get-MAX_TAG>(){}[0]
 }
 
 final const val com.monkopedia.ksrpc.packets.internal/CONTENT_LENGTH // com.monkopedia.ksrpc.packets.internal/CONTENT_LENGTH|{}CONTENT_LENGTH[0]

--- a/ksrpc-packets/src/commonMain/kotlin/Packet.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/Packet.kt
@@ -17,10 +17,28 @@ package com.monkopedia.ksrpc.packets.internal
 
 import com.monkopedia.ksrpc.SuspendCloseable
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Wire-format packet exchanged by [PacketChannelBase].
+ *
+ * The packet carries the existing core fields ([type], [id], [messageId], [endpoint], [data])
+ * plus an extensible [metadata] TLV-style section. [metadata] is a map from 16-bit tag to raw
+ * opaque bytes; consumers decode each tag according to their own rules and silently ignore
+ * tags they don't recognise. The map defaults to empty and is omitted from the wire when empty,
+ * so packets without metadata are byte-identical to the pre-TLV format.
+ *
+ * Reserved tag values are documented in [PacketTlv]; tag numbers are allocated there, but the
+ * library performs no validation beyond "decoding unknown tags must not fail."
+ *
+ * See issue #70. This is the one-time wire break; from this release forward, new metadata
+ * tags can be added without requiring peer upgrades.
+ */
 @KsrpcInternal
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class Packet<T>(
     @SerialName("t")
@@ -32,7 +50,17 @@ data class Packet<T>(
     @SerialName("e")
     val endpoint: String,
     @SerialName("d")
-    val data: T
+    val data: T,
+    /**
+     * Extensible metadata section: a map from 16-bit tag number to opaque bytes. Empty by
+     * default; when empty the field is omitted from the wire (see [EncodeDefault.Mode.NEVER]).
+     *
+     * Consumers reading this map should look up the specific tags they care about and ignore
+     * the rest — this is what makes future additions forward-compatible.
+     */
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    @SerialName("x")
+    val metadata: Map<Int, ByteArray> = emptyMap()
 ) {
     val input: Boolean get() = (type and 1) != 0
     val binary: Boolean get() = (type and 2) != 0
@@ -54,7 +82,8 @@ data class Packet<T>(
         id: String,
         messageId: String,
         endpoint: String,
-        data: T
+        data: T,
+        metadata: Map<Int, ByteArray> = emptyMap()
     ) : this(
         (if (input) 1 else 0) or
             (if (binary) 2 else 0) or
@@ -63,8 +92,40 @@ data class Packet<T>(
         id,
         messageId,
         endpoint,
-        data
+        data,
+        metadata
     )
+
+    // equals/hashCode: ByteArray identity is reference-based by default, which is wrong for
+    // a value-style data class. Override so test round-trips can compare cleanly.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Packet<*>) return false
+        if (type != other.type) return false
+        if (id != other.id) return false
+        if (messageId != other.messageId) return false
+        if (endpoint != other.endpoint) return false
+        if (data != other.data) return false
+        if (metadata.size != other.metadata.size) return false
+        for ((k, v) in metadata) {
+            val ov = other.metadata[k] ?: return false
+            if (!v.contentEquals(ov)) return false
+        }
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = type
+        result = 31 * result + id.hashCode()
+        result = 31 * result + messageId.hashCode()
+        result = 31 * result + endpoint.hashCode()
+        result = 31 * result + (data?.hashCode() ?: 0)
+        for ((k, v) in metadata) {
+            result = 31 * result + k
+            result = 31 * result + v.contentHashCode()
+        }
+        return result
+    }
 }
 
 @KsrpcInternal

--- a/ksrpc-packets/src/commonMain/kotlin/PacketTlv.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketTlv.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.packets.internal
+
+/**
+ * Reserved tag numbers for the [Packet.metadata] TLV section (see issue #70).
+ *
+ * Tags are 16-bit unsigned values carried in a map keyed by [Int]. Allocations happen here
+ * from 1 upward; tag 0 is reserved as "unassigned". Implementations MUST silently ignore
+ * tags they do not recognise — this is the forward-compatibility contract that the TLV
+ * section exists to guarantee.
+ *
+ * Adding a new tag is NOT a wire break provided older peers leave it in place (or drop it)
+ * without failing. Removing a tag IS a break if in-flight peers require it.
+ */
+object PacketTlv {
+    /** Reserved for #28 context propagation. Value encoding: consumer-defined. */
+    const val CONTEXT_MAP: Int = 1
+
+    /** Largest valid tag value (16-bit unsigned). */
+    const val MAX_TAG: Int = 0xFFFF
+}

--- a/ksrpc-test/src/commonTest/kotlin/PacketMetadataTlvTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketMetadataTlvTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.packets.internal.Packet
+import com.monkopedia.ksrpc.packets.internal.PacketTlv
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Covers the TLV metadata contract added in issue #70.
+ *
+ * The critical guarantee under test: a packet produced by a peer that adds a metadata tag
+ * the current decoder has never heard of must still decode cleanly, with the unknown tag
+ * preserved (or at minimum ignored) — that is the forward-compat contract.
+ */
+class PacketMetadataTlvTest {
+
+    private val json = Json
+    private val serializer = Packet.serializer(String.serializer())
+
+    @Test
+    fun emptyMetadataIsOmittedFromWire() {
+        // With @EncodeDefault(NEVER) the field must not appear in the serialised form when
+        // empty. This keeps packets without metadata byte-identical to the pre-TLV format
+        // for already-connected empty flows.
+        val packet = Packet(
+            input = true,
+            id = "channel",
+            messageId = "42",
+            endpoint = "/do",
+            data = "payload"
+        )
+
+        val encoded = json.encodeToString(serializer, packet)
+
+        assertFalse("\"x\"" in encoded, "expected metadata key 'x' absent when empty: $encoded")
+    }
+
+    @Test
+    fun roundTripPreservesKnownMetadataEntries() {
+        val packet = Packet(
+            input = false,
+            id = "channel",
+            messageId = "7",
+            endpoint = "/do",
+            data = "payload",
+            metadata = mapOf(
+                PacketTlv.CONTEXT_MAP to byteArrayOf(1, 2, 3, 4),
+                42 to byteArrayOf(9, 8)
+            )
+        )
+
+        val encoded = json.encodeToString(serializer, packet)
+        val decoded = json.decodeFromString(serializer, encoded)
+
+        assertEquals(2, decoded.metadata.size)
+        assertTrue(decoded.metadata[PacketTlv.CONTEXT_MAP]!!.contentEquals(byteArrayOf(1, 2, 3, 4)))
+        assertTrue(decoded.metadata[42]!!.contentEquals(byteArrayOf(9, 8)))
+        assertEquals(packet, decoded)
+    }
+
+    @Test
+    fun forwardCompatUnknownTagSurvivesDecode() {
+        // Simulate a "future" peer adding a tag (99) that the current code has no awareness
+        // of. The decoder must still succeed; consumers looking for tag 99 would find the
+        // raw bytes, while consumers only aware of (say) CONTEXT_MAP skip it entirely. This
+        // is the contract that makes post-1.0 additions non-breaking.
+        val future = Packet(
+            input = true,
+            id = "channel",
+            messageId = "1",
+            endpoint = "/do",
+            data = "payload",
+            metadata = mapOf(99 to "hello".encodeToByteArray())
+        )
+
+        val encoded = json.encodeToString(serializer, future)
+        val decoded = json.decodeFromString(serializer, encoded)
+
+        // Current code doesn't know tag 99 exists; it should still round-trip.
+        assertEquals(1, decoded.metadata.size)
+        assertTrue(decoded.metadata[99]!!.contentEquals("hello".encodeToByteArray()))
+
+        // And a consumer that only cares about CONTEXT_MAP sees nothing for it, no crash.
+        assertEquals(null, decoded.metadata[PacketTlv.CONTEXT_MAP])
+    }
+
+    @Test
+    fun decodingPreTlvPayloadYieldsEmptyMetadata() {
+        // A packet produced by an older encoder (pre-#70) has no 'x' field. The default
+        // value on the constructor means decoding gives an empty map, no failure.
+        val legacyWire = """{"t":1,"i":"channel","m":"1","e":"/do","d":"payload"}"""
+
+        val decoded = json.decodeFromString(serializer, legacyWire)
+
+        assertTrue(decoded.metadata.isEmpty())
+        assertEquals("channel", decoded.id)
+        assertEquals("1", decoded.messageId)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `metadata: Map<Int, ByteArray>` section to `Packet` so future fields (auth, tracing, context propagation from #28, etc.) can be added without peers-must-upgrade-together wire breaks.
- Empty metadata is omitted from the wire via `@EncodeDefault(Mode.NEVER)`, so packets without metadata are byte-identical to the pre-TLV format.
- Introduces `PacketTlv` as a reserved tag registry; `CONTEXT_MAP = 1` is pre-reserved for #28. Tags are 16-bit; unknown tags are silently preserved/ignored.

## One-time wire break

The packet format changes in this PR between pre-1.0 and this release — a new serialised key (`x`) is introduced. An old peer receiving a new packet that contains a non-empty metadata map will reject it unless configured with `ignoreUnknownKeys`. Because empty metadata is not encoded, pre-existing deployments that don't opt into any metadata continue to interoperate unchanged.

**From this PR forward**, new metadata TLVs can be added without breaks: new peers write new tags, old peers that already understand the `x` key simply skip the ones they don't know. This is the forward-compat guarantee #70 exists to establish before the 1.0.0 format freeze.

## Implementation notes

- The TLV concept maps to an extensible `Map<Int, ByteArray>` field because `Packet` is encoded via the user-supplied `CallDataSerializer` (JSON by default, but pluggable). Rather than imposing a length-prefixed binary layout — which would fight every non-binary format — the TLV section rides on the chosen serializer's native map encoding. Forward-compat is preserved because consumers look up tags they know about and leave unknown entries alone.
- `PacketChannelBase` doesn't need a change: the new field defaults to empty, so existing send/receive paths already carry it correctly.
- No production consumers set metadata in this PR — #28 will fill it.

## TLV shape chosen

- Tag: 16-bit (`Int`, validated by convention via `PacketTlv.MAX_TAG = 0xFFFF`).
- Length: implicit (delegated to the underlying serializer's ByteArray encoding).
- Value: raw bytes, opaque.
- Count: implicit (serializer-native map size; JSON writes the full map).

## Test plan

- [x] `./gradlew :ksrpc-packets:compileKotlinJvm :ksrpc-packets:compileKotlinLinuxX64`
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-core:jvmTest :compiler:ksrpc-compiler-plugin:test`
- [x] `./gradlew :ksrpc-test:linuxX64Test`
- [x] `./gradlew apiDump && apiCheck`
- [x] ktlint clean on touched files (`PacketMetadataTlvTest.kt`, `Packet.kt`, `PacketTlv.kt`).
- [x] New `PacketMetadataTlvTest` covers: empty-metadata omission, round-trip preservation, forward-compat with an unknown tag (99), pre-TLV wire decode yielding empty metadata.

Closes #70

Generated with Claude Code