### PR TITLE
Fix #76: KsrpcException base class and @KsError annotation (part 1 of #13)

### DIFF
--- a/ksrpc-api/api/ksrpc-api.api
+++ b/ksrpc-api/api/ksrpc-api.api
@@ -1,8 +1,3 @@
-public final class com/monkopedia/ksrpc/RpcException : java/lang/RuntimeException {
-	public fun <init> (Ljava/lang/String;)V
-	public fun getMessage ()Ljava/lang/String;
-}
-
 public final class com/monkopedia/ksrpc/RpcFailure {
 	public static final field Companion Lcom/monkopedia/ksrpc/RpcFailure$Companion;
 	public fun <init> (Ljava/lang/String;)V
@@ -12,7 +7,6 @@ public final class com/monkopedia/ksrpc/RpcFailure {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getStack ()Ljava/lang/String;
 	public fun hashCode ()I
-	public final fun toException ()Ljava/lang/RuntimeException;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -44,6 +38,15 @@ public abstract interface class com/monkopedia/ksrpc/SuspendCloseable {
 }
 
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/ExperimentalKsrpc : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsError : java/lang/annotation/Annotation {
+	public abstract fun code ()I
+	public abstract fun type ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsError$Container : java/lang/annotation/Annotation {
+	public abstract fun value ()[Lcom/monkopedia/ksrpc/annotation/KsError;
 }
 
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsMethod : java/lang/annotation/Annotation {

--- a/ksrpc-api/api/ksrpc-api.klib.api
+++ b/ksrpc-api/api/ksrpc-api.klib.api
@@ -10,6 +10,15 @@ open annotation class com.monkopedia.ksrpc.annotation/ExperimentalKsrpc : kotlin
     constructor <init>() // com.monkopedia.ksrpc.annotation/ExperimentalKsrpc.<init>|<init>(){}[0]
 }
 
+open annotation class com.monkopedia.ksrpc.annotation/KsError : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsError|null[0]
+    constructor <init>(kotlin/Int, kotlin.reflect/KClass<*>) // com.monkopedia.ksrpc.annotation/KsError.<init>|<init>(kotlin.Int;kotlin.reflect.KClass<*>){}[0]
+
+    final val code // com.monkopedia.ksrpc.annotation/KsError.code|{}code[0]
+        final fun <get-code>(): kotlin/Int // com.monkopedia.ksrpc.annotation/KsError.code.<get-code>|<get-code>(){}[0]
+    final val type // com.monkopedia.ksrpc.annotation/KsError.type|{}type[0]
+        final fun <get-type>(): kotlin.reflect/KClass<*> // com.monkopedia.ksrpc.annotation/KsError.type.<get-type>|<get-type>(){}[0]
+}
+
 open annotation class com.monkopedia.ksrpc.annotation/KsMethod : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsMethod|null[0]
     constructor <init>(kotlin/String) // com.monkopedia.ksrpc.annotation/KsMethod.<init>|<init>(kotlin.String){}[0]
 
@@ -52,13 +61,6 @@ abstract interface com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksr
     abstract suspend fun close() // com.monkopedia.ksrpc/SuspendCloseable.close|close(){}[0]
 }
 
-final class com.monkopedia.ksrpc/RpcException : kotlin/RuntimeException { // com.monkopedia.ksrpc/RpcException|null[0]
-    constructor <init>(kotlin/String) // com.monkopedia.ksrpc/RpcException.<init>|<init>(kotlin.String){}[0]
-
-    final val message // com.monkopedia.ksrpc/RpcException.message|{}message[0]
-        final fun <get-message>(): kotlin/String // com.monkopedia.ksrpc/RpcException.message.<get-message>|<get-message>(){}[0]
-}
-
 final class com.monkopedia.ksrpc/RpcFailure { // com.monkopedia.ksrpc/RpcFailure|null[0]
     constructor <init>(kotlin/String) // com.monkopedia.ksrpc/RpcFailure.<init>|<init>(kotlin.String){}[0]
 
@@ -69,7 +71,6 @@ final class com.monkopedia.ksrpc/RpcFailure { // com.monkopedia.ksrpc/RpcFailure
     final fun copy(kotlin/String = ...): com.monkopedia.ksrpc/RpcFailure // com.monkopedia.ksrpc/RpcFailure.copy|copy(kotlin.String){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc/RpcFailure.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc/RpcFailure.hashCode|hashCode(){}[0]
-    final fun toException(): kotlin/RuntimeException // com.monkopedia.ksrpc/RpcFailure.toException|toException(){}[0]
     final fun toString(): kotlin/String // com.monkopedia.ksrpc/RpcFailure.toString|toString(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.monkopedia.ksrpc/RpcFailure> { // com.monkopedia.ksrpc/RpcFailure.$serializer|null[0]

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsError.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsError.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.annotation
+
+import kotlin.reflect.KClass
+
+/**
+ * Binds a thrown error payload to a wire-level integer error code on a
+ * [KsMethod]-annotated function.
+ *
+ * Declared at the call site with one entry per bindable error type:
+ *
+ * ```
+ * @KsMethod("/initialize")
+ * @KsError(code = 100, type = InitError::class)
+ * @KsError(code = 101, type = VersionError::class)
+ * suspend fun initialize(params: InitParams): InitResult
+ * ```
+ *
+ * [type] must be a `@Serializable` data class (validated by the ksrpc
+ * compiler plugin in Part 2 of #13). The plugin captures
+ * `KSerializer<type>` and exposes a bidirectional map on the generated
+ * `RpcMethod` descriptor — forward (code → KSerializer) for client-side
+ * deserialization, reverse (KClass → code + KSerializer) for server-side
+ * resolution of a thrown `data::class`.
+ *
+ * Unlike sibling annotations propagated via `@KsMethodMetadata`, this
+ * marker is consumed by the compiler plugin directly because the binding
+ * requires a real serializer reference and a dedicated lookup table, not
+ * an opaque metadata bag.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@Repeatable
+annotation class KsError(val code: Int, val type: KClass<*>)

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -66,6 +66,14 @@ public final class com/monkopedia/ksrpc/KsrpcEnvironmentKt {
 	public static final fun reconfigure (Lcom/monkopedia/ksrpc/KsrpcEnvironment;Lkotlin/jvm/functions/Function1;)Lcom/monkopedia/ksrpc/KsrpcEnvironment;
 }
 
+public class com/monkopedia/ksrpc/KsrpcException : java/lang/RuntimeException {
+	public fun <init> (ILjava/lang/String;Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Object;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCode ()I
+	public final fun getData ()Ljava/lang/Object;
+	public fun getMessage ()Ljava/lang/String;
+}
+
 public abstract interface class com/monkopedia/ksrpc/Logger {
 	public fun debug (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public static synthetic fun debug$default (Lcom/monkopedia/ksrpc/Logger;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
@@ -204,8 +212,16 @@ public final class com/monkopedia/ksrpc/MethodMetadata {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class com/monkopedia/ksrpc/RpcEndpointException : java/lang/IllegalArgumentException {
+public class com/monkopedia/ksrpc/RpcEndpointException : com/monkopedia/ksrpc/KsrpcException {
 	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/monkopedia/ksrpc/RpcException : com/monkopedia/ksrpc/KsrpcException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/monkopedia/ksrpc/RpcExceptionKt {
+	public static final fun toException (Lcom/monkopedia/ksrpc/RpcFailure;)Lcom/monkopedia/ksrpc/RpcException;
 }
 
 public final class com/monkopedia/ksrpc/RpcMethod {

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -322,7 +322,22 @@ final class com.monkopedia.ksrpc/MethodMetadata { // com.monkopedia.ksrpc/Method
     final fun toString(): kotlin/String // com.monkopedia.ksrpc/MethodMetadata.toString|toString(){}[0]
 }
 
-open class com.monkopedia.ksrpc/RpcEndpointException : kotlin/IllegalArgumentException { // com.monkopedia.ksrpc/RpcEndpointException|null[0]
+final class com.monkopedia.ksrpc/RpcException : com.monkopedia.ksrpc/KsrpcException { // com.monkopedia.ksrpc/RpcException|null[0]
+    constructor <init>(kotlin/String) // com.monkopedia.ksrpc/RpcException.<init>|<init>(kotlin.String){}[0]
+}
+
+open class com.monkopedia.ksrpc/KsrpcException : kotlin/RuntimeException { // com.monkopedia.ksrpc/KsrpcException|null[0]
+    constructor <init>(kotlin/Int, kotlin/String, kotlin/Any? = ..., kotlin/Throwable? = ...) // com.monkopedia.ksrpc/KsrpcException.<init>|<init>(kotlin.Int;kotlin.String;kotlin.Any?;kotlin.Throwable?){}[0]
+
+    final val code // com.monkopedia.ksrpc/KsrpcException.code|{}code[0]
+        final fun <get-code>(): kotlin/Int // com.monkopedia.ksrpc/KsrpcException.code.<get-code>|<get-code>(){}[0]
+    final val data // com.monkopedia.ksrpc/KsrpcException.data|{}data[0]
+        final fun <get-data>(): kotlin/Any? // com.monkopedia.ksrpc/KsrpcException.data.<get-data>|<get-data>(){}[0]
+    open val message // com.monkopedia.ksrpc/KsrpcException.message|{}message[0]
+        open fun <get-message>(): kotlin/String // com.monkopedia.ksrpc/KsrpcException.message.<get-message>|<get-message>(){}[0]
+}
+
+open class com.monkopedia.ksrpc/RpcEndpointException : com.monkopedia.ksrpc/KsrpcException { // com.monkopedia.ksrpc/RpcEndpointException|null[0]
     constructor <init>(kotlin/String) // com.monkopedia.ksrpc/RpcEndpointException.<init>|<init>(kotlin.String){}[0]
 }
 
@@ -505,6 +520,7 @@ final val com.monkopedia.ksrpc/asString // com.monkopedia.ksrpc/asString|@kotlin
 final val com.monkopedia.ksrpc/timeoutMillis // com.monkopedia.ksrpc/timeoutMillis|@com.monkopedia.ksrpc.RpcMethod<*,*,*>{}timeoutMillis[0]
     final fun (com.monkopedia.ksrpc/RpcMethod<*, *, *>).<get-timeoutMillis>(): kotlin/Long? // com.monkopedia.ksrpc/timeoutMillis.<get-timeoutMillis>|<get-timeoutMillis>@com.monkopedia.ksrpc.RpcMethod<*,*,*>(){}[0]
 
+final fun (com.monkopedia.ksrpc/RpcFailure).com.monkopedia.ksrpc/toException(): com.monkopedia.ksrpc/RpcException // com.monkopedia.ksrpc/toException|toException@com.monkopedia.ksrpc.RpcFailure(){}[0]
 final fun (com.monkopedia.ksrpc/RpcObject<*>).com.monkopedia.ksrpc/serviceInterfaceName(): kotlin/String // com.monkopedia.ksrpc/serviceInterfaceName|serviceInterfaceName@com.monkopedia.ksrpc.RpcObject<*>(){}[0]
 final fun <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> (#A).com.monkopedia.ksrpc/serialized(com.monkopedia.ksrpc/RpcObject<#A>, com.monkopedia.ksrpc/KsrpcEnvironment<#B>): com.monkopedia.ksrpc.channels/SerializedService<#B> // com.monkopedia.ksrpc/serialized|serialized@0:0(com.monkopedia.ksrpc.RpcObject<0:0>;com.monkopedia.ksrpc.KsrpcEnvironment<0:1>){0§<com.monkopedia.ksrpc.RpcService>;1§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/onError(com.monkopedia.ksrpc/ErrorListener): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/onError|onError@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(com.monkopedia.ksrpc.ErrorListener){0§<kotlin.Any?>}[0]

--- a/ksrpc-core/src/commonMain/kotlin/KsrpcException.kt
+++ b/ksrpc-core/src/commonMain/kotlin/KsrpcException.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+/**
+ * Base class for exceptions thrown by the ksrpc runtime.
+ *
+ * Carries an integer [code] classifying the error, a human-readable [message]
+ * for wire-format compatibility and fallback debugging, and an optional typed
+ * [data] payload. When a method declares `@KsError` bindings, the runtime
+ * deserializes the wire payload into the mapped `@Serializable` type and
+ * exposes it here; callers that handle a known error type down-cast [data] to
+ * inspect it, while callers without a typed mapping observe `data == null`
+ * and rely on [code] + [message].
+ *
+ * Subclasses may narrow the conventions (e.g. [RpcException] pins `code = -1`,
+ * [RpcEndpointException] pins `code = -32601`), and transports translate
+ * [code] into their native error envelope.
+ */
+open class KsrpcException(
+    val code: Int,
+    override val message: String,
+    val data: Any? = null,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/ksrpc-core/src/commonMain/kotlin/RpcException.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcException.kt
@@ -15,13 +15,16 @@
  */
 package com.monkopedia.ksrpc
 
-import kotlinx.serialization.Serializable
+/**
+ * Wrapper around exceptions thrown in remote calls.
+ *
+ * Pins [code] to `-1` — a generic "remote error" classification. Typed
+ * binding of error codes to `@Serializable` data classes via `@KsError`
+ * will surface as bare [KsrpcException] instances with mapped `code`/`data`.
+ */
+class RpcException(message: String) : KsrpcException(code = -1, message = message)
 
 /**
- * Serializable wrapper around exceptions thrown in remote calls.
- *
- * The concrete `toException` builder lives in `ksrpc-core`, where the
- * `RpcException`/`KsrpcException` hierarchy is declared.
+ * Build an [RpcException] carrying the stack captured in this [RpcFailure].
  */
-@Serializable
-data class RpcFailure(val stack: String)
+fun RpcFailure.toException(): RpcException = RpcException(stack)

--- a/ksrpc-core/src/commonMain/kotlin/RpcServiceUtils.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcServiceUtils.kt
@@ -50,5 +50,8 @@ inline fun <reified T : RpcService, S> SerializedService<S>.toStub(): T =
 /**
  * Thrown when an endpoint cannot be found.
  * Could happen from version mismatch or other programmer errors.
+ *
+ * Pins [code] to `-32601` to align with the JSON-RPC "method not found"
+ * error code; HTTP transports translate this to `404` in Part 4 of #13.
  */
-open class RpcEndpointException(str: String) : IllegalArgumentException(str)
+open class RpcEndpointException(str: String) : KsrpcException(code = -32601, message = str)

--- a/ksrpc-core/src/commonTest/kotlin/KsrpcExceptionTest.kt
+++ b/ksrpc-core/src/commonTest/kotlin/KsrpcExceptionTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class KsrpcExceptionTest {
+
+    @Test
+    fun ksrpcException_storesAllFields() {
+        val payload = "details"
+        val cause = IllegalStateException("root")
+        val exception = KsrpcException(
+            code = 42,
+            message = "something broke",
+            data = payload,
+            cause = cause
+        )
+        assertEquals(42, exception.code)
+        assertEquals("something broke", exception.message)
+        assertSame(payload, exception.data)
+        assertSame(cause, exception.cause)
+    }
+
+    @Test
+    fun ksrpcException_defaultsDataAndCauseToNull() {
+        val exception = KsrpcException(code = 7, message = "no payload")
+        assertEquals(7, exception.code)
+        assertEquals("no payload", exception.message)
+        assertNull(exception.data)
+        assertNull(exception.cause)
+    }
+
+    @Test
+    fun ksrpcException_isRuntimeException() {
+        val exception: Throwable = KsrpcException(code = 1, message = "x")
+        assertIs<RuntimeException>(exception)
+    }
+}

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowService.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowService.kt
@@ -17,6 +17,7 @@ package com.monkopedia.ksrpc.flow
 
 import com.monkopedia.ksrpc.RpcFailure
 import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.toException
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
 import kotlinx.coroutines.CancellationException

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowService.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowService.kt
@@ -17,9 +17,9 @@ package com.monkopedia.ksrpc.flow
 
 import com.monkopedia.ksrpc.RpcFailure
 import com.monkopedia.ksrpc.RpcService
-import com.monkopedia.ksrpc.toException
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.toException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow

--- a/ksrpc-jni/src/commonMain/kotlin/com/monkopedia/ksrpc/jni/JniSerialization.kt
+++ b/ksrpc-jni/src/commonMain/kotlin/com/monkopedia/ksrpc/jni/JniSerialization.kt
@@ -21,6 +21,7 @@ import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.RpcEndpointException
 import com.monkopedia.ksrpc.RpcFailure
 import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.toException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers

--- a/ksrpc-jni/src/jvmMain/kotlin/com/monkopedia/ksrpc/jni/JavaJniContinuation.kt
+++ b/ksrpc-jni/src/jvmMain/kotlin/com/monkopedia/ksrpc/jni/JavaJniContinuation.kt
@@ -18,6 +18,7 @@
 package com.monkopedia.ksrpc.jni
 
 import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.toException
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException

--- a/ksrpc-jni/src/nativeMain/kotlin/com/monkopedia/ksrpc/jni/NativeJniContinuation.kt
+++ b/ksrpc-jni/src/nativeMain/kotlin/com/monkopedia/ksrpc/jni/NativeJniContinuation.kt
@@ -23,6 +23,7 @@ import com.monkopedia.jni.jobject
 import com.monkopedia.jnitest.JNI
 import com.monkopedia.jnitest.initThread
 import com.monkopedia.ksrpc.RpcFailure
+import com.monkopedia.ksrpc.toException
 import kotlin.coroutines.Continuation
 import kotlin.experimental.ExperimentalNativeApi
 import kotlinx.cinterop.CPointed

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
@@ -29,6 +29,7 @@ import com.monkopedia.ksrpc.channels.awaitRequestCancellable
 import com.monkopedia.ksrpc.internal.MultiChannel
 import com.monkopedia.ksrpc.jsonrpc.JsonRpcCallId
 import com.monkopedia.ksrpc.jsonrpc.JsonRpcCancellationConvention
+import com.monkopedia.ksrpc.toException
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred

--- a/ksrpc-ktor/client/src/commonMain/kotlin/HttpSerializedChannel.kt
+++ b/ksrpc-ktor/client/src/commonMain/kotlin/HttpSerializedChannel.kt
@@ -33,6 +33,7 @@ import com.monkopedia.ksrpc.internal.ClientChannelContext
 import com.monkopedia.ksrpc.internal.ENDPOINT_NOT_FOUND_PREFIX
 import com.monkopedia.ksrpc.internal.ERROR_PREFIX
 import com.monkopedia.ksrpc.internal.SubserviceChannel
+import com.monkopedia.ksrpc.toException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.accept

--- a/ksrpc-test/src/commonTest/kotlin/RpcEndpointExceptionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcEndpointExceptionTest.kt
@@ -22,10 +22,17 @@ import kotlin.test.assertIs
 class RpcEndpointExceptionTest {
 
     @Test
-    fun rpcEndpointExceptionIsIllegalArgumentExceptionWithMessage() {
+    fun rpcEndpointExceptionIsKsrpcExceptionWithMessage() {
         val exception = RpcEndpointException("missing endpoint")
 
-        assertIs<IllegalArgumentException>(exception)
+        assertIs<KsrpcException>(exception)
         assertEquals("missing endpoint", exception.message)
+    }
+
+    @Test
+    fun rpcEndpointExceptionPinsJsonRpcMethodNotFoundCode() {
+        val exception = RpcEndpointException("missing endpoint")
+
+        assertEquals(-32601, exception.code)
     }
 }


### PR DESCRIPTION
## Summary

Part 1 of 4 for typed error binding (#13). Introduces the type surface only — compiler plumbing (#77), runtime routing (#78), and transport wire formats (#79) follow.

- New `KsrpcException(code, message, data, cause)` base class in `ksrpc-core`. `data: Any?` stays runtime-only so ksrpc-api stays annotation-only.
- `RpcException` moves from ksrpc-api to ksrpc-core and extends `KsrpcException(code = -1, message)`. `RpcFailure` stays in ksrpc-api; its `toException()` becomes an extension function declared in ksrpc-core returning `RpcException`.
- `RpcEndpointException` is retargeted from `IllegalArgumentException` to `KsrpcException`, pinning `code = -32601` (JSON-RPC "method not found") — HTTP transports will translate that to 404 in #79.
- New `@KsError(code: Int, type: KClass<*>)` annotation in `ksrpc-api.annotation`, `@Repeatable`, `BINARY` retention, function target. Consumed directly by the plugin (no `@KsMethodMetadata`) because the downstream binding needs a real serializer reference and a dedicated bidirectional lookup table.

## Scope deferred

- **`@Serializable` validation of `@KsError.type`:** the compiler plugin validation requires FIR diagnostic plumbing that fits better alongside the bidirectional-map work. Deferred to #77 as the task permitted.

## BCV delta

**ksrpc-api**
- Removed: `com.monkopedia.ksrpc.RpcException`
- Removed: `com.monkopedia.ksrpc.RpcFailure.toException()`
- Added: `com.monkopedia.ksrpc.annotation.KsError` (+ compiler-generated `KsError.Container` for `@Repeatable`)

**ksrpc-core**
- Added: `com.monkopedia.ksrpc.KsrpcException`
- Added: `com.monkopedia.ksrpc.RpcException : KsrpcException`
- Added: `com.monkopedia.ksrpc.RpcExceptionKt.toException(RpcFailure): RpcException`
- Changed: `RpcEndpointException` supertype `IllegalArgumentException -> KsrpcException`

## Downstream impact

- Imports of `com.monkopedia.ksrpc.RpcException` are unchanged (same package). Only consumers that pulled it from ksrpc-api in isolation need to add ksrpc-core — none in this repo.
- Consumers outside the `com.monkopedia.ksrpc` package that call `RpcFailure.toException()` need an explicit `import com.monkopedia.ksrpc.toException` (now an extension). Updated internally in ksrpc-flow, ksrpc-jni (common + jvm + native), ksrpc-ktor/client, ksrpc-jsonrpc.
- `RpcEndpointException` no longer extends `IllegalArgumentException`. The only `catch (e: IllegalArgumentException)` in the codebase (`RpcObjectFactory.resolveSerializerOrThrow`) is scoped to `kotlinx.serialization` failures and doesn't rely on this.
- `RpcFailure.toException()` now statically returns `RpcException` instead of `RuntimeException`.

## Test plan

- [x] `./gradlew :ksrpc-core:jvmTest :ksrpc-core:linuxX64Test`
- [x] `./gradlew :ksrpc-api:jvmTest` (no sources)
- [x] `./gradlew :ksrpc-test:jvmTest :ksrpc-test:linuxX64Test`
- [x] `./gradlew :ksrpc-jsonrpc:jvmTest` (linuxX64 skipped — no test sources)
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test`
- [x] `./gradlew apiDump && apiCheck`
- [x] ktlint clean on touched files
- [x] `RpcEndpointExceptionTest` updated: asserts `KsrpcException` supertype and pinned code

Closes #76.

Generated with [Claude Code](https://claude.com/claude-code)