### PR TITLE
Fix #54: add cross-module compile-testing coverage for the ksrpc compiler plugin

### DIFF
--- a/compiler/plugin/src/test/java/CrossModuleCompileTest.kt
+++ b/compiler/plugin/src/test/java/CrossModuleCompileTest.kt
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Two-stage `KotlinCompilation` tests covering cross-module usage of the ksrpc
+ * compiler plugin (issue #54).
+ *
+ * Each test compiles a "library" module first that declares a `@KsService`
+ * interface, then compiles a "consumer" module that references the library's
+ * service — e.g. implementing it, constructing a `Stub`/`RpcObject`, or
+ * calling `toStub<Foo>()`. The consumer's classpath includes the library's
+ * `classesDir`, mirroring how a real downstream KMP module sees a dependency
+ * module's already-compiled output.
+ *
+ * This exercises plugin code paths that behave differently for
+ * already-compiled binary dependencies (FIR `getCallableNamesForClass` does
+ * not fire for types loaded off the classpath, so the consumer's IR-phase
+ * stub/obj generation has to resolve the library-emitted companion by
+ * symbol lookup rather than by re-synthesizing it).
+ */
+class CrossModuleCompileTest {
+
+    @Test
+    fun `non-generic service in library, implementation in consumer`() {
+        val library = SourceFile.kotlin(
+            "Library.kt",
+            """
+package lib
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Foo : RpcService {
+    @KsMethod("/greet")
+    suspend fun greet(name: String): String
+}
+"""
+        )
+        val libraryResult = CrossModuleTestHarness.compileLibrary(library)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            libraryResult.exitCode,
+            "library compile failed: ${libraryResult.messages}"
+        )
+
+        val consumer = SourceFile.kotlin(
+            "App.kt",
+            """
+package app
+
+import lib.Foo
+
+class FooImpl : Foo {
+    override suspend fun greet(name: String): String = "Hello, ${"$"}name"
+}
+"""
+        )
+        val consumerResult = CrossModuleTestHarness.compileConsumer(libraryResult, consumer)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            consumerResult.exitCode,
+            "consumer compile failed: ${consumerResult.messages}"
+        )
+    }
+
+    @Test
+    fun `non-generic service in library, stub construction in consumer`() {
+        // Consumer constructs the library's plugin-generated Stub directly. This
+        // verifies the companion/Stub classes emitted into the library's classfiles
+        // are visible and callable from a downstream compilation — the core gap
+        // flagged in issue #54.
+        val library = SourceFile.kotlin(
+            "Library.kt",
+            """
+package lib
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Bar : RpcService {
+    @KsMethod("/ping")
+    suspend fun ping(u: Unit): String
+}
+"""
+        )
+        val libraryResult = CrossModuleTestHarness.compileLibrary(library)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            libraryResult.exitCode,
+            "library compile failed: ${libraryResult.messages}"
+        )
+
+        val consumer = SourceFile.kotlin(
+            "App.kt",
+            """
+package app
+
+import com.monkopedia.ksrpc.channels.SerializedService
+import lib.Bar
+
+fun <S> useStub(channel: SerializedService<S>): Bar = Bar.Stub(channel)
+"""
+        )
+        val consumerResult = CrossModuleTestHarness.compileConsumer(libraryResult, consumer)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            consumerResult.exitCode,
+            "consumer compile failed: ${consumerResult.messages}"
+        )
+    }
+
+    @Test
+    fun `service in library, toStub consumer in app resolves library companion`() {
+        // `toStub<T>()` is the reified-inline entry point in ksrpc-core — it calls
+        // `rpcObject<T>()` whose expected body is `T.Companion`. The library's
+        // plugin-emitted companion has to be resolvable from the consumer
+        // compilation's reified call site or this fails to resolve.
+        val library = SourceFile.kotlin(
+            "Library.kt",
+            """
+package lib
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Baz : RpcService {
+    @KsMethod("/echo")
+    suspend fun echo(value: String): String
+}
+"""
+        )
+        val libraryResult = CrossModuleTestHarness.compileLibrary(library)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            libraryResult.exitCode,
+            "library compile failed: ${libraryResult.messages}"
+        )
+
+        val consumer = SourceFile.kotlin(
+            "App.kt",
+            """
+package app
+
+import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.toStub
+import lib.Baz
+
+fun <S> useStub(channel: SerializedService<S>): Baz = channel.toStub<Baz, S>()
+"""
+        )
+        val consumerResult = CrossModuleTestHarness.compileConsumer(libraryResult, consumer)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            consumerResult.exitCode,
+            "consumer compile failed: ${consumerResult.messages}"
+        )
+    }
+
+    @Test
+    fun `generic service in library, concrete-type usage in consumer`() {
+        // Covers the generic-across-modules path: a 1-type-param `@KsService`
+        // compiled in the library, then instantiated in the consumer with a
+        // concrete `@Serializable` element type. The consumer must be able to
+        // (a) subtype the library service at a concrete T and (b) construct
+        // the library's generated `Stub<T>(channel, serializer)` form.
+        val library = SourceFile.kotlin(
+            "Library.kt",
+            """
+package lib
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface Stream<T> : RpcService {
+    @KsMethod("/next")
+    suspend fun next(u: Unit): T
+}
+"""
+        )
+        val libraryResult = CrossModuleTestHarness.compileLibrary(library)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            libraryResult.exitCode,
+            "library compile failed: ${libraryResult.messages}"
+        )
+
+        val consumer = SourceFile.kotlin(
+            "App.kt",
+            """
+package app
+
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import lib.Stream
+
+@Serializable
+data class Item(val id: Int)
+
+class ItemStream : Stream<Item> {
+    override suspend fun next(u: Unit): Item = Item(0)
+}
+
+fun <S> useStub(
+    channel: SerializedService<S>,
+    serializer: KSerializer<Item>
+): Stream<Item> = Stream.Stub<Item>(channel, serializer)
+"""
+        )
+        val consumerResult = CrossModuleTestHarness.compileConsumer(libraryResult, consumer)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            consumerResult.exitCode,
+            "consumer compile failed: ${consumerResult.messages}"
+        )
+    }
+}

