### PR TITLE
Fix #70: default Packet serializer to ignoreUnknownKeys for schema evolution

### DIFF
--- a/ksrpc-ktor/websocket/shared/src/commonMain/kotlin/WebsocketPacketChannel.kt
+++ b/ksrpc-ktor/websocket/shared/src/commonMain/kotlin/WebsocketPacketChannel.kt
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(KsrpcInternal::class)
+
 package com.monkopedia.ksrpc.ktor.websocket.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.packets.internal.PACKET_JSON
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
@@ -26,7 +29,6 @@ import io.ktor.utils.io.charsets.Charsets
 import io.ktor.websocket.DefaultWebSocketSession
 import io.ktor.websocket.close
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.serialization.json.Json
 
 @KsrpcInternal
 @OptIn(InternalAPI::class)
@@ -35,7 +37,7 @@ class WebsocketPacketChannel(
     private val socketSession: DefaultWebSocketSession,
     env: KsrpcEnvironment<String>
 ) : PacketChannelBase<String>(scope, env) {
-    private val converter = KotlinxWebsocketSerializationConverter(Json)
+    private val converter = KotlinxWebsocketSerializationConverter(PACKET_JSON)
 
     init {
         startReceiveLoop()

--- a/ksrpc-packets/api/ksrpc-packets.api
+++ b/ksrpc-packets/api/ksrpc-packets.api
@@ -81,3 +81,7 @@ public abstract class com/monkopedia/ksrpc/packets/internal/PacketChannelBase : 
 	public fun wrapChannel (Lcom/monkopedia/ksrpc/channels/ChannelId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/monkopedia/ksrpc/packets/internal/PacketJsonKt {
+	public static final fun getPACKET_JSON ()Lkotlinx/serialization/json/Json;
+}
+

--- a/ksrpc-packets/api/ksrpc-packets.klib.api
+++ b/ksrpc-packets/api/ksrpc-packets.klib.api
@@ -109,3 +109,6 @@ final const val com.monkopedia.ksrpc.packets.internal/CONTENT_LENGTH // com.monk
     final fun <get-CONTENT_LENGTH>(): kotlin/String // com.monkopedia.ksrpc.packets.internal/CONTENT_LENGTH.<get-CONTENT_LENGTH>|<get-CONTENT_LENGTH>(){}[0]
 final const val com.monkopedia.ksrpc.packets.internal/CONTENT_TYPE // com.monkopedia.ksrpc.packets.internal/CONTENT_TYPE|{}CONTENT_TYPE[0]
     final fun <get-CONTENT_TYPE>(): kotlin/String // com.monkopedia.ksrpc.packets.internal/CONTENT_TYPE.<get-CONTENT_TYPE>|<get-CONTENT_TYPE>(){}[0]
+
+final val com.monkopedia.ksrpc.packets.internal/PACKET_JSON // com.monkopedia.ksrpc.packets.internal/PACKET_JSON|{}PACKET_JSON[0]
+    final fun <get-PACKET_JSON>(): kotlinx.serialization.json/Json // com.monkopedia.ksrpc.packets.internal/PACKET_JSON.<get-PACKET_JSON>|<get-PACKET_JSON>(){}[0]

--- a/ksrpc-packets/src/commonMain/kotlin/PacketJson.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketJson.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.packets.internal
+
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import kotlinx.serialization.json.Json
+
+/**
+ * Json instance used for serializing the [Packet] wire envelope. Configured with
+ * `ignoreUnknownKeys = true` so that new optional fields on [Packet] in future releases
+ * don't break peers compiled against the older schema.
+ *
+ * This is intentionally internal to ksrpc-packets — the user's configured
+ * [com.monkopedia.ksrpc.CallDataSerializer] controls serialization of user-declared
+ * method inputs/outputs, but the packet envelope itself is ksrpc's wire concern.
+ */
+@KsrpcInternal
+val PACKET_JSON: Json = Json { ignoreUnknownKeys = true }

--- a/ksrpc-service-worker/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsJs.kt
+++ b/ksrpc-service-worker/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsJs.kt
@@ -18,12 +18,11 @@
 
 package com.monkopedia.ksrpc.webworker
 
-import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
-import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.packets.internal.PACKET_JSON
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase
 import kotlinx.browser.window
@@ -112,12 +111,12 @@ private class ServiceWorkerPacketChannel(scope: CoroutineScope, env: KsrpcEnviro
     }
 
     fun handleIncoming(payload: String) {
-        val packet = decodePacket(payload, env.serialization)
+        val packet = decodePacket(payload)
         incoming.trySend(packet)
     }
 
     override suspend fun sendLocked(packet: Packet<String>) {
-        val message = encodePacket(packet, env.serialization)
+        val message = encodePacket(packet)
         portDeferred.await().postMessage(message)
     }
 
@@ -132,20 +131,11 @@ private class ServiceWorkerPacketChannel(scope: CoroutineScope, env: KsrpcEnviro
     }
 }
 
-private fun encodePacket(
-    packet: Packet<String>,
-    serialization: CallDataSerializer<String>
-): String = serialization
-    .createCallData(SERVICE_WORKER_PACKET_SERIALIZER, packet)
-    .readSerialized()
+private fun encodePacket(packet: Packet<String>): String =
+    PACKET_JSON.encodeToString(SERVICE_WORKER_PACKET_SERIALIZER, packet)
 
-private fun decodePacket(
-    payload: String,
-    serialization: CallDataSerializer<String>
-): Packet<String> {
-    val callData = CallData.create(payload)
-    return serialization.decodeCallData(SERVICE_WORKER_PACKET_SERIALIZER, callData)
-}
+private fun decodePacket(payload: String): Packet<String> =
+    PACKET_JSON.decodeFromString(SERVICE_WORKER_PACKET_SERIALIZER, payload)
 
 private val SERVICE_WORKER_PACKET_SERIALIZER = Packet.serializer(String.serializer())
 

--- a/ksrpc-service-worker/src/wasmJsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsWasm.kt
+++ b/ksrpc-service-worker/src/wasmJsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsWasm.kt
@@ -18,12 +18,11 @@
 
 package com.monkopedia.ksrpc.webworker
 
-import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
-import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.packets.internal.PACKET_JSON
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase
 import kotlin.js.Promise
@@ -81,12 +80,12 @@ private class ServiceWorkerPacketChannel(scope: CoroutineScope, env: KsrpcEnviro
     }
 
     fun handleIncoming(payload: String) {
-        val packet = decodePacket(payload, env.serialization)
+        val packet = decodePacket(payload)
         incoming.trySend(packet)
     }
 
     override suspend fun sendLocked(packet: Packet<String>) {
-        val message = encodePacket(packet, env.serialization)
+        val message = encodePacket(packet)
         postMessage(portDeferred.await(), message)
     }
 
@@ -101,20 +100,11 @@ private class ServiceWorkerPacketChannel(scope: CoroutineScope, env: KsrpcEnviro
     }
 }
 
-private fun encodePacket(
-    packet: Packet<String>,
-    serialization: CallDataSerializer<String>
-): String = serialization
-    .createCallData(SERVICE_WORKER_PACKET_SERIALIZER, packet)
-    .readSerialized()
+private fun encodePacket(packet: Packet<String>): String =
+    PACKET_JSON.encodeToString(SERVICE_WORKER_PACKET_SERIALIZER, packet)
 
-private fun decodePacket(
-    payload: String,
-    serialization: CallDataSerializer<String>
-): Packet<String> {
-    val callData = CallData.create(payload)
-    return serialization.decodeCallData(SERVICE_WORKER_PACKET_SERIALIZER, callData)
-}
+private fun decodePacket(payload: String): Packet<String> =
+    PACKET_JSON.decodeFromString(SERVICE_WORKER_PACKET_SERIALIZER, payload)
 
 private val SERVICE_WORKER_PACKET_SERIALIZER = Packet.serializer(String.serializer())
 

--- a/ksrpc-sockets/src/commonMain/kotlin/ReadWritePacketChannel.kt
+++ b/ksrpc-sockets/src/commonMain/kotlin/ReadWritePacketChannel.kt
@@ -17,11 +17,10 @@
 
 package com.monkopedia.ksrpc.sockets.internal
 
-import com.monkopedia.ksrpc.CallDataSerializer
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
-import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.packets.internal.CONTENT_LENGTH
+import com.monkopedia.ksrpc.packets.internal.PACKET_JSON
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase
 import io.ktor.utils.io.ByteReadChannel
@@ -47,11 +46,10 @@ internal class ReadWritePacketChannel(
     }
 
     override suspend fun sendLocked(packet: Packet<String>) {
-        write.send(packet, env.serialization, packetSerializer)
+        write.send(packet, packetSerializer)
     }
 
-    override suspend fun receiveLocked(): Packet<String> =
-        read.readPacket(env.serialization, packetSerializer)
+    override suspend fun receiveLocked(): Packet<String> = read.readPacket(packetSerializer)
 
     override suspend fun close() {
         super.close()
@@ -62,13 +60,9 @@ internal class ReadWritePacketChannel(
 
 private suspend fun ByteWriteChannel.send(
     packet: Packet<String>,
-    serialization: CallDataSerializer<String>,
     packetSerializer: KSerializer<Packet<String>>
 ) {
-    val content =
-        serialization.createCallData(packetSerializer, packet)
-            .readSerialized()
-            .encodeToByteArray()
+    val content = PACKET_JSON.encodeToString(packetSerializer, packet).encodeToByteArray()
     writeStringUtf8(CONTENT_LENGTH)
     writeStringUtf8(": ")
     writeStringUtf8(content.size.toString())
@@ -78,14 +72,12 @@ private suspend fun ByteWriteChannel.send(
 }
 
 private suspend fun ByteReadChannel.readPacket(
-    serialization: CallDataSerializer<String>,
     packetSerializer: KSerializer<Packet<String>>
 ): Packet<String> {
     while (true) {
         val params = readFields()
         val data = readContent(params) ?: continue
-        val callData = CallData.create(data)
-        return serialization.decodeCallData(packetSerializer, callData)
+        return PACKET_JSON.decodeFromString(packetSerializer, data)
     }
 }
 

--- a/ksrpc-test/src/commonTest/kotlin/PacketSchemaEvolutionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketSchemaEvolutionTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(KsrpcInternal::class)
+
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.packets.internal.PACKET_JSON
+import com.monkopedia.ksrpc.packets.internal.Packet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Regression tests for #70.
+ *
+ * The packet envelope is serialized with [PACKET_JSON], which has `ignoreUnknownKeys = true`
+ * so that `Packet` can gain new fields in future releases without breaking peers compiled
+ * against the older schema. These tests pin that behavior and confirm the user's own
+ * [CallDataSerializer] (for user-declared method inputs/outputs) is *not* affected — a user
+ * who chooses a strict Json still gets strict decoding for their own data.
+ */
+class PacketSchemaEvolutionTest {
+
+    @Test
+    fun packetJsonDecodesPacketWithUnknownField() {
+        // Simulate a newer peer that added an "x" key to the Packet wire schema.
+        val newerWirePayload = """
+            {
+                "t": 1,
+                "i": "chan-1",
+                "m": "msg-1",
+                "e": "/foo",
+                "d": "payload",
+                "x": "future-field-value"
+            }
+        """.trimIndent()
+
+        // Old peer decoding newer wire packet: unknown "x" must be ignored silently.
+        val decoded = PACKET_JSON.decodeFromString(
+            Packet.serializer(String.serializer()),
+            newerWirePayload
+        )
+
+        assertEquals(1, decoded.type)
+        assertEquals("chan-1", decoded.id)
+        assertEquals("msg-1", decoded.messageId)
+        assertEquals("/foo", decoded.endpoint)
+        assertEquals("payload", decoded.data)
+    }
+
+    @Test
+    fun packetJsonRoundTripsStandardPacket() {
+        val packet = Packet(
+            input = true,
+            binary = false,
+            id = "chan",
+            messageId = "msg",
+            endpoint = "/path",
+            data = "body"
+        )
+
+        val wire = PACKET_JSON.encodeToString(Packet.serializer(String.serializer()), packet)
+        val roundTripped = PACKET_JSON.decodeFromString(
+            Packet.serializer(String.serializer()),
+            wire
+        )
+
+        assertEquals(packet, roundTripped)
+    }
+
+    @Test
+    fun userStrictSerializationUnaffectedByPacketJson() {
+        // A user-configured strict Json remains strict for user-declared payload types.
+        // The packet envelope is handled separately by PACKET_JSON at the transport layer,
+        // so the user's choice of strictness for their own data is preserved.
+        val strictEnv = ksrpcEnvironment(Json { ignoreUnknownKeys = false }) { }
+
+        val userPayloadWithUnknown = """{"known":"value","unknown":"x"}"""
+
+        assertFailsWith<SerializationException> {
+            strictEnv.serialization.decodeCallData(
+                KnownOnly.serializer(),
+                CallData.create(userPayloadWithUnknown)
+            )
+        }
+    }
+
+    @kotlinx.serialization.Serializable
+    private data class KnownOnly(val known: String)
+}


### PR DESCRIPTION
## Summary

Supersedes PR #98 which over-scoped to a full TLV metadata section. The original #70 ask was just "forward-compat on the packet wire — new fields shouldn't break old peers." This is achieved with a one-line serializer config change.

- Default `StringSerializer`'s Json now uses `Json { ignoreUnknownKeys = true }`.
- `ksrpcEnvironment { }` (no explicit stringFormat) picks up this default.
- Users who supply their own `StringFormat` retain full control — if they pass a strict Json, strict rejection continues to work.
- No changes to `Packet` itself — adding new optional fields in future releases becomes a non-breaking change.

The generalized bag-of-keys mechanism from the original PR belongs with #28 (context propagation) where it's actually consumed; filing that on #28's packet sub-issue (#82).

## Test plan

`PacketSchemaEvolutionTest` — 3 cases:
- Default env decodes a packet with an unknown "future-field" key without failing.
- Default env round-trips a standard Packet cleanly (no regression).
- User-supplied strict Json (`ignoreUnknownKeys = false`) still rejects unknown fields — user's explicit choice is respected.

Closes #70