### PR TITLE
Fix #77: compiler plugin captures @KsError bidirectional map on RpcMethod (part 2 of #13)

### DIFF
--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -37,6 +37,15 @@ dependencies {
     ksp(libs.autoservice)
     compileOnly(libs.autoservice.annotations)
 
+    // Locally-built `ksrpc-api` jvmJar, listed BEFORE the published `ksrpctest`
+    // coordinate so the newly-added `@KsError` annotation (#77, Part 2 of #13)
+    // is visible to the test sources. The published 0.11.1 ksrpc-api coordinate
+    // predates the annotation.
+    testImplementation(
+        files(
+            project.rootDir.resolve("../ksrpc-api/build/libs/ksrpc-api-jvm-0.11.1.jar")
+        )
+    )
     // Locally-built `ksrpc-core` jvmJar, listed BEFORE the published `ksrpctest`
     // coordinate so the local (non-sealed) `Transformer` interface takes
     // precedence over the published (sealed) one. The FlowSupportTest (#39) needs
@@ -103,6 +112,14 @@ dependencies {
     testImplementation(libs.okio)
     testImplementation(kotlin("test-junit"))
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
+    // Exposes `SerializationComponentRegistrar` so tests that need to round-trip
+    // through kotlinx-serialization (e.g. KsErrorBindingTest verifying the
+    // captured `KSerializer` resolves at runtime) can chain the kotlinx.serialization
+    // plugin alongside the ksrpc plugin via compile-testing. Kept out of the main
+    // classpath to avoid leaking onto production builds.
+    testImplementation(
+        "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable"
+    )
     testImplementation(libs.kotlin.compiletesting)
 }
 

--- a/compiler/plugin/src/main/java/ErrorMappingIrBuilder.kt
+++ b/compiler/plugin/src/main/java/ErrorMappingIrBuilder.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irInt
+import org.jetbrains.kotlin.ir.builders.irVararg
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.expressions.IrClassReference
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.starProjectedType
+import org.jetbrains.kotlin.ir.types.typeWith
+import org.jetbrains.kotlin.ir.util.constructors
+
+/**
+ * Builds IR that materializes the `@KsError(code, type)` annotations captured
+ * on a `@KsMethod` function into `List<KsErrorMapping>` at runtime, for
+ * inclusion in the generated `RpcMethod` descriptor.
+ *
+ * Each entry emits `KsErrorMapping(code, type::class, serializer<Type>())`
+ * where the serializer is resolved via `kotlinx.serialization.serializer<T>()`.
+ * The payload type must be `@Serializable` — that validation is enforced
+ * separately in [KsrpcIrGenerationExtension.validate] and surfaces a user
+ * diagnostic before we reach codegen.
+ *
+ * Safe to instantiate even when `env.errorMappingSupported` is false — the
+ * caller still needs to check that flag to decide whether to pass the
+ * resulting list into the `RpcMethod` constructor.
+ */
+class ErrorMappingIrBuilder(
+    private val env: KsrpcGenerationEnvironment,
+    private val builder: DeclarationIrBuilder,
+    @Suppress("unused") private val report: MessageCollector
+) {
+    init {
+        check(env.errorMappingSupported) {
+            "ksrpc internal: ErrorMappingIrBuilder created without error-mapping " +
+                "dependencies — caller should guard on env.errorMappingSupported"
+        }
+    }
+
+    private val ksErrorMapping = env.ksErrorMapping!!
+
+    fun buildErrorMappingList(errorAnnotations: List<IrConstructorCall>): IrExpression =
+        buildListOf(ksErrorMapping.starProjectedType, errorAnnotations.map { buildMapping(it) })
+
+    private fun buildMapping(annotation: IrConstructorCall): IrExpression {
+        // Named-arg resolution: @KsError(code: Int, type: KClass<*>). The FIR/IR
+        // argument list is positional, so we fetch by index and verify shape.
+        val codeExpr = annotation.arguments.getOrNull(0) as? IrConst
+            ?: reportInternal(
+                "@KsError is missing its `code` argument or it is not an Int constant"
+            )
+        val typeExpr = annotation.arguments.getOrNull(1) as? IrClassReference
+            ?: reportInternal(
+                "@KsError is missing its `type` argument or it is not a KClass literal"
+            )
+        val codeValue = codeExpr.value as? Int ?: reportInternal(
+            "@KsError.code is not an Int constant (got ${codeExpr.value?.let { it::class }})"
+        )
+        val errorType = typeExpr.classType
+        val serializerFn = env.serializerMethod ?: reportInternal(
+            "can't resolve kotlinx.serialization.serializer<T>() — " +
+                "kotlinx-serialization-core must be on the compile classpath"
+        )
+        val serializerCall = builder.irCall(serializerFn).apply {
+            typeArguments[0] = errorType
+            type = env.kSerializer.typeWith(errorType)
+        }
+        return builder.irCallConstructor(
+            ksErrorMapping.constructors.first(),
+            emptyList()
+        ).apply {
+            type = ksErrorMapping.starProjectedType
+            putArgs(
+                builder.irInt(codeValue),
+                typeExpr,
+                serializerCall
+            )
+        }
+    }
+
+    private fun buildListOf(
+        elementType: org.jetbrains.kotlin.ir.types.IrType,
+        items: List<IrExpression>
+    ): IrExpression = builder.irCall(env.listOfFunction).apply {
+        typeArguments[0] = elementType
+        val varargParameter = env.listOfFunction.owner.parameters
+            .single { it.kind == IrParameterKind.Regular }
+        arguments[varargParameter] = builder.irVararg(elementType, items)
+    }
+}

--- a/compiler/plugin/src/main/java/FqConstants.kt
+++ b/compiler/plugin/src/main/java/FqConstants.kt
@@ -121,6 +121,15 @@ object FqConstants {
     val KS_INTROSPECTABLE = FqName("com.monkopedia.ksrpc.annotation.KsIntrospectable")
     val KS_METHOD_METADATA = FqName("com.monkopedia.ksrpc.annotation.KsMethodMetadata")
     val KS_NOTIFICATION = FqName("com.monkopedia.ksrpc.annotation.KsNotification")
+    val KS_ERROR = FqName("com.monkopedia.ksrpc.annotation.KsError")
+
+    // kotlinx.serialization.Serializable annotation FQN — used by @KsError validation
+    // to check that the bound error payload type is @Serializable.
+    val KOTLINX_SERIALIZABLE = FqName("kotlinx.serialization.Serializable")
+
+    // Ksrpc runtime classes used to materialize @KsError bindings into
+    // `List<KsErrorMapping>` at codegen time.
+    val KS_ERROR_MAPPING = ClassId(FQPKG, Name.identifier("KsErrorMapping"))
 
     val METHOD_METADATA = ClassId(FQPKG, Name.identifier("MethodMetadata"))
     val METADATA_VALUE = ClassId(FQPKG, Name.identifier("MetadataValue"))

--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -180,6 +180,20 @@ class KsrpcGenerationEnvironment(
         }
             ?: reportInternal("can't resolve kotlin.collections.listOf (vararg overload)")
 
+    // Error-binding (#77) support is optional so the compiler plugin continues
+    // to work against older ksrpc-core artifacts that predate the `KsErrorMapping`
+    // type. When unresolved, the plugin does not emit the seventh constructor
+    // argument on `RpcMethod` and the generated service carries no error maps.
+    val ksErrorMapping = maybeReferenceClass(FqConstants.KS_ERROR_MAPPING)
+
+    /**
+     * True when `KsErrorMapping` was resolved — the ksrpc-core on the compile
+     * classpath supports the `@KsError` bidirectional binding (Part 2 of #13).
+     * Also requires the 6-argument `RpcMethod` constructor.
+     */
+    val errorMappingSupported: Boolean get() = ksErrorMapping != null &&
+        rpcMethod.constructors.first().owner.parameters.size >= 6
+
     // Metadata propagation support is optional so the compiler plugin continues
     // to work against older ksrpc-core artifacts that predate #11.
     val methodMetadata = maybeReferenceClass(FqConstants.METHOD_METADATA)

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -131,6 +131,7 @@ import org.jetbrains.kotlin.ir.backend.js.utils.isDispatchReceiver
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -169,6 +170,9 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
                 names,
                 env
             ) && validateNotification(
+                cls.irClass,
+                serviceMethod
+            ) && validateErrorBindings(
                 cls.irClass,
                 serviceMethod
             ) && current
@@ -346,6 +350,43 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
                         "`implementation(\"com.monkopedia:ksrpc-flow\")` to your " +
                         "dependencies.",
                     element = method
+                )
+                isValid = false
+            }
+        }
+        return isValid
+    }
+
+    /**
+     * Reject `@KsError(type = ...)` bindings whose payload type is not
+     * `@Serializable`. The compiler plugin captures the `type` argument as an
+     * `IrClassReference` and emits `serializer<type>()` at codegen; without
+     * `@Serializable`, that lookup fails at runtime with a confusing
+     * `SerializationException`. Catching it here gives the user a clear
+     * pointer at the offending annotation.
+     *
+     * IR-phase validation was chosen because the plugin does not yet register
+     * FIR checkers (a FIR-phase checker would give an IDE red-squiggle;
+     * tracked by #65 as a 1.0+ follow-up).
+     */
+    private fun validateErrorBindings(irClass: IrClass, serviceMethod: ServiceMethod): Boolean {
+        var isValid = true
+        for (annotation in serviceMethod.errorAnnotations) {
+            val typeArg = annotation.arguments.getOrNull(1) as? IrClassReference ?: continue
+            val payloadClass = typeArg.classType.classOrNull?.owner ?: continue
+            val isSerializable = payloadClass.annotations.any {
+                it.type.classFqName == FqConstants.KOTLINX_SERIALIZABLE
+            }
+            if (!isSerializable) {
+                val fqName = irClass.kotlinFqName.asString()
+                val methodName = serviceMethod.function.name.asString()
+                val payloadFqName = payloadClass.kotlinFqName.asString()
+                report.reportUserError(
+                    "@KsError on $fqName.$methodName: type `$payloadFqName` must be " +
+                        "`@Serializable`. Annotate `$payloadFqName` with " +
+                        "`@kotlinx.serialization.Serializable` or remove this " +
+                        "@KsError binding.",
+                    element = serviceMethod.function
                 )
                 isValid = false
             }

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -231,6 +231,7 @@ class ObjGeneration(
                             endpoint,
                             method.function,
                             method.metadataAnnotations,
+                            method.errorAnnotations,
                             executor = executor
                         )
                     )
@@ -271,6 +272,7 @@ internal class GenericMethodIrBuilder(
         endpoint: String,
         method: IrSimpleFunction,
         metadataAnnotations: List<IrConstructorCall>,
+        errorAnnotations: List<IrConstructorCall>,
         executor: IrClass
     ): IrConstructorCall {
         // 0-arg @KsMethod functions fall back to Unit as the input type.
@@ -306,14 +308,18 @@ internal class GenericMethodIrBuilder(
             outputConverter,
             executorInstance
         )
+        val decl = DeclarationIrBuilder(
+            context,
+            method.symbol,
+            SYNTHETIC_OFFSET,
+            SYNTHETIC_OFFSET
+        )
         if (supportsMetadata) {
-            val decl = DeclarationIrBuilder(
-                context,
-                method.symbol,
-                SYNTHETIC_OFFSET,
-                SYNTHETIC_OFFSET
-            )
             args += MetadataIrBuilder(env, decl, report).buildMetadataList(metadataAnnotations)
+        }
+        if (env.errorMappingSupported) {
+            args += ErrorMappingIrBuilder(env, decl, report)
+                .buildErrorMappingList(errorAnnotations)
         }
         call.putArgs(*args.toTypedArray())
         return call

--- a/compiler/plugin/src/main/java/ServiceClass.kt
+++ b/compiler/plugin/src/main/java/ServiceClass.kt
@@ -40,6 +40,7 @@ private class Visitor(private val messageCollector: MessageCollector) : IrElemen
     private val method = FqName("com.monkopedia.ksrpc.annotation.KsMethod")
     private val service = FqName("com.monkopedia.ksrpc.annotation.KsService")
     private val metadataMarker = FqConstants.KS_METHOD_METADATA
+    private val ksError = FqConstants.KS_ERROR
 
     override fun visitClass(declaration: IrClass): IrStatement {
         val annotation = declaration.annotations.find { annotation ->
@@ -76,11 +77,18 @@ private class Visitor(private val messageCollector: MessageCollector) : IrElemen
                             it.type.classFqName == metadataMarker
                         } == true
                 }
+                // Capture @KsError bindings. `@Repeatable` annotations may appear
+                // either as individual entries or wrapped in a synthesized
+                // Container class — preserve declaration order across either shape.
+                val errorAnnotations = declaration.annotations.filter {
+                    it.type.classFqName == ksError
+                }
                 current.methods.add(
                     ServiceMethod(
                         function = declaration,
                         ksMethodAnnotation = annotation,
-                        metadataAnnotations = metadataAnnotations
+                        metadataAnnotations = metadataAnnotations,
+                        errorAnnotations = errorAnnotations
                     )
                 )
             } else if (!declaration.isFakeOverride) {
@@ -133,7 +141,13 @@ private class SubclassVisitor(
 data class ServiceMethod(
     val function: IrSimpleFunction,
     val ksMethodAnnotation: IrConstructorCall,
-    val metadataAnnotations: List<IrConstructorCall> = emptyList()
+    val metadataAnnotations: List<IrConstructorCall> = emptyList(),
+    /**
+     * `@KsError(code, type)` annotations captured in declaration order. The
+     * compiler plugin emits one [com.monkopedia.ksrpc.KsErrorMapping] entry per
+     * annotation into the generated `RpcMethod.errorMappings` list. See #77.
+     */
+    val errorAnnotations: List<IrConstructorCall> = emptyList()
 )
 
 data class ServiceClass(

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -147,6 +147,7 @@ class StubGeneration(
                             serviceMethod.function,
                             endpoint,
                             serviceMethod.metadataAnnotations,
+                            serviceMethod.errorAnnotations,
                             service,
                             genericBuilder
                         )
@@ -157,6 +158,7 @@ class StubGeneration(
                             serviceMethod.function,
                             serviceMethod.ksMethodAnnotation,
                             serviceMethod.metadataAnnotations,
+                            serviceMethod.errorAnnotations,
                             companion,
                             service
                         )
@@ -183,6 +185,7 @@ class StubGeneration(
         method: IrSimpleFunction,
         endpoint: String,
         metadataAnnotations: List<IrConstructorCall>,
+        errorAnnotations: List<IrConstructorCall>,
         service: ServiceClass,
         builder: GenericMethodIrBuilder
     ): IrFunction {
@@ -220,6 +223,7 @@ class StubGeneration(
                             endpoint,
                             method,
                             metadataAnnotations,
+                            errorAnnotations,
                             executor = executor
                         ),
                         irGetField(irGet(thisParam), service.channel),
@@ -324,6 +328,7 @@ class StubGeneration(
         method: IrSimpleFunction,
         annotation: IrConstructorCall,
         metadataAnnotations: List<IrConstructorCall>,
+        errorAnnotations: List<IrConstructorCall>,
         companion: IrClass,
         service: ServiceClass
     ): IrFunction {
@@ -332,7 +337,15 @@ class StubGeneration(
                 "argument after validation"
         )
         val methodField =
-            generateRpcMethod(env, endpoint, method, this, companion, metadataAnnotations)
+            generateRpcMethod(
+                env,
+                endpoint,
+                method,
+                this,
+                companion,
+                metadataAnnotations,
+                errorAnnotations
+            )
 
         service.addEndpoint(endpoint, methodField)
         val callChannel = env.rpcMethod.findMethod(FqConstants.CALL_CHANNEL)
@@ -379,7 +392,8 @@ class StubGeneration(
         method: IrSimpleFunction,
         serviceInterface: IrClass,
         companion: IrClass,
-        metadataAnnotations: List<IrConstructorCall>
+        metadataAnnotations: List<IrConstructorCall>,
+        errorAnnotations: List<IrConstructorCall>
     ): IrFunction {
         val field = companion.addField {
             startOffset = SYNTHETIC_OFFSET
@@ -413,7 +427,8 @@ class StubGeneration(
                             serviceInterface,
                             endpoint,
                             method,
-                            metadataAnnotations
+                            metadataAnnotations,
+                            errorAnnotations
                         )
                     )
                 )
@@ -426,7 +441,8 @@ class StubGeneration(
         serviceInterface: IrClass,
         endpoint: String,
         method: IrSimpleFunction,
-        metadataAnnotations: List<IrConstructorCall>
+        metadataAnnotations: List<IrConstructorCall>,
+        errorAnnotations: List<IrConstructorCall>
     ): IrConstructorCall {
         // 0-arg @KsMethod functions have no user-declared input; fall back to Unit
         // so the generated RpcMethod is shaped as `RpcMethod<Service, Unit, Out>`.
@@ -442,6 +458,7 @@ class StubGeneration(
         // MethodMetadata is available, always emit the five-arg shape and pass
         // `emptyList()` when there is no metadata.
         val supportsMetadata = env.metadataSupported && constructor.owner.parameters.size >= 5
+        val supportsErrorMapping = env.errorMappingSupported
         return irCallConstructor(
             constructor,
             listOf(serviceInterface.typeWith(), inputType, outputType)
@@ -466,6 +483,10 @@ class StubGeneration(
             if (supportsMetadata) {
                 args += MetadataIrBuilder(env, this@irCreateRpcMethod, messageCollector)
                     .buildMetadataList(metadataAnnotations)
+            }
+            if (supportsErrorMapping) {
+                args += ErrorMappingIrBuilder(env, this@irCreateRpcMethod, messageCollector)
+                    .buildErrorMappingList(errorAnnotations)
             }
             putArgs(*args.toTypedArray())
         }

--- a/compiler/plugin/src/test/java/KsErrorBindingTest.kt
+++ b/compiler/plugin/src/test/java/KsErrorBindingTest.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlinx.serialization.compiler.extensions.SerializationComponentRegistrar
+import org.junit.Test
+
+/**
+ * Tests for #77 — compiler plugin captures `@KsError(code, type)` annotations
+ * on `@KsMethod` functions and emits a `List<KsErrorMapping>` into the
+ * generated `RpcMethod` descriptor.
+ *
+ * The assertion strategy here reflects the kotlin-compile-testing harness:
+ * we compile a service and then reach into the resulting classloader to
+ * instantiate the generated companion, invoke `findEndpoint`, and introspect
+ * `rpcMethod.errorMappings` via reflection. This exercises the full plugin
+ * pipeline (FIR + IR) end-to-end rather than unit-testing the IR builder in
+ * isolation.
+ */
+class KsErrorBindingTest {
+
+    @Test
+    fun `single @KsError captures code, type, and serializer`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsError
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class InitError(val retry: Boolean)
+
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/init")
+    @KsError(code = 100, type = InitError::class)
+    suspend fun init(input: String): Int
+}
+"""
+        )
+        val result = compileWithSerialization(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+        val mappings = findEndpointErrorMappings(result, "MyService", "init")
+        assertEquals(1, mappings.size, "Expected exactly one mapping, got $mappings")
+        val entry = mappings.single()
+        assertEquals(100, entry.code)
+        assertEquals("InitError", entry.dataType.simpleName)
+        // The captured serializer must refer to the compiled InitError. Verify by
+        // inspecting its descriptor's serialName — avoids depending on specific
+        // internal `*Serializer` class naming conventions.
+        val serialName = serialName(entry.dataSerializer)
+        assertTrue(
+            serialName.endsWith("InitError"),
+            "Expected serializer for InitError (serialName ends with 'InitError'), " +
+                "got '$serialName'"
+        )
+    }
+
+    @Test
+    fun `multiple @KsError annotations on one method are all captured`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsError
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class InitError(val retry: Boolean)
+
+@Serializable
+data class VersionError(val expected: Int, val actual: Int)
+
+@KsService
+interface MultiService : RpcService {
+    @KsMethod("/init")
+    @KsError(code = 100, type = InitError::class)
+    @KsError(code = 101, type = VersionError::class)
+    suspend fun init(input: String): Int
+}
+"""
+        )
+        val result = compileWithSerialization(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+        val mappings = findEndpointErrorMappings(result, "MultiService", "init")
+        assertEquals(
+            2,
+            mappings.size,
+            "Expected two mappings, got ${mappings.map { it.code to it.dataType.simpleName }}"
+        )
+        val byCode = mappings.associateBy { it.code }
+        assertEquals("InitError", byCode[100]?.dataType?.simpleName)
+        assertEquals("VersionError", byCode[101]?.dataType?.simpleName)
+    }
+
+    @Test
+    fun `method without @KsError has an empty errorMappings list`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface NoErrorService : RpcService {
+    @KsMethod("/plain")
+    suspend fun plain(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+        val mappings = findEndpointErrorMappings(result, "NoErrorService", "plain")
+        assertTrue(
+            mappings.isEmpty(),
+            "Expected empty errorMappings when no @KsError present, got $mappings"
+        )
+    }
+
+    @Test
+    fun `non-@Serializable error payload type is rejected at compile time`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsError
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+// Deliberately NOT @Serializable — the plugin must reject this with a clear diagnostic.
+data class NotSerializable(val value: String)
+
+@KsService
+interface BadService : RpcService {
+    @KsMethod("/op")
+    @KsError(code = 42, type = NotSerializable::class)
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("@KsError") &&
+                result.messages.contains("NotSerializable") &&
+                result.messages.contains("@Serializable"),
+            "Expected @Serializable-validation diagnostic naming NotSerializable, " +
+                "got: ${result.messages}"
+        )
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    /**
+     * Chain the kotlinx-serialization and ksrpc compiler plugins through
+     * kotlin-compile-testing. The serialization plugin synthesizes
+     * `*.serializer()` / `$serializer` on `@Serializable` types so that the
+     * ksrpc plugin's emitted `serializer<Type>()` call resolves at runtime —
+     * without it the KSerializer lookup falls back to reflection and fails
+     * with `SerializationException: Serializer for class 'X' is not found`.
+     */
+    private fun compileWithSerialization(sources: List<SourceFile>): JvmCompilationResult =
+        KotlinCompilation().apply {
+            this.sources = sources
+            compilerPluginRegistrars = listOf<CompilerPluginRegistrar>(
+                SerializationComponentRegistrar(),
+                KsrpcComponentRegistrar()
+            )
+            inheritClassPath = true
+        }.compile()
+
+    /**
+     * Simplified view of a captured `KsErrorMapping` for assertion purposes —
+     * pulled out of the classloader-created instances via reflection so tests
+     * don't need to reach into ksrpc-core's own classes.
+     */
+    private data class MappingSnapshot(
+        val code: Int,
+        val dataType: Class<*>,
+        val dataSerializer: Any
+    )
+
+    private fun findEndpointErrorMappings(
+        result: JvmCompilationResult,
+        serviceFqName: String,
+        endpointName: String
+    ): List<MappingSnapshot> {
+        val serviceClass = result.classLoader.loadClass(serviceFqName)
+        val companion = serviceClass.getField("Companion").get(null)
+        val findEndpoint = companion.javaClass.methods.single { it.name == "findEndpoint" }
+        val rpcMethod = findEndpoint.invoke(companion, endpointName)
+            ?: error("findEndpoint($endpointName) returned null on $serviceFqName")
+        val getMappings = rpcMethod.javaClass.methods.singleOrNull {
+            it.name == "getErrorMappings"
+        } ?: error(
+            "RpcMethod for $serviceFqName.$endpointName has no getErrorMappings() — " +
+                "plugin did not emit the errorMappings constructor argument"
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val rawList = getMappings.invoke(rpcMethod) as List<Any>
+        return rawList.map { raw ->
+            val cls = raw.javaClass
+            MappingSnapshot(
+                code = cls.getMethod("getCode").invoke(raw) as Int,
+                dataType =
+                    (cls.getMethod("getDataType").invoke(raw) as kotlin.reflect.KClass<*>).java,
+                dataSerializer = cls.getMethod("getDataSerializer").invoke(raw)!!
+            )
+        }
+    }
+
+    /** Fetch `descriptor.serialName` off a `KSerializer<*>` via reflection. */
+    private fun serialName(serializer: Any): String {
+        val descriptor = serializer.javaClass.methods.single {
+            it.name == "getDescriptor" && it.parameterCount == 0
+        }.invoke(serializer)
+        return descriptor.javaClass.methods.single {
+            it.name == "getSerialName" && it.parameterCount == 0
+        }.invoke(descriptor) as String
+    }
+}

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -1,3 +1,14 @@
+public abstract class com/monkopedia/ksrpc/BaseSubserviceTransformer : com/monkopedia/ksrpc/Transformer {
+	public fun <init> ()V
+	protected abstract fun fromService (Lcom/monkopedia/ksrpc/RpcService;)Ljava/lang/Object;
+	public fun getHasContent ()Z
+	public abstract fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
+	protected abstract fun toService (Ljava/lang/Object;)Lcom/monkopedia/ksrpc/RpcService;
+	public fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
+	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class com/monkopedia/ksrpc/BinaryDataTransformer {
 }
 
@@ -43,24 +54,15 @@ public abstract interface class com/monkopedia/ksrpc/KsrpcEnvironment$Element {
 }
 
 public final class com/monkopedia/ksrpc/KsrpcEnvironmentBuilder : com/monkopedia/ksrpc/KsrpcEnvironment {
-	public final fun component1 ()Lcom/monkopedia/ksrpc/CallDataSerializer;
-	public final fun component2 ()Lkotlinx/coroutines/CoroutineScope;
-	public final fun component3 ()Lcom/monkopedia/ksrpc/Logger;
-	public final fun component4 ()Lcom/monkopedia/ksrpc/ErrorListener;
-	public final fun copy (Lcom/monkopedia/ksrpc/CallDataSerializer;Lkotlinx/coroutines/CoroutineScope;Lcom/monkopedia/ksrpc/Logger;Lcom/monkopedia/ksrpc/ErrorListener;)Lcom/monkopedia/ksrpc/KsrpcEnvironmentBuilder;
-	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/KsrpcEnvironmentBuilder;Lcom/monkopedia/ksrpc/CallDataSerializer;Lkotlinx/coroutines/CoroutineScope;Lcom/monkopedia/ksrpc/Logger;Lcom/monkopedia/ksrpc/ErrorListener;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/KsrpcEnvironmentBuilder;
-	public fun equals (Ljava/lang/Object;)Z
 	public fun getCoroutineExceptionHandler ()Lkotlinx/coroutines/CoroutineExceptionHandler;
 	public fun getDefaultScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getErrorListener ()Lcom/monkopedia/ksrpc/ErrorListener;
 	public fun getLogger ()Lcom/monkopedia/ksrpc/Logger;
 	public fun getSerialization ()Lcom/monkopedia/ksrpc/CallDataSerializer;
-	public fun hashCode ()I
 	public fun setDefaultScope (Lkotlinx/coroutines/CoroutineScope;)V
 	public fun setErrorListener (Lcom/monkopedia/ksrpc/ErrorListener;)V
 	public fun setLogger (Lcom/monkopedia/ksrpc/Logger;)V
 	public fun setSerialization (Lcom/monkopedia/ksrpc/CallDataSerializer;)V
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/KsrpcEnvironmentKt {
@@ -217,11 +219,6 @@ public final class com/monkopedia/ksrpc/MethodMetadata {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/monkopedia/ksrpc/RpcChannelKt {
-	public static final field ENDPOINT_NOT_FOUND_PREFIX Ljava/lang/String;
-	public static final field ERROR_PREFIX Ljava/lang/String;
-}
-
 public class com/monkopedia/ksrpc/RpcEndpointException : com/monkopedia/ksrpc/KsrpcException {
 	public fun <init> (Ljava/lang/String;)V
 }
@@ -235,8 +232,8 @@ public final class com/monkopedia/ksrpc/RpcExceptionKt {
 }
 
 public final class com/monkopedia/ksrpc/RpcMethod {
-	public fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/ServiceExecutor;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/ServiceExecutor;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/internal/ServiceExecutor;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/internal/ServiceExecutor;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun call (Lcom/monkopedia/ksrpc/channels/SerializedService;Lcom/monkopedia/ksrpc/RpcService;Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/RpcCallId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun callChannel (Lcom/monkopedia/ksrpc/channels/SerializedService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun findSubserviceTransformers ()Ljava/util/List;
@@ -292,23 +289,16 @@ public final class com/monkopedia/ksrpc/SerializerTransformer : com/monkopedia/k
 	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class com/monkopedia/ksrpc/ServiceExecutor {
-	public abstract fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class com/monkopedia/ksrpc/ServiceNameKt {
 	public static final fun serviceInterfaceName (Lcom/monkopedia/ksrpc/RpcObject;)Ljava/lang/String;
 	public static final fun serviceNameFor (Lkotlin/reflect/KClass;)Ljava/lang/String;
 }
 
-public final class com/monkopedia/ksrpc/SubserviceTransformer : com/monkopedia/ksrpc/Transformer {
+public final class com/monkopedia/ksrpc/SubserviceTransformer : com/monkopedia/ksrpc/BaseSubserviceTransformer {
 	public fun <init> (Lcom/monkopedia/ksrpc/RpcObject;)V
-	public fun getHasContent ()Z
-	public final fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
-	public fun transform (Lcom/monkopedia/ksrpc/RpcService;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public synthetic fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
-	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun fromService (Lcom/monkopedia/ksrpc/RpcService;)Ljava/lang/Object;
+	public fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
+	public synthetic fun toService (Ljava/lang/Object;)Lcom/monkopedia/ksrpc/RpcService;
 }
 
 public abstract interface class com/monkopedia/ksrpc/SuspendCloseableObservable : com/monkopedia/ksrpc/SuspendCloseable {
@@ -507,10 +497,6 @@ public abstract interface class com/monkopedia/ksrpc/channels/SingleChannelHost 
 	public abstract fun registerDefault (Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/monkopedia/ksrpc/channels/UtilsJvmKt {
-	public static final fun randomUuid ()Ljava/lang/String;
-}
-
 public final class com/monkopedia/ksrpc/internal/ClientChannelContext : kotlin/coroutines/CoroutineContext$Element {
 	public fun <init> (Lcom/monkopedia/ksrpc/channels/ChannelClient;)V
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
@@ -523,6 +509,11 @@ public final class com/monkopedia/ksrpc/internal/ClientChannelContext : kotlin/c
 
 public final class com/monkopedia/ksrpc/internal/ClientChannelContext$Key : kotlin/coroutines/CoroutineContext$Key {
 	public static final field INSTANCE Lcom/monkopedia/ksrpc/internal/ClientChannelContext$Key;
+}
+
+public final class com/monkopedia/ksrpc/internal/ErrorPrefixesKt {
+	public static final field ENDPOINT_NOT_FOUND_PREFIX Ljava/lang/String;
+	public static final field ERROR_PREFIX Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/internal/HostChannelContext : kotlin/coroutines/CoroutineContext$Element {
@@ -567,6 +558,14 @@ public final class com/monkopedia/ksrpc/internal/MultiChannel {
 	public final fun close (Ljava/util/concurrent/CancellationException;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun close$default (Lcom/monkopedia/ksrpc/internal/MultiChannel;Ljava/util/concurrent/CancellationException;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun send (Ljava/lang/String;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/internal/RandomUuidJvmKt {
+	public static final fun randomUuid ()Ljava/lang/String;
+}
+
+public abstract interface class com/monkopedia/ksrpc/internal/ServiceExecutor {
+	public abstract fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/monkopedia/ksrpc/internal/SubserviceChannel : com/monkopedia/ksrpc/channels/SerializedService {

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -1,14 +1,3 @@
-public abstract class com/monkopedia/ksrpc/BaseSubserviceTransformer : com/monkopedia/ksrpc/Transformer {
-	public fun <init> ()V
-	protected abstract fun fromService (Lcom/monkopedia/ksrpc/RpcService;)Ljava/lang/Object;
-	public fun getHasContent ()Z
-	public abstract fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
-	protected abstract fun toService (Ljava/lang/Object;)Lcom/monkopedia/ksrpc/RpcService;
-	public fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
-	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public abstract interface class com/monkopedia/ksrpc/BinaryDataTransformer {
 }
 
@@ -34,6 +23,13 @@ public abstract interface class com/monkopedia/ksrpc/ErrorListener {
 	public abstract fun onError (Ljava/lang/Throwable;)V
 }
 
+public final class com/monkopedia/ksrpc/KsErrorMapping {
+	public fun <init> (ILkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
+	public final fun getCode ()I
+	public final fun getDataSerializer ()Lkotlinx/serialization/KSerializer;
+	public final fun getDataType ()Lkotlin/reflect/KClass;
+}
+
 public abstract interface class com/monkopedia/ksrpc/KsrpcEnvironment {
 	public abstract fun getCoroutineExceptionHandler ()Lkotlinx/coroutines/CoroutineExceptionHandler;
 	public abstract fun getDefaultScope ()Lkotlinx/coroutines/CoroutineScope;
@@ -47,15 +43,24 @@ public abstract interface class com/monkopedia/ksrpc/KsrpcEnvironment$Element {
 }
 
 public final class com/monkopedia/ksrpc/KsrpcEnvironmentBuilder : com/monkopedia/ksrpc/KsrpcEnvironment {
+	public final fun component1 ()Lcom/monkopedia/ksrpc/CallDataSerializer;
+	public final fun component2 ()Lkotlinx/coroutines/CoroutineScope;
+	public final fun component3 ()Lcom/monkopedia/ksrpc/Logger;
+	public final fun component4 ()Lcom/monkopedia/ksrpc/ErrorListener;
+	public final fun copy (Lcom/monkopedia/ksrpc/CallDataSerializer;Lkotlinx/coroutines/CoroutineScope;Lcom/monkopedia/ksrpc/Logger;Lcom/monkopedia/ksrpc/ErrorListener;)Lcom/monkopedia/ksrpc/KsrpcEnvironmentBuilder;
+	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/KsrpcEnvironmentBuilder;Lcom/monkopedia/ksrpc/CallDataSerializer;Lkotlinx/coroutines/CoroutineScope;Lcom/monkopedia/ksrpc/Logger;Lcom/monkopedia/ksrpc/ErrorListener;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/KsrpcEnvironmentBuilder;
+	public fun equals (Ljava/lang/Object;)Z
 	public fun getCoroutineExceptionHandler ()Lkotlinx/coroutines/CoroutineExceptionHandler;
 	public fun getDefaultScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getErrorListener ()Lcom/monkopedia/ksrpc/ErrorListener;
 	public fun getLogger ()Lcom/monkopedia/ksrpc/Logger;
 	public fun getSerialization ()Lcom/monkopedia/ksrpc/CallDataSerializer;
+	public fun hashCode ()I
 	public fun setDefaultScope (Lkotlinx/coroutines/CoroutineScope;)V
 	public fun setErrorListener (Lcom/monkopedia/ksrpc/ErrorListener;)V
 	public fun setLogger (Lcom/monkopedia/ksrpc/Logger;)V
 	public fun setSerialization (Lcom/monkopedia/ksrpc/CallDataSerializer;)V
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/KsrpcEnvironmentKt {
@@ -212,6 +217,11 @@ public final class com/monkopedia/ksrpc/MethodMetadata {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/monkopedia/ksrpc/RpcChannelKt {
+	public static final field ENDPOINT_NOT_FOUND_PREFIX Ljava/lang/String;
+	public static final field ERROR_PREFIX Ljava/lang/String;
+}
+
 public class com/monkopedia/ksrpc/RpcEndpointException : com/monkopedia/ksrpc/KsrpcException {
 	public fun <init> (Ljava/lang/String;)V
 }
@@ -225,11 +235,13 @@ public final class com/monkopedia/ksrpc/RpcExceptionKt {
 }
 
 public final class com/monkopedia/ksrpc/RpcMethod {
-	public fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/internal/ServiceExecutor;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/ServiceExecutor;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/ServiceExecutor;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun call (Lcom/monkopedia/ksrpc/channels/SerializedService;Lcom/monkopedia/ksrpc/RpcService;Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/RpcCallId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun callChannel (Lcom/monkopedia/ksrpc/channels/SerializedService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun findSubserviceTransformers ()Ljava/util/List;
 	public final fun getEndpoint ()Ljava/lang/String;
+	public final fun getErrorMappings ()Ljava/util/List;
 	public final fun getHasReturnType ()Z
 	public final fun getInputTransform ()Lcom/monkopedia/ksrpc/Transformer;
 	public final fun getMetadata ()Ljava/util/List;
@@ -238,6 +250,8 @@ public final class com/monkopedia/ksrpc/RpcMethod {
 }
 
 public final class com/monkopedia/ksrpc/RpcMethodKt {
+	public static final fun getForwardErrorMap (Lcom/monkopedia/ksrpc/RpcMethod;)Ljava/util/Map;
+	public static final fun getReverseErrorMap (Lcom/monkopedia/ksrpc/RpcMethod;)Ljava/util/Map;
 	public static final fun getTimeoutMillis (Lcom/monkopedia/ksrpc/RpcMethod;)Ljava/lang/Long;
 }
 
@@ -278,16 +292,23 @@ public final class com/monkopedia/ksrpc/SerializerTransformer : com/monkopedia/k
 	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class com/monkopedia/ksrpc/ServiceExecutor {
+	public abstract fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/monkopedia/ksrpc/ServiceNameKt {
 	public static final fun serviceInterfaceName (Lcom/monkopedia/ksrpc/RpcObject;)Ljava/lang/String;
 	public static final fun serviceNameFor (Lkotlin/reflect/KClass;)Ljava/lang/String;
 }
 
-public final class com/monkopedia/ksrpc/SubserviceTransformer : com/monkopedia/ksrpc/BaseSubserviceTransformer {
+public final class com/monkopedia/ksrpc/SubserviceTransformer : com/monkopedia/ksrpc/Transformer {
 	public fun <init> (Lcom/monkopedia/ksrpc/RpcObject;)V
-	public synthetic fun fromService (Lcom/monkopedia/ksrpc/RpcService;)Ljava/lang/Object;
-	public fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
-	public synthetic fun toService (Ljava/lang/Object;)Lcom/monkopedia/ksrpc/RpcService;
+	public fun getHasContent ()Z
+	public final fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
+	public fun transform (Lcom/monkopedia/ksrpc/RpcService;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unpackError (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;)V
+	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/monkopedia/ksrpc/SuspendCloseableObservable : com/monkopedia/ksrpc/SuspendCloseable {
@@ -486,6 +507,10 @@ public abstract interface class com/monkopedia/ksrpc/channels/SingleChannelHost 
 	public abstract fun registerDefault (Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/monkopedia/ksrpc/channels/UtilsJvmKt {
+	public static final fun randomUuid ()Ljava/lang/String;
+}
+
 public final class com/monkopedia/ksrpc/internal/ClientChannelContext : kotlin/coroutines/CoroutineContext$Element {
 	public fun <init> (Lcom/monkopedia/ksrpc/channels/ChannelClient;)V
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
@@ -498,11 +523,6 @@ public final class com/monkopedia/ksrpc/internal/ClientChannelContext : kotlin/c
 
 public final class com/monkopedia/ksrpc/internal/ClientChannelContext$Key : kotlin/coroutines/CoroutineContext$Key {
 	public static final field INSTANCE Lcom/monkopedia/ksrpc/internal/ClientChannelContext$Key;
-}
-
-public final class com/monkopedia/ksrpc/internal/ErrorPrefixesKt {
-	public static final field ENDPOINT_NOT_FOUND_PREFIX Ljava/lang/String;
-	public static final field ERROR_PREFIX Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/internal/HostChannelContext : kotlin/coroutines/CoroutineContext$Element {
@@ -547,14 +567,6 @@ public final class com/monkopedia/ksrpc/internal/MultiChannel {
 	public final fun close (Ljava/util/concurrent/CancellationException;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun close$default (Lcom/monkopedia/ksrpc/internal/MultiChannel;Ljava/util/concurrent/CancellationException;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun send (Ljava/lang/String;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/monkopedia/ksrpc/internal/RandomUuidJvmKt {
-	public static final fun randomUuid ()Ljava/lang/String;
-}
-
-public abstract interface class com/monkopedia/ksrpc/internal/ServiceExecutor {
-	public abstract fun invoke (Lcom/monkopedia/ksrpc/RpcService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/monkopedia/ksrpc/internal/SubserviceChannel : com/monkopedia/ksrpc/channels/SerializedService {

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -127,10 +127,6 @@ abstract interface com.monkopedia.ksrpc.channels/RpcBinaryData : com.monkopedia.
 
 abstract interface com.monkopedia.ksrpc.channels/RpcCallId // com.monkopedia.ksrpc.channels/RpcCallId|null[0]
 
-abstract interface com.monkopedia.ksrpc.internal/ServiceExecutor { // com.monkopedia.ksrpc.internal/ServiceExecutor|null[0]
-    abstract suspend fun invoke(com.monkopedia.ksrpc/RpcService, kotlin/Any?): kotlin/Any? // com.monkopedia.ksrpc.internal/ServiceExecutor.invoke|invoke(com.monkopedia.ksrpc.RpcService;kotlin.Any?){}[0]
-}
-
 abstract interface com.monkopedia.ksrpc/BinaryDataTransformer // com.monkopedia.ksrpc/BinaryDataTransformer|null[0]
 
 abstract interface com.monkopedia.ksrpc/Logger { // com.monkopedia.ksrpc/Logger|null[0]
@@ -138,6 +134,10 @@ abstract interface com.monkopedia.ksrpc/Logger { // com.monkopedia.ksrpc/Logger|
     open fun error(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.error|error(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
     open fun info(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.info|info(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
     open fun warn(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.warn|warn(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
+}
+
+abstract interface com.monkopedia.ksrpc/ServiceExecutor { // com.monkopedia.ksrpc/ServiceExecutor|null[0]
+    abstract suspend fun invoke(com.monkopedia.ksrpc/RpcService, kotlin/Any?): kotlin/Any? // com.monkopedia.ksrpc/ServiceExecutor.invoke|invoke(com.monkopedia.ksrpc.RpcService;kotlin.Any?){}[0]
 }
 
 abstract interface com.monkopedia.ksrpc/SuspendCloseableObservable : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc/SuspendCloseableObservable|null[0]
@@ -148,23 +148,13 @@ abstract interface com.monkopedia.ksrpc/UnhandledMethodHandler { // com.monkoped
     abstract suspend fun <#A1: kotlin/Any?> onUnhandled(kotlin/String, com.monkopedia.ksrpc.channels/CallData<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/UnhandledMethodHandler.onUnhandled|onUnhandled(kotlin.String;com.monkopedia.ksrpc.channels.CallData<0:0>){0§<kotlin.Any?>}[0]
 }
 
-abstract class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> com.monkopedia.ksrpc/BaseSubserviceTransformer : com.monkopedia.ksrpc/Transformer<#B> { // com.monkopedia.ksrpc/BaseSubserviceTransformer|null[0]
-    constructor <init>() // com.monkopedia.ksrpc/BaseSubserviceTransformer.<init>|<init>(){}[0]
-
-    abstract val serviceObject // com.monkopedia.ksrpc/BaseSubserviceTransformer.serviceObject|{}serviceObject[0]
-        abstract fun <get-serviceObject>(): com.monkopedia.ksrpc/RpcObject<#A> // com.monkopedia.ksrpc/BaseSubserviceTransformer.serviceObject.<get-serviceObject>|<get-serviceObject>(){}[0]
-
-    abstract fun fromService(#A): #B // com.monkopedia.ksrpc/BaseSubserviceTransformer.fromService|fromService(1:0){}[0]
-    abstract fun toService(#B): #A // com.monkopedia.ksrpc/BaseSubserviceTransformer.toService|toService(1:1){}[0]
-    open suspend fun <#A1: kotlin/Any?> transform(#B, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/BaseSubserviceTransformer.transform|transform(1:1;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
-    open suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): #B // com.monkopedia.ksrpc/BaseSubserviceTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
-}
-
 final class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?, #C: kotlin/Any?> com.monkopedia.ksrpc/RpcMethod { // com.monkopedia.ksrpc/RpcMethod|null[0]
-    constructor <init>(kotlin/String, com.monkopedia.ksrpc/Transformer<#B>, com.monkopedia.ksrpc/Transformer<#C>, com.monkopedia.ksrpc.internal/ServiceExecutor, kotlin.collections/List<com.monkopedia.ksrpc/MethodMetadata>) // com.monkopedia.ksrpc/RpcMethod.<init>|<init>(kotlin.String;com.monkopedia.ksrpc.Transformer<1:1>;com.monkopedia.ksrpc.Transformer<1:2>;com.monkopedia.ksrpc.internal.ServiceExecutor;kotlin.collections.List<com.monkopedia.ksrpc.MethodMetadata>){}[0]
+    constructor <init>(kotlin/String, com.monkopedia.ksrpc/Transformer<#B>, com.monkopedia.ksrpc/Transformer<#C>, com.monkopedia.ksrpc/ServiceExecutor, kotlin.collections/List<com.monkopedia.ksrpc/MethodMetadata>, kotlin.collections/List<com.monkopedia.ksrpc/KsErrorMapping> = ...) // com.monkopedia.ksrpc/RpcMethod.<init>|<init>(kotlin.String;com.monkopedia.ksrpc.Transformer<1:1>;com.monkopedia.ksrpc.Transformer<1:2>;com.monkopedia.ksrpc.ServiceExecutor;kotlin.collections.List<com.monkopedia.ksrpc.MethodMetadata>;kotlin.collections.List<com.monkopedia.ksrpc.KsErrorMapping>){}[0]
 
     final val endpoint // com.monkopedia.ksrpc/RpcMethod.endpoint|{}endpoint[0]
         final fun <get-endpoint>(): kotlin/String // com.monkopedia.ksrpc/RpcMethod.endpoint.<get-endpoint>|<get-endpoint>(){}[0]
+    final val errorMappings // com.monkopedia.ksrpc/RpcMethod.errorMappings|{}errorMappings[0]
+        final fun <get-errorMappings>(): kotlin.collections/List<com.monkopedia.ksrpc/KsErrorMapping> // com.monkopedia.ksrpc/RpcMethod.errorMappings.<get-errorMappings>|<get-errorMappings>(){}[0]
     final val hasReturnType // com.monkopedia.ksrpc/RpcMethod.hasReturnType|{}hasReturnType[0]
         final fun <get-hasReturnType>(): kotlin/Boolean // com.monkopedia.ksrpc/RpcMethod.hasReturnType.<get-hasReturnType>|<get-hasReturnType>(){}[0]
     final val inputTransform // com.monkopedia.ksrpc/RpcMethod.inputTransform|{}inputTransform[0]
@@ -174,17 +164,20 @@ final class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?, #C: kotlin/An
     final val outputTransform // com.monkopedia.ksrpc/RpcMethod.outputTransform|{}outputTransform[0]
         final fun <get-outputTransform>(): com.monkopedia.ksrpc/Transformer<#C> // com.monkopedia.ksrpc/RpcMethod.outputTransform.<get-outputTransform>|<get-outputTransform>(){}[0]
 
-    final fun findSubserviceTransformers(): kotlin.collections/List<com.monkopedia.ksrpc/BaseSubserviceTransformer<*, *>> // com.monkopedia.ksrpc/RpcMethod.findSubserviceTransformers|findSubserviceTransformers(){}[0]
+    final fun findSubserviceTransformers(): kotlin.collections/List<com.monkopedia.ksrpc/SubserviceTransformer<out com.monkopedia.ksrpc/RpcService>> // com.monkopedia.ksrpc/RpcMethod.findSubserviceTransformers|findSubserviceTransformers(){}[0]
     final fun metadata(kotlin/String): com.monkopedia.ksrpc/MethodMetadata? // com.monkopedia.ksrpc/RpcMethod.metadata|metadata(kotlin.String){}[0]
     final suspend fun <#A1: kotlin/Any?> call(com.monkopedia.ksrpc.channels/SerializedService<#A1>, com.monkopedia.ksrpc/RpcService, com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/RpcCallId?): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/RpcMethod.call|call(com.monkopedia.ksrpc.channels.SerializedService<0:0>;com.monkopedia.ksrpc.RpcService;com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.RpcCallId?){0§<kotlin.Any?>}[0]
     final suspend fun <#A1: kotlin/Any?> callChannel(com.monkopedia.ksrpc.channels/SerializedService<#A1>, kotlin/Any?): kotlin/Any? // com.monkopedia.ksrpc/RpcMethod.callChannel|callChannel(com.monkopedia.ksrpc.channels.SerializedService<0:0>;kotlin.Any?){0§<kotlin.Any?>}[0]
 }
 
-final class <#A: com.monkopedia.ksrpc/RpcService> com.monkopedia.ksrpc/SubserviceTransformer : com.monkopedia.ksrpc/BaseSubserviceTransformer<#A, #A> { // com.monkopedia.ksrpc/SubserviceTransformer|null[0]
+final class <#A: com.monkopedia.ksrpc/RpcService> com.monkopedia.ksrpc/SubserviceTransformer : com.monkopedia.ksrpc/Transformer<#A> { // com.monkopedia.ksrpc/SubserviceTransformer|null[0]
     constructor <init>(com.monkopedia.ksrpc/RpcObject<#A>) // com.monkopedia.ksrpc/SubserviceTransformer.<init>|<init>(com.monkopedia.ksrpc.RpcObject<1:0>){}[0]
 
     final val serviceObject // com.monkopedia.ksrpc/SubserviceTransformer.serviceObject|{}serviceObject[0]
         final fun <get-serviceObject>(): com.monkopedia.ksrpc/RpcObject<#A> // com.monkopedia.ksrpc/SubserviceTransformer.serviceObject.<get-serviceObject>|<get-serviceObject>(){}[0]
+
+    final suspend fun <#A1: kotlin/Any?> transform(#A, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/SubserviceTransformer.transform|transform(1:0;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): #A // com.monkopedia.ksrpc/SubserviceTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc.internal/ClientChannelContext : kotlin.coroutines/CoroutineContext.Element { // com.monkopedia.ksrpc.internal/ClientChannelContext|null[0]
@@ -265,6 +258,15 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc/KsrpcEnvironmentBuilder : com
     final var serialization // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.serialization|{}serialization[0]
         final fun <get-serialization>(): com.monkopedia.ksrpc/CallDataSerializer<#A> // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.serialization.<get-serialization>|<get-serialization>(){}[0]
         final fun <set-serialization>(com.monkopedia.ksrpc/CallDataSerializer<#A>) // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.serialization.<set-serialization>|<set-serialization>(com.monkopedia.ksrpc.CallDataSerializer<1:0>){}[0]
+
+    final fun component1(): com.monkopedia.ksrpc/CallDataSerializer<#A> // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.component1|component1(){}[0]
+    final fun component2(): kotlinx.coroutines/CoroutineScope // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.component2|component2(){}[0]
+    final fun component3(): com.monkopedia.ksrpc/Logger // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.component3|component3(){}[0]
+    final fun component4(): com.monkopedia.ksrpc/ErrorListener // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.component4|component4(){}[0]
+    final fun copy(com.monkopedia.ksrpc/CallDataSerializer<#A> = ..., kotlinx.coroutines/CoroutineScope = ..., com.monkopedia.ksrpc/Logger = ..., com.monkopedia.ksrpc/ErrorListener = ...): com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A> // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.copy|copy(com.monkopedia.ksrpc.CallDataSerializer<1:0>;kotlinx.coroutines.CoroutineScope;com.monkopedia.ksrpc.Logger;com.monkopedia.ksrpc.ErrorListener){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.toString|toString(){}[0]
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc/SerializerTransformer : com.monkopedia.ksrpc/Transformer<#A> { // com.monkopedia.ksrpc/SerializerTransformer|null[0]
@@ -303,6 +305,17 @@ final class com.monkopedia.ksrpc.channels/CurrentRpcCallElement : kotlin.corouti
     final fun toString(): kotlin/String // com.monkopedia.ksrpc.channels/CurrentRpcCallElement.toString|toString(){}[0]
 
     final object CurrentRpcCall : kotlin.coroutines/CoroutineContext.Key<com.monkopedia.ksrpc.channels/CurrentRpcCallElement> // com.monkopedia.ksrpc.channels/CurrentRpcCallElement.CurrentRpcCall|null[0]
+}
+
+final class com.monkopedia.ksrpc/KsErrorMapping { // com.monkopedia.ksrpc/KsErrorMapping|null[0]
+    constructor <init>(kotlin/Int, kotlin.reflect/KClass<*>, kotlinx.serialization/KSerializer<*>) // com.monkopedia.ksrpc/KsErrorMapping.<init>|<init>(kotlin.Int;kotlin.reflect.KClass<*>;kotlinx.serialization.KSerializer<*>){}[0]
+
+    final val code // com.monkopedia.ksrpc/KsErrorMapping.code|{}code[0]
+        final fun <get-code>(): kotlin/Int // com.monkopedia.ksrpc/KsErrorMapping.code.<get-code>|<get-code>(){}[0]
+    final val dataSerializer // com.monkopedia.ksrpc/KsErrorMapping.dataSerializer|{}dataSerializer[0]
+        final fun <get-dataSerializer>(): kotlinx.serialization/KSerializer<*> // com.monkopedia.ksrpc/KsErrorMapping.dataSerializer.<get-dataSerializer>|<get-dataSerializer>(){}[0]
+    final val dataType // com.monkopedia.ksrpc/KsErrorMapping.dataType|{}dataType[0]
+        final fun <get-dataType>(): kotlin.reflect/KClass<*> // com.monkopedia.ksrpc/KsErrorMapping.dataType.<get-dataType>|<get-dataType>(){}[0]
 }
 
 final class com.monkopedia.ksrpc/MethodMetadata { // com.monkopedia.ksrpc/MethodMetadata|null[0]
@@ -508,15 +521,19 @@ final object com.monkopedia.ksrpc/BinaryTransformer : com.monkopedia.ksrpc/Binar
     final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc/BinaryTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
 }
 
-final const val com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX // com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX|{}ENDPOINT_NOT_FOUND_PREFIX[0]
-    final fun <get-ENDPOINT_NOT_FOUND_PREFIX>(): kotlin/String // com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX.<get-ENDPOINT_NOT_FOUND_PREFIX>|<get-ENDPOINT_NOT_FOUND_PREFIX>(){}[0]
-final const val com.monkopedia.ksrpc.internal/ERROR_PREFIX // com.monkopedia.ksrpc.internal/ERROR_PREFIX|{}ERROR_PREFIX[0]
-    final fun <get-ERROR_PREFIX>(): kotlin/String // com.monkopedia.ksrpc.internal/ERROR_PREFIX.<get-ERROR_PREFIX>|<get-ERROR_PREFIX>(){}[0]
+final const val com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX // com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX|{}ENDPOINT_NOT_FOUND_PREFIX[0]
+    final fun <get-ENDPOINT_NOT_FOUND_PREFIX>(): kotlin/String // com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX.<get-ENDPOINT_NOT_FOUND_PREFIX>|<get-ENDPOINT_NOT_FOUND_PREFIX>(){}[0]
+final const val com.monkopedia.ksrpc/ERROR_PREFIX // com.monkopedia.ksrpc/ERROR_PREFIX|{}ERROR_PREFIX[0]
+    final fun <get-ERROR_PREFIX>(): kotlin/String // com.monkopedia.ksrpc/ERROR_PREFIX.<get-ERROR_PREFIX>|<get-ERROR_PREFIX>(){}[0]
 
 final val com.monkopedia.ksrpc.internal/asClient // com.monkopedia.ksrpc.internal/asClient|@com.monkopedia.ksrpc.channels.SerializedChannel<0:0>{0§<kotlin.Any?>}asClient[0]
     final fun <#A1: kotlin/Any?> (com.monkopedia.ksrpc.channels/SerializedChannel<#A1>).<get-asClient>(): com.monkopedia.ksrpc.channels/ChannelClient<#A1> // com.monkopedia.ksrpc.internal/asClient.<get-asClient>|<get-asClient>@com.monkopedia.ksrpc.channels.SerializedChannel<0:0>(){0§<kotlin.Any?>}[0]
 final val com.monkopedia.ksrpc/asString // com.monkopedia.ksrpc/asString|@kotlin.Throwable{}asString[0]
     final fun (kotlin/Throwable).<get-asString>(): kotlin/String // com.monkopedia.ksrpc/asString.<get-asString>|<get-asString>@kotlin.Throwable(){}[0]
+final val com.monkopedia.ksrpc/forwardErrorMap // com.monkopedia.ksrpc/forwardErrorMap|@com.monkopedia.ksrpc.RpcMethod<*,*,*>{}forwardErrorMap[0]
+    final fun (com.monkopedia.ksrpc/RpcMethod<*, *, *>).<get-forwardErrorMap>(): kotlin.collections/Map<kotlin/Int, com.monkopedia.ksrpc/KsErrorMapping> // com.monkopedia.ksrpc/forwardErrorMap.<get-forwardErrorMap>|<get-forwardErrorMap>@com.monkopedia.ksrpc.RpcMethod<*,*,*>(){}[0]
+final val com.monkopedia.ksrpc/reverseErrorMap // com.monkopedia.ksrpc/reverseErrorMap|@com.monkopedia.ksrpc.RpcMethod<*,*,*>{}reverseErrorMap[0]
+    final fun (com.monkopedia.ksrpc/RpcMethod<*, *, *>).<get-reverseErrorMap>(): kotlin.collections/Map<kotlin.reflect/KClass<*>, com.monkopedia.ksrpc/KsErrorMapping> // com.monkopedia.ksrpc/reverseErrorMap.<get-reverseErrorMap>|<get-reverseErrorMap>@com.monkopedia.ksrpc.RpcMethod<*,*,*>(){}[0]
 final val com.monkopedia.ksrpc/timeoutMillis // com.monkopedia.ksrpc/timeoutMillis|@com.monkopedia.ksrpc.RpcMethod<*,*,*>{}timeoutMillis[0]
     final fun (com.monkopedia.ksrpc/RpcMethod<*, *, *>).<get-timeoutMillis>(): kotlin/Long? // com.monkopedia.ksrpc/timeoutMillis.<get-timeoutMillis>|<get-timeoutMillis>@com.monkopedia.ksrpc.RpcMethod<*,*,*>(){}[0]
 
@@ -526,7 +543,7 @@ final fun <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> (#A).com.monkop
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/onError(com.monkopedia.ksrpc/ErrorListener): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/onError|onError@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(com.monkopedia.ksrpc.ErrorListener){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/reconfigure(kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/reconfigure|reconfigure@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> com.monkopedia.ksrpc/ksrpcEnvironment(com.monkopedia.ksrpc/CallDataSerializer<#A>, kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/ksrpcEnvironment|ksrpcEnvironment(com.monkopedia.ksrpc.CallDataSerializer<0:0>;kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
-final fun com.monkopedia.ksrpc.internal/randomUuid(): kotlin/String // com.monkopedia.ksrpc.internal/randomUuid|randomUuid(){}[0]
+final fun com.monkopedia.ksrpc.channels/randomUuid(): kotlin/String // com.monkopedia.ksrpc.channels/randomUuid|randomUuid(){}[0]
 final fun com.monkopedia.ksrpc/ksrpcEnvironment(kotlinx.serialization/StringFormat = ..., kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<kotlin/String>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<kotlin/String> // com.monkopedia.ksrpc/ksrpcEnvironment|ksrpcEnvironment(kotlinx.serialization.StringFormat;kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<kotlin.String>,kotlin.Unit>){}[0]
 final fun com.monkopedia.ksrpc/resolveSerializerOrThrow(kotlin.reflect/KType, kotlin/String): kotlinx.serialization/KSerializer<kotlin/Any?> // com.monkopedia.ksrpc/resolveSerializerOrThrow|resolveSerializerOrThrow(kotlin.reflect.KType;kotlin.String){}[0]
 final fun com.monkopedia.ksrpc/serviceNameFor(kotlin.reflect/KClass<*>): kotlin/String // com.monkopedia.ksrpc/serviceNameFor|serviceNameFor(kotlin.reflect.KClass<*>){}[0]

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -127,6 +127,10 @@ abstract interface com.monkopedia.ksrpc.channels/RpcBinaryData : com.monkopedia.
 
 abstract interface com.monkopedia.ksrpc.channels/RpcCallId // com.monkopedia.ksrpc.channels/RpcCallId|null[0]
 
+abstract interface com.monkopedia.ksrpc.internal/ServiceExecutor { // com.monkopedia.ksrpc.internal/ServiceExecutor|null[0]
+    abstract suspend fun invoke(com.monkopedia.ksrpc/RpcService, kotlin/Any?): kotlin/Any? // com.monkopedia.ksrpc.internal/ServiceExecutor.invoke|invoke(com.monkopedia.ksrpc.RpcService;kotlin.Any?){}[0]
+}
+
 abstract interface com.monkopedia.ksrpc/BinaryDataTransformer // com.monkopedia.ksrpc/BinaryDataTransformer|null[0]
 
 abstract interface com.monkopedia.ksrpc/Logger { // com.monkopedia.ksrpc/Logger|null[0]
@@ -134,10 +138,6 @@ abstract interface com.monkopedia.ksrpc/Logger { // com.monkopedia.ksrpc/Logger|
     open fun error(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.error|error(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
     open fun info(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.info|info(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
     open fun warn(kotlin/String, kotlin/String, kotlin/Throwable? = ...) // com.monkopedia.ksrpc/Logger.warn|warn(kotlin.String;kotlin.String;kotlin.Throwable?){}[0]
-}
-
-abstract interface com.monkopedia.ksrpc/ServiceExecutor { // com.monkopedia.ksrpc/ServiceExecutor|null[0]
-    abstract suspend fun invoke(com.monkopedia.ksrpc/RpcService, kotlin/Any?): kotlin/Any? // com.monkopedia.ksrpc/ServiceExecutor.invoke|invoke(com.monkopedia.ksrpc.RpcService;kotlin.Any?){}[0]
 }
 
 abstract interface com.monkopedia.ksrpc/SuspendCloseableObservable : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc/SuspendCloseableObservable|null[0]
@@ -148,8 +148,20 @@ abstract interface com.monkopedia.ksrpc/UnhandledMethodHandler { // com.monkoped
     abstract suspend fun <#A1: kotlin/Any?> onUnhandled(kotlin/String, com.monkopedia.ksrpc.channels/CallData<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/UnhandledMethodHandler.onUnhandled|onUnhandled(kotlin.String;com.monkopedia.ksrpc.channels.CallData<0:0>){0§<kotlin.Any?>}[0]
 }
 
+abstract class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> com.monkopedia.ksrpc/BaseSubserviceTransformer : com.monkopedia.ksrpc/Transformer<#B> { // com.monkopedia.ksrpc/BaseSubserviceTransformer|null[0]
+    constructor <init>() // com.monkopedia.ksrpc/BaseSubserviceTransformer.<init>|<init>(){}[0]
+
+    abstract val serviceObject // com.monkopedia.ksrpc/BaseSubserviceTransformer.serviceObject|{}serviceObject[0]
+        abstract fun <get-serviceObject>(): com.monkopedia.ksrpc/RpcObject<#A> // com.monkopedia.ksrpc/BaseSubserviceTransformer.serviceObject.<get-serviceObject>|<get-serviceObject>(){}[0]
+
+    abstract fun fromService(#A): #B // com.monkopedia.ksrpc/BaseSubserviceTransformer.fromService|fromService(1:0){}[0]
+    abstract fun toService(#B): #A // com.monkopedia.ksrpc/BaseSubserviceTransformer.toService|toService(1:1){}[0]
+    open suspend fun <#A1: kotlin/Any?> transform(#B, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/BaseSubserviceTransformer.transform|transform(1:1;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+    open suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): #B // com.monkopedia.ksrpc/BaseSubserviceTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
+}
+
 final class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?, #C: kotlin/Any?> com.monkopedia.ksrpc/RpcMethod { // com.monkopedia.ksrpc/RpcMethod|null[0]
-    constructor <init>(kotlin/String, com.monkopedia.ksrpc/Transformer<#B>, com.monkopedia.ksrpc/Transformer<#C>, com.monkopedia.ksrpc/ServiceExecutor, kotlin.collections/List<com.monkopedia.ksrpc/MethodMetadata>, kotlin.collections/List<com.monkopedia.ksrpc/KsErrorMapping> = ...) // com.monkopedia.ksrpc/RpcMethod.<init>|<init>(kotlin.String;com.monkopedia.ksrpc.Transformer<1:1>;com.monkopedia.ksrpc.Transformer<1:2>;com.monkopedia.ksrpc.ServiceExecutor;kotlin.collections.List<com.monkopedia.ksrpc.MethodMetadata>;kotlin.collections.List<com.monkopedia.ksrpc.KsErrorMapping>){}[0]
+    constructor <init>(kotlin/String, com.monkopedia.ksrpc/Transformer<#B>, com.monkopedia.ksrpc/Transformer<#C>, com.monkopedia.ksrpc.internal/ServiceExecutor, kotlin.collections/List<com.monkopedia.ksrpc/MethodMetadata>, kotlin.collections/List<com.monkopedia.ksrpc/KsErrorMapping> = ...) // com.monkopedia.ksrpc/RpcMethod.<init>|<init>(kotlin.String;com.monkopedia.ksrpc.Transformer<1:1>;com.monkopedia.ksrpc.Transformer<1:2>;com.monkopedia.ksrpc.internal.ServiceExecutor;kotlin.collections.List<com.monkopedia.ksrpc.MethodMetadata>;kotlin.collections.List<com.monkopedia.ksrpc.KsErrorMapping>){}[0]
 
     final val endpoint // com.monkopedia.ksrpc/RpcMethod.endpoint|{}endpoint[0]
         final fun <get-endpoint>(): kotlin/String // com.monkopedia.ksrpc/RpcMethod.endpoint.<get-endpoint>|<get-endpoint>(){}[0]
@@ -164,20 +176,17 @@ final class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?, #C: kotlin/An
     final val outputTransform // com.monkopedia.ksrpc/RpcMethod.outputTransform|{}outputTransform[0]
         final fun <get-outputTransform>(): com.monkopedia.ksrpc/Transformer<#C> // com.monkopedia.ksrpc/RpcMethod.outputTransform.<get-outputTransform>|<get-outputTransform>(){}[0]
 
-    final fun findSubserviceTransformers(): kotlin.collections/List<com.monkopedia.ksrpc/SubserviceTransformer<out com.monkopedia.ksrpc/RpcService>> // com.monkopedia.ksrpc/RpcMethod.findSubserviceTransformers|findSubserviceTransformers(){}[0]
+    final fun findSubserviceTransformers(): kotlin.collections/List<com.monkopedia.ksrpc/BaseSubserviceTransformer<*, *>> // com.monkopedia.ksrpc/RpcMethod.findSubserviceTransformers|findSubserviceTransformers(){}[0]
     final fun metadata(kotlin/String): com.monkopedia.ksrpc/MethodMetadata? // com.monkopedia.ksrpc/RpcMethod.metadata|metadata(kotlin.String){}[0]
     final suspend fun <#A1: kotlin/Any?> call(com.monkopedia.ksrpc.channels/SerializedService<#A1>, com.monkopedia.ksrpc/RpcService, com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/RpcCallId?): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/RpcMethod.call|call(com.monkopedia.ksrpc.channels.SerializedService<0:0>;com.monkopedia.ksrpc.RpcService;com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.RpcCallId?){0§<kotlin.Any?>}[0]
     final suspend fun <#A1: kotlin/Any?> callChannel(com.monkopedia.ksrpc.channels/SerializedService<#A1>, kotlin/Any?): kotlin/Any? // com.monkopedia.ksrpc/RpcMethod.callChannel|callChannel(com.monkopedia.ksrpc.channels.SerializedService<0:0>;kotlin.Any?){0§<kotlin.Any?>}[0]
 }
 
-final class <#A: com.monkopedia.ksrpc/RpcService> com.monkopedia.ksrpc/SubserviceTransformer : com.monkopedia.ksrpc/Transformer<#A> { // com.monkopedia.ksrpc/SubserviceTransformer|null[0]
+final class <#A: com.monkopedia.ksrpc/RpcService> com.monkopedia.ksrpc/SubserviceTransformer : com.monkopedia.ksrpc/BaseSubserviceTransformer<#A, #A> { // com.monkopedia.ksrpc/SubserviceTransformer|null[0]
     constructor <init>(com.monkopedia.ksrpc/RpcObject<#A>) // com.monkopedia.ksrpc/SubserviceTransformer.<init>|<init>(com.monkopedia.ksrpc.RpcObject<1:0>){}[0]
 
     final val serviceObject // com.monkopedia.ksrpc/SubserviceTransformer.serviceObject|{}serviceObject[0]
         final fun <get-serviceObject>(): com.monkopedia.ksrpc/RpcObject<#A> // com.monkopedia.ksrpc/SubserviceTransformer.serviceObject.<get-serviceObject>|<get-serviceObject>(){}[0]
-
-    final suspend fun <#A1: kotlin/Any?> transform(#A, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/CallData<#A1> // com.monkopedia.ksrpc/SubserviceTransformer.transform|transform(1:0;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
-    final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): #A // com.monkopedia.ksrpc/SubserviceTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc.internal/ClientChannelContext : kotlin.coroutines/CoroutineContext.Element { // com.monkopedia.ksrpc.internal/ClientChannelContext|null[0]
@@ -258,15 +267,6 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc/KsrpcEnvironmentBuilder : com
     final var serialization // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.serialization|{}serialization[0]
         final fun <get-serialization>(): com.monkopedia.ksrpc/CallDataSerializer<#A> // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.serialization.<get-serialization>|<get-serialization>(){}[0]
         final fun <set-serialization>(com.monkopedia.ksrpc/CallDataSerializer<#A>) // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.serialization.<set-serialization>|<set-serialization>(com.monkopedia.ksrpc.CallDataSerializer<1:0>){}[0]
-
-    final fun component1(): com.monkopedia.ksrpc/CallDataSerializer<#A> // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.component1|component1(){}[0]
-    final fun component2(): kotlinx.coroutines/CoroutineScope // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.component2|component2(){}[0]
-    final fun component3(): com.monkopedia.ksrpc/Logger // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.component3|component3(){}[0]
-    final fun component4(): com.monkopedia.ksrpc/ErrorListener // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.component4|component4(){}[0]
-    final fun copy(com.monkopedia.ksrpc/CallDataSerializer<#A> = ..., kotlinx.coroutines/CoroutineScope = ..., com.monkopedia.ksrpc/Logger = ..., com.monkopedia.ksrpc/ErrorListener = ...): com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A> // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.copy|copy(com.monkopedia.ksrpc.CallDataSerializer<1:0>;kotlinx.coroutines.CoroutineScope;com.monkopedia.ksrpc.Logger;com.monkopedia.ksrpc.ErrorListener){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // com.monkopedia.ksrpc/KsrpcEnvironmentBuilder.toString|toString(){}[0]
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc/SerializerTransformer : com.monkopedia.ksrpc/Transformer<#A> { // com.monkopedia.ksrpc/SerializerTransformer|null[0]
@@ -521,10 +521,10 @@ final object com.monkopedia.ksrpc/BinaryTransformer : com.monkopedia.ksrpc/Binar
     final suspend fun <#A1: kotlin/Any?> untransform(com.monkopedia.ksrpc.channels/CallData<#A1>, com.monkopedia.ksrpc.channels/SerializedService<#A1>): com.monkopedia.ksrpc.channels/RpcBinaryData // com.monkopedia.ksrpc/BinaryTransformer.untransform|untransform(com.monkopedia.ksrpc.channels.CallData<0:0>;com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
 }
 
-final const val com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX // com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX|{}ENDPOINT_NOT_FOUND_PREFIX[0]
-    final fun <get-ENDPOINT_NOT_FOUND_PREFIX>(): kotlin/String // com.monkopedia.ksrpc/ENDPOINT_NOT_FOUND_PREFIX.<get-ENDPOINT_NOT_FOUND_PREFIX>|<get-ENDPOINT_NOT_FOUND_PREFIX>(){}[0]
-final const val com.monkopedia.ksrpc/ERROR_PREFIX // com.monkopedia.ksrpc/ERROR_PREFIX|{}ERROR_PREFIX[0]
-    final fun <get-ERROR_PREFIX>(): kotlin/String // com.monkopedia.ksrpc/ERROR_PREFIX.<get-ERROR_PREFIX>|<get-ERROR_PREFIX>(){}[0]
+final const val com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX // com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX|{}ENDPOINT_NOT_FOUND_PREFIX[0]
+    final fun <get-ENDPOINT_NOT_FOUND_PREFIX>(): kotlin/String // com.monkopedia.ksrpc.internal/ENDPOINT_NOT_FOUND_PREFIX.<get-ENDPOINT_NOT_FOUND_PREFIX>|<get-ENDPOINT_NOT_FOUND_PREFIX>(){}[0]
+final const val com.monkopedia.ksrpc.internal/ERROR_PREFIX // com.monkopedia.ksrpc.internal/ERROR_PREFIX|{}ERROR_PREFIX[0]
+    final fun <get-ERROR_PREFIX>(): kotlin/String // com.monkopedia.ksrpc.internal/ERROR_PREFIX.<get-ERROR_PREFIX>|<get-ERROR_PREFIX>(){}[0]
 
 final val com.monkopedia.ksrpc.internal/asClient // com.monkopedia.ksrpc.internal/asClient|@com.monkopedia.ksrpc.channels.SerializedChannel<0:0>{0§<kotlin.Any?>}asClient[0]
     final fun <#A1: kotlin/Any?> (com.monkopedia.ksrpc.channels/SerializedChannel<#A1>).<get-asClient>(): com.monkopedia.ksrpc.channels/ChannelClient<#A1> // com.monkopedia.ksrpc.internal/asClient.<get-asClient>|<get-asClient>@com.monkopedia.ksrpc.channels.SerializedChannel<0:0>(){0§<kotlin.Any?>}[0]
@@ -543,7 +543,7 @@ final fun <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> (#A).com.monkop
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/onError(com.monkopedia.ksrpc/ErrorListener): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/onError|onError@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(com.monkopedia.ksrpc.ErrorListener){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (com.monkopedia.ksrpc/KsrpcEnvironment<#A>).com.monkopedia.ksrpc/reconfigure(kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/reconfigure|reconfigure@com.monkopedia.ksrpc.KsrpcEnvironment<0:0>(kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> com.monkopedia.ksrpc/ksrpcEnvironment(com.monkopedia.ksrpc/CallDataSerializer<#A>, kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<#A>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<#A> // com.monkopedia.ksrpc/ksrpcEnvironment|ksrpcEnvironment(com.monkopedia.ksrpc.CallDataSerializer<0:0>;kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any?>}[0]
-final fun com.monkopedia.ksrpc.channels/randomUuid(): kotlin/String // com.monkopedia.ksrpc.channels/randomUuid|randomUuid(){}[0]
+final fun com.monkopedia.ksrpc.internal/randomUuid(): kotlin/String // com.monkopedia.ksrpc.internal/randomUuid|randomUuid(){}[0]
 final fun com.monkopedia.ksrpc/ksrpcEnvironment(kotlinx.serialization/StringFormat = ..., kotlin/Function1<com.monkopedia.ksrpc/KsrpcEnvironmentBuilder<kotlin/String>, kotlin/Unit>): com.monkopedia.ksrpc/KsrpcEnvironment<kotlin/String> // com.monkopedia.ksrpc/ksrpcEnvironment|ksrpcEnvironment(kotlinx.serialization.StringFormat;kotlin.Function1<com.monkopedia.ksrpc.KsrpcEnvironmentBuilder<kotlin.String>,kotlin.Unit>){}[0]
 final fun com.monkopedia.ksrpc/resolveSerializerOrThrow(kotlin.reflect/KType, kotlin/String): kotlinx.serialization/KSerializer<kotlin/Any?> // com.monkopedia.ksrpc/resolveSerializerOrThrow|resolveSerializerOrThrow(kotlin.reflect.KType;kotlin.String){}[0]
 final fun com.monkopedia.ksrpc/serviceNameFor(kotlin.reflect/KClass<*>): kotlin/String // com.monkopedia.ksrpc/serviceNameFor|serviceNameFor(kotlin.reflect.KClass<*>){}[0]

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -29,6 +29,7 @@ import com.monkopedia.ksrpc.internal.ServiceExecutor
 import com.monkopedia.ksrpc.internal.client
 import com.monkopedia.ksrpc.internal.host
 import com.monkopedia.ksrpc.internal.randomUuid
+import kotlin.reflect.KClass
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -161,19 +162,58 @@ class SubserviceTransformer<T : RpcService>(
 }
 
 /**
+ * Describes one `@KsError(code, type)` binding captured by the ksrpc compiler
+ * plugin on a `@KsMethod` function. The plugin emits one entry per annotation
+ * in declaration order into [RpcMethod.errorMappings]. Runtime routing (#78)
+ * consumes these via the [forwardErrorMap] / [reverseErrorMap] helpers on
+ * [RpcMethod] — forward maps for client-side deserialization by incoming wire
+ * code, reverse maps for server-side resolution of a thrown `data::class` back
+ * to its code + serializer.
+ */
+class KsErrorMapping(val code: Int, val dataType: KClass<*>, val dataSerializer: KSerializer<*>)
+
+/**
+ * Forward lookup built from [RpcMethod.errorMappings]: code → mapping. Used by
+ * the client-side error-decoder to resolve an incoming wire-level code back to
+ * the captured [KSerializer] for deserializing the payload. Entries from later
+ * `@KsError` annotations that share a code overwrite earlier ones; duplicate
+ * codes on a single method are a programming error that transport validation
+ * can surface.
+ */
+val RpcMethod<*, *, *>.forwardErrorMap: Map<Int, KsErrorMapping>
+    get() = errorMappings.associateBy { it.code }
+
+/**
+ * Reverse lookup built from [RpcMethod.errorMappings]: `data::class` → mapping.
+ * Used by the server-side error-encoder to resolve the thrown `data::class`
+ * back to its bound code + captured [KSerializer]. Later entries overwrite
+ * earlier ones for the same type.
+ */
+val RpcMethod<*, *, *>.reverseErrorMap: Map<KClass<*>, KsErrorMapping>
+    get() = errorMappings.associateBy { it.dataType }
+
+/**
  * A wrapper around calling into or from stubs/serialization.
  *
  * The optional [metadata] list carries sibling-annotation metadata captured by
  * the ksrpc compiler plugin from annotations on the source method that are
  * themselves annotated `@KsMethodMetadata`. Transport layers can read it to
  * customize how a call is serialized.
+ *
+ * The optional [errorMappings] list carries `@KsError(code, type)` bindings
+ * captured by the compiler plugin on the source method. Each entry pairs a
+ * wire-level integer code with the `@Serializable` payload type and its
+ * [KSerializer]. Runtime routing (see [forwardErrorMap] / [reverseErrorMap])
+ * uses these to translate between thrown exception data and wire-level error
+ * envelopes.
  */
 class RpcMethod<T : RpcService, I, O>(
     val endpoint: String,
     val inputTransform: Transformer<I>,
     val outputTransform: Transformer<O>,
     private val method: ServiceExecutor,
-    val metadata: List<MethodMetadata>
+    val metadata: List<MethodMetadata>,
+    val errorMappings: List<KsErrorMapping> = emptyList()
 ) {
 
     val hasReturnType: Boolean


### PR DESCRIPTION
## Summary

Part 2 of #13 (the error binding chain, following #76). The compiler plugin captures `@KsError(code, type)` annotations on `@KsMethod` functions and emits them into a new `errorMappings: List<KsErrorMapping>` parameter on `RpcMethod`. Each entry pairs a wire-level integer `code` with a `@Serializable` payload `KClass` and its `KSerializer`.

`forwardErrorMap` / `reverseErrorMap` extension properties on `RpcMethod` provide the lookup surfaces that runtime routing (#78) will consume:
- forward: `code → KsErrorMapping` for client-side deserialization of incoming wire codes
- reverse: `data::class → KsErrorMapping` for server-side encoding of thrown exceptions

The plugin also validates that the referenced type carries `@Serializable` and emits a compile-time diagnostic otherwise.

Rebased onto current main (which now includes #76 via squash merge, #91 transformer hierarchy, #99 environment builder, #105/#112 skew tests, etc.).

Fixes #77.

## Test plan
- [x] `./gradlew :ksrpc-core:apiCheck :ksrpc-api:apiCheck` pass locally
- [x] `./gradlew :ksrpc-test:jvmTest` passes locally
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)