--- a/compiler/plugin/src/test/java/CrossModuleTestHarness.kt
+++ b/compiler/plugin/src/test/java/CrossModuleTestHarness.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+/**
+ * Harness for two-stage `KotlinCompilation` tests that exercise the compiler plugin
+ * across a "library" module and a downstream "consumer" module (issue #54).
+ *
+ * The library module compiles first with the ksrpc compiler plugin applied, producing
+ * `@KsService` interfaces plus their plugin-generated companion/Stub/RpcObject bodies.
+ * The consumer module compiles second, also with the plugin applied, with the library's
+ * `classesDir` prepended to its classpath — mirroring how a real downstream KMP module
+ * sees a dependency module's compiled output.
+ *
+ * This exercises the code paths that behave differently for already-compiled binaries
+ * (e.g. FIR-phase `getCallableNamesForClass` doesn't fire for types read off the
+ * classpath, but the consumer's IR-phase stub/obj generation still has to resolve the
+ * companion emitted into the library's classfiles).
+ */
+object CrossModuleTestHarness {
+
+    /**
+     * Compile [librarySources] with the ksrpc plugin applied. Returns the compilation
+     * result; callers typically assert `exitCode == OK` and pass the result into
+     * [compileConsumer] to stitch its `classesDir` onto a downstream compilation.
+     */
+    fun compileLibrary(librarySources: List<SourceFile>): JvmCompilationResult =
+        KotlinCompilation().apply {
+            sources = librarySources
+            compilerPluginRegistrars = listOf(KsrpcComponentRegistrar())
+            inheritClassPath = true
+        }.compile()
+
+    /** Convenience overload for a single-source library module. */
+    fun compileLibrary(librarySource: SourceFile): JvmCompilationResult =
+        compileLibrary(listOf(librarySource))
+
+    /**
+     * Compile [consumerSources] with the ksrpc plugin applied, with
+     * [libraryResult].classesDir prepended to the classpath so the consumer sees the
+     * library's compiled classes (including the plugin-generated companions and Stubs).
+     *
+     * Uses `inheritClassPath = true` so the test-runtime classpath (ksrpc-core,
+     * kotlinx.serialization, etc.) is still available to the consumer; only the
+     * library's classfiles are added on top via [KotlinCompilation.classpaths].
+     */
+    fun compileConsumer(
+        libraryResult: JvmCompilationResult,
+        consumerSources: List<SourceFile>
+    ): JvmCompilationResult = KotlinCompilation().apply {
+        sources = consumerSources
+        compilerPluginRegistrars = listOf(KsrpcComponentRegistrar())
+        inheritClassPath = true
+        classpaths = listOf(libraryResult.outputDirectory) + classpaths
+    }.compile()
+
+    /** Convenience overload for a single-source consumer module. */
+    fun compileConsumer(
+        libraryResult: JvmCompilationResult,
+        consumerSource: SourceFile
+    ): JvmCompilationResult = compileConsumer(libraryResult, listOf(consumerSource))
+}


### PR DESCRIPTION
## Summary

- Add `CrossModuleTestHarness` — a two-stage `KotlinCompilation` helper that compiles a "library" source set with the ksrpc compiler plugin applied, then compiles a "consumer" source set that sees the library's `outputDirectory` on its classpath. Mirrors how a downstream KMP module sees a dependency module's already-compiled classfiles.
- Add `CrossModuleCompileTest` with four cases driven by the harness:
  - Non-generic `@KsService` in the library module, `class FooImpl : Foo` in the consumer module.
  - Non-generic service in the library, consumer constructs the library's generated `Foo.Stub(channel)` directly.
  - Non-generic service in the library, consumer uses the reified `channel.toStub<Foo, S>()` helper — verifies the library-emitted companion is resolvable from a cross-module reified call site.
  - Generic 1-type-param service in the library (`Stream<T>`), consumer declares `@Serializable data class Item`, subtypes `Stream<Item>`, and constructs `Stream.Stub<Item>(channel, itemSerializer)`.
- Tests only — no production-code changes.

## Why

Per the #47 audit follow-up (#54): all prior compiler-plugin unit tests compiled the service interface and any consuming code inside a single `KotlinCompilation`. The dominant real-world usage pattern (`commonMain` declares `@KsService interface Foo`, `jvmMain`/`iosMain` or a separate Gradle module implements/consumes it) was only covered by the `ksrpc-test` integration tests, which give no plugin-level "did it compile / what was emitted" signal. This PR closes that gap at the plugin-unit-test level without touching runtime or codegen.

## Test plan

- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — all tests pass including the four new cross-module ones.
- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test` — pass.
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test` — pass (one flaky `PacketCancellationTest` hit a 5s timeout then passed on re-run; unrelated to this change since this PR is tests-only in `compiler/plugin/src/test`).
- [x] `./gradlew apiCheck` — pass.
- [x] Ktlint on touched files — pass (`runKtlintCheckOverTestSourceSet` clean; pre-existing unrelated indentation violation in generated `BuildConfig.kt` only).

No cross-module bugs surfaced — all four cases pass with current plugin behavior.

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)