### PR TITLE
Fix #23: drop data class from Packet to reduce 1.0.0 opt-in commitment surface

### DIFF
--- a/ksrpc-packets/api/ksrpc-packets.api
+++ b/ksrpc-packets/api/ksrpc-packets.api
@@ -9,14 +9,6 @@ public final class com/monkopedia/ksrpc/packets/internal/Packet {
 	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
 	public synthetic fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/Object;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Lcom/monkopedia/ksrpc/packets/internal/Packet;
-	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/packets/internal/Packet;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/packets/internal/Packet;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBinary ()Z
 	public final fun getCancel ()Z
 	public final fun getData ()Ljava/lang/Object;
@@ -26,8 +18,6 @@ public final class com/monkopedia/ksrpc/packets/internal/Packet {
 	public final fun getMessageId ()Ljava/lang/String;
 	public final fun getStartBinary ()Z
 	public final fun getType ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final synthetic class com/monkopedia/ksrpc/packets/internal/Packet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {

--- a/ksrpc-packets/api/ksrpc-packets.klib.api
+++ b/ksrpc-packets/api/ksrpc-packets.klib.api
@@ -57,16 +57,6 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/Packet { // 
     final val type // com.monkopedia.ksrpc.packets.internal/Packet.type|{}type[0]
         final fun <get-type>(): kotlin/Int // com.monkopedia.ksrpc.packets.internal/Packet.type.<get-type>|<get-type>(){}[0]
 
-    final fun component1(): kotlin/Int // com.monkopedia.ksrpc.packets.internal/Packet.component1|component1(){}[0]
-    final fun component2(): kotlin/String // com.monkopedia.ksrpc.packets.internal/Packet.component2|component2(){}[0]
-    final fun component3(): kotlin/String // com.monkopedia.ksrpc.packets.internal/Packet.component3|component3(){}[0]
-    final fun component4(): kotlin/String // com.monkopedia.ksrpc.packets.internal/Packet.component4|component4(){}[0]
-    final fun component5(): #A // com.monkopedia.ksrpc.packets.internal/Packet.component5|component5(){}[0]
-    final fun copy(kotlin/Int = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., #A = ...): com.monkopedia.ksrpc.packets.internal/Packet<#A> // com.monkopedia.ksrpc.packets.internal/Packet.copy|copy(kotlin.Int;kotlin.String;kotlin.String;kotlin.String;1:0){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc.packets.internal/Packet.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc.packets.internal/Packet.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // com.monkopedia.ksrpc.packets.internal/Packet.toString|toString(){}[0]
-
     final class <#A1: kotlin/Any?> $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.monkopedia.ksrpc.packets.internal/Packet<#A1>> { // com.monkopedia.ksrpc.packets.internal/Packet.$serializer|null[0]
         constructor <init>(kotlinx.serialization/KSerializer<#A1>) // com.monkopedia.ksrpc.packets.internal/Packet.$serializer.<init>|<init>(kotlinx.serialization.KSerializer<1:0>){}[0]
 

--- a/ksrpc-packets/src/commonMain/kotlin/Packet.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/Packet.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.Serializable
 
 @KsrpcInternal
 @Serializable
-data class Packet<T>(
+class Packet<T>(
     @SerialName("t")
     val type: Int = 0,
     @SerialName("i")

--- a/ksrpc-test/src/commonTest/kotlin/PacketSchemaEvolutionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketSchemaEvolutionTest.kt
@@ -83,7 +83,12 @@ class PacketSchemaEvolutionTest {
             wire
         )
 
-        assertEquals(packet, roundTripped)
+        // Packet is no longer a data class (see #23), so compare field by field.
+        assertEquals(packet.type, roundTripped.type)
+        assertEquals(packet.id, roundTripped.id)
+        assertEquals(packet.messageId, roundTripped.messageId)
+        assertEquals(packet.endpoint, roundTripped.endpoint)
+        assertEquals(packet.data, roundTripped.data)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Drops the `data` modifier on internal `Packet<T>` so `component1`..`component5`, `copy(...)`, `copy$default`, `equals`, `hashCode`, and `toString` no longer appear in the frozen 1.0.0 ABI.
- These auto-generated members lock field order forever once the library tags 1.0.0 and would prevent adding or reordering packet fields (metadata TLV, new bitfield flags, wire-format evolution) without a semver break.
- Same treatment as #21 / PR #99 applied to `KsrpcEnvironmentBuilder`; `Packet` is even safer since it's already effectively an internal transport symbol (only used by transport-plugin callers).

The constructor surface (`Packet(type, id, messageId, endpoint, data)` plus the boolean-flag overload) and all property accessors are unchanged. No call site in the repo destructures `Packet` or calls `Packet.copy(...)`, so no internal updates were required.

## BCV delta

```
-  public final fun component1 ()I
-  public final fun component2 ()Ljava/lang/String;
-  public final fun component3 ()Ljava/lang/String;
-  public final fun component4 ()Ljava/lang/String;
-  public final fun component5 ()Ljava/lang/Object;
-  public final fun copy (ILjava/lang/String;...)Lcom/monkopedia/ksrpc/packets/internal/Packet;
-  public static synthetic fun copy$default (...)Lcom/monkopedia/ksrpc/packets/internal/Packet;
-  public fun equals (Ljava/lang/Object;)Z
-  public fun hashCode ()I
-  public fun toString ()Ljava/lang/String;
```

Mirrored in the klib ABI dump.

## Test plan

- [x] `./gradlew :ksrpc-packets:jvmTest :ksrpc-packets:linuxX64Test`
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test`
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test`
- [x] `./gradlew :ksrpc-packets:apiDump` + `apiCheck` (dump delta committed)
- [x] `./gradlew :ksrpc-packets:ktlintCheck`

Closes #23