### PR TITLE
Fix #80: @KsContext core API + FIR validation (part 1 of #28)

### DIFF
--- a/compiler/plugin/src/main/java/fir/KsContextAnnotationChecker.kt
+++ b/compiler/plugin/src/main/java/fir/KsContextAnnotationChecker.kt
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(
+    org.jetbrains.kotlin.fir.symbols.SymbolInternals::class,
+    org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess::class
+)
+
+package com.monkopedia.ksrpc.plugin.fir
+
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirDeclarationChecker
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.FirProperty
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.declarations.utils.classId
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
+import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.types.ConeClassLikeType
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.ConeKotlinTypeProjection
+import org.jetbrains.kotlin.fir.types.classId
+import org.jetbrains.kotlin.fir.types.coneType
+import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlin.fir.types.toRegularClassSymbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * FIR-side validation for `@KsContext`-meta-annotated annotations.
+ *
+ * For every annotation applied to a `@KsService` interface or a `@KsMethod`
+ * function whose annotation class itself carries `@KsContext(binding = ...)`:
+ *
+ *  - The `binding` argument must reference a class that implements
+ *    [com.monkopedia.ksrpc.KsContextBinding]. Anything else is rejected with a
+ *    diagnostic naming the binding interface.
+ *
+ *  - Two `@KsContext`-meta-annotated annotations applied (directly or via the
+ *    enclosing class) to a single `@KsMethod` function whose bindings declare
+ *    the same `wireKey` are rejected. The check inspects each binding's
+ *    `wireKey` property initializer when it is a string literal — bindings
+ *    whose `wireKey` is computed are excluded from the duplicate check.
+ *
+ * Code emission for stub-side put-into-context, handler-side
+ * read-from-coroutine-context, and per-transport wire formats is intentionally
+ * out of scope for this checker — see issues #81 / #82.
+ */
+internal object KsContextAnnotationChecker {
+
+    internal val KS_CONTEXT_ID =
+        ClassId(FqName("com.monkopedia.ksrpc.annotation"), Name.identifier("KsContext"))
+    internal val KS_CONTEXT_BINDING_FQ =
+        FqName("com.monkopedia.ksrpc.KsContextBinding")
+    internal val KS_METHOD_ID =
+        ClassId(FqName("com.monkopedia.ksrpc.annotation"), Name.identifier("KsMethod"))
+    internal val KS_SERVICE_ID =
+        ClassId(FqName("com.monkopedia.ksrpc.annotation"), Name.identifier("KsService"))
+
+    /**
+     * Captures one `@KsContext`-meta-annotated annotation found on a
+     * declaration: the call-site source (for diagnostic placement), the
+     * resolved binding class symbol, and — when statically known — the
+     * literal value of the binding's `wireKey` property.
+     */
+    internal data class BindingUsage(
+        val source: KtSourceElement,
+        val annotationFqName: FqName,
+        val bindingSymbol: FirRegularClassSymbol?,
+        val wireKey: String?
+    )
+
+    /**
+     * Walks the annotations on [declaration]; for each annotation whose class
+     * itself carries `@KsContext(binding = X::class)`, returns a [BindingUsage]
+     * describing the binding and its statically-known `wireKey` (if any).
+     */
+    internal fun collectBindingUsages(
+        session: FirSession,
+        declaration: FirDeclaration
+    ): List<BindingUsage> = declaration.annotations.mapNotNull { ann ->
+        val annClass = ann.annotationTypeRef.toRegularClassSymbol(session) ?: return@mapNotNull null
+        val ksContext = annClass.annotations.firstOrNull { meta ->
+            meta.annotationTypeRef.toRegularClassSymbol(session)?.classId == KS_CONTEXT_ID
+        } ?: return@mapNotNull null
+        val source = ann.source ?: declaration.source ?: return@mapNotNull null
+        val bindingSymbol = bindingArgumentClassSymbol(session, ksContext)
+        val wireKey = bindingSymbol?.let { staticWireKey(it) }
+        BindingUsage(
+            source = source,
+            annotationFqName = annClass.classId.asSingleFqName(),
+            bindingSymbol = bindingSymbol,
+            wireKey = wireKey
+        )
+    }
+
+    /**
+     * Resolve the `binding = X::class` argument on a `@KsContext` annotation to
+     * the referenced class symbol. Returns null if the argument is missing or
+     * the expression isn't a class literal.
+     */
+    internal fun bindingArgumentClassSymbol(
+        session: FirSession,
+        ksContext: FirAnnotation
+    ): FirRegularClassSymbol? {
+        val arg = ksContext.argumentMapping.mapping.values.firstOrNull() as? FirGetClassCall
+            ?: return null
+        return classFromGetClassCall(session, arg)
+    }
+
+    /**
+     * Resolve `T` from a `T::class` expression. Tries the argument's own type
+     * first; if that's unhelpful, falls back to the first type argument of the
+     * `KClass<T>` type the expression as a whole was inferred to.
+     */
+    private fun classFromGetClassCall(
+        session: FirSession,
+        getClassCall: FirGetClassCall
+    ): FirRegularClassSymbol? {
+        coneTypeToRegularClassSymbol(session, getClassCall.argument.resolvedType)
+            ?.let { return it }
+        val firstArg = getClassCall.resolvedType.typeArguments.firstOrNull()
+            as? ConeKotlinTypeProjection ?: return null
+        val argType = firstArg.type ?: return null
+        return coneTypeToRegularClassSymbol(session, argType)
+    }
+
+    /**
+     * Resolve a [ConeKotlinType] (assumed to be a class-like type) to its
+     * declaring class symbol. Returns null for type parameters, function
+     * types, or types whose declaration isn't on the compile classpath.
+     */
+    private fun coneTypeToRegularClassSymbol(
+        session: FirSession,
+        type: ConeKotlinType?
+    ): FirRegularClassSymbol? {
+        val classLike = type as? ConeClassLikeType ?: return null
+        val classId = classLike.lookupTag.classId
+        return session.symbolProvider.getClassLikeSymbolByClassId(classId)
+            as? FirRegularClassSymbol
+    }
+
+    /**
+     * True iff [classSymbol] (or any of its supertypes, transitively) is the
+     * `KsContextBinding` interface.
+     */
+    internal fun implementsKsContextBinding(
+        session: FirSession,
+        classSymbol: FirRegularClassSymbol
+    ): Boolean {
+        if (classSymbol.classId.asSingleFqName() == KS_CONTEXT_BINDING_FQ) return true
+        val seen = mutableSetOf<ClassId>()
+        val queue = ArrayDeque<FirRegularClassSymbol>()
+        queue.addLast(classSymbol)
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (!seen.add(current.classId)) continue
+            for (superType in current.resolvedSuperTypes) {
+                val superSym = coneTypeToRegularClassSymbol(session, superType) ?: continue
+                if (superSym.classId.asSingleFqName() == KS_CONTEXT_BINDING_FQ) return true
+                queue.addLast(superSym)
+            }
+        }
+        return false
+    }
+
+    /**
+     * Read [bindingSymbol]'s `wireKey` property and, if its initializer is a
+     * string literal, return that literal. Returns null if the class is not
+     * source-visible (e.g. it lives in another already-compiled module) or the
+     * initializer isn't a constant string.
+     */
+    private fun staticWireKey(bindingSymbol: FirRegularClassSymbol): String? {
+        val classDecl: FirRegularClass = try {
+            bindingSymbol.fir
+        } catch (_: Throwable) {
+            return null
+        }
+        for (decl in classDecl.declarations) {
+            if (decl !is FirProperty) continue
+            if (decl.name.asString() != "wireKey") continue
+            val init = decl.initializer ?: continue
+            return (init as? FirLiteralExpression)?.value as? String
+        }
+        // wireKey isn't declared in this class body — could be inherited or
+        // declared via constructor parameter. Skip the duplicate-key check in
+        // that case.
+        return null
+    }
+
+    /**
+     * Emit a "binding doesn't implement KsContextBinding" diagnostic for
+     * [usage], referencing [usage]'s call-site so the IDE points the squiggle
+     * at the offending annotation.
+     */
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    internal fun reportInvalidBinding(usage: BindingUsage, ownerDescription: String) {
+        val bindingFq = usage.bindingSymbol?.classId?.asFqNameString() ?: "<unresolved>"
+        reporter.reportOn(
+            usage.source,
+            KsrpcDiagnostics.KSCONTEXT_BINDING_NOT_KSCONTEXTBINDING,
+            "@${usage.annotationFqName.shortName().asString()} on $ownerDescription: " +
+                "@KsContext binding `$bindingFq` must implement " +
+                "${KS_CONTEXT_BINDING_FQ.asString()}.",
+            context
+        )
+    }
+}
+
+/**
+ * Class-level checker — validates `@KsContext`-meta-annotated annotations on
+ * `@KsService`-tagged classes, plus all annotations on annotation classes
+ * carrying the `@KsContext` meta themselves (so `@KsContext(binding = NotABinding::class)`
+ * is rejected even if the user forgets to apply the resulting annotation).
+ */
+internal object KsContextClassChecker :
+    FirDeclarationChecker<FirClass>(MppCheckerKind.Common) {
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirClass) {
+        val session = context.session
+        val symbol = declaration.symbol
+
+        // Validate annotations applied to a @KsService class.
+        val isKsService = symbol.hasAnnotation(KsContextAnnotationChecker.KS_SERVICE_ID, session)
+        if (isKsService) {
+            val usages = KsContextAnnotationChecker.collectBindingUsages(session, declaration)
+            for (usage in usages) {
+                val bindingSymbol = usage.bindingSymbol
+                val ownerDescription = symbol.classId.asFqNameString()
+                if (bindingSymbol == null ||
+                    !KsContextAnnotationChecker.implementsKsContextBinding(session, bindingSymbol)
+                ) {
+                    KsContextAnnotationChecker.reportInvalidBinding(usage, ownerDescription)
+                }
+            }
+        }
+
+        // Validate `@KsContext(binding = ...)` directly on annotation classes.
+        // This catches misuse at the declaration site even when the resulting
+        // annotation is never applied to a service.
+        val ksContext = declaration.annotations.firstOrNull { ann ->
+            ann.annotationTypeRef.toRegularClassSymbol(session)?.classId ==
+                KsContextAnnotationChecker.KS_CONTEXT_ID
+        } ?: return
+        val bindingSymbol = KsContextAnnotationChecker.bindingArgumentClassSymbol(
+            session,
+            ksContext
+        )
+        val source = ksContext.source ?: declaration.source ?: return
+        if (bindingSymbol == null ||
+            !KsContextAnnotationChecker.implementsKsContextBinding(session, bindingSymbol)
+        ) {
+            val bindingFq = bindingSymbol?.classId?.asFqNameString() ?: "<unresolved>"
+            reporter.reportOn(
+                source,
+                KsrpcDiagnostics.KSCONTEXT_BINDING_NOT_KSCONTEXTBINDING,
+                "@KsContext on annotation class ${symbol.classId.asFqNameString()}: " +
+                    "binding `$bindingFq` must implement " +
+                    "${KsContextAnnotationChecker.KS_CONTEXT_BINDING_FQ.asString()}.",
+                context
+            )
+        }
+    }
+}
+
+/**
+ * Function-level checker — validates `@KsContext`-meta-annotated annotations
+ * on `@KsMethod` functions, and rejects duplicate `wireKey`s across the union
+ * of method-level and enclosing-class-level bindings.
+ */
+internal object KsContextMethodChecker :
+    FirDeclarationChecker<FirNamedFunction>(MppCheckerKind.Common) {
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirNamedFunction) {
+        val session = context.session
+        val symbol = declaration.symbol
+        if (!symbol.hasAnnotation(KsContextAnnotationChecker.KS_METHOD_ID, session)) return
+
+        val containingClass = containingClassSymbol(context)
+        val methodFqName = "${containingClass?.classId?.asFqNameString() ?: "<no-class>"}." +
+            declaration.name.asString()
+
+        val methodUsages = KsContextAnnotationChecker.collectBindingUsages(session, declaration)
+        val classUsages = if (containingClass is FirRegularClassSymbol) {
+            KsContextAnnotationChecker.collectBindingUsages(session, containingClass.fir)
+        } else {
+            emptyList()
+        }
+
+        for (usage in methodUsages) {
+            val bindingSymbol = usage.bindingSymbol
+            if (bindingSymbol == null ||
+                !KsContextAnnotationChecker.implementsKsContextBinding(session, bindingSymbol)
+            ) {
+                KsContextAnnotationChecker.reportInvalidBinding(usage, methodFqName)
+            }
+        }
+
+        // Duplicate-wireKey: union of class-level + method-level bindings whose
+        // wireKey is statically known. Class-level bindings are validated by
+        // [KsContextClassChecker]; here we only need them to participate in the
+        // duplicate-key calculation.
+        val all = classUsages + methodUsages
+        val byKey = all.filter { it.wireKey != null }.groupBy { it.wireKey!! }
+        for ((wireKey, usages) in byKey) {
+            if (usages.size <= 1) continue
+            // Report on each of the second-and-later occurrences in the order
+            // they appeared. The first occurrence is kept silent — same shape
+            // as the duplicate-endpoint diagnostic.
+            for (usage in usages.drop(1)) {
+                reporter.reportOn(
+                    usage.source,
+                    KsrpcDiagnostics.KSCONTEXT_DUPLICATE_WIRE_KEY,
+                    "$methodFqName: @KsContext bindings produce duplicate wireKey " +
+                        "\"$wireKey\" — annotations " +
+                        usages.joinToString(", ") { "@${it.annotationFqName.shortName()}" } +
+                        " resolve to the same wire-level identifier.",
+                    context
+                )
+            }
+        }
+    }
+
+    private fun containingClassSymbol(context: CheckerContext): FirClassSymbol<*>? {
+        val containers = context.containingDeclarations
+        for (i in containers.indices.reversed()) {
+            val sym = containers[i]
+            if (sym is FirClassSymbol<*>) return sym
+        }
+        return null
+    }
+}

--- a/compiler/plugin/src/main/java/fir/KsrpcDiagnostics.kt
+++ b/compiler/plugin/src/main/java/fir/KsrpcDiagnostics.kt
@@ -75,6 +75,16 @@ object KsrpcDiagnostics : KtDiagnosticsContainer() {
     // 10: Multiple @KsService supertypes on a class
     val MULTIPLE_KSSERVICE_SUPERTYPES: KtDiagnosticFactory1<String> by error1<KtElement, String>()
 
+    // 11: @KsContext-meta-annotated annotation whose `binding` argument doesn't
+    // implement `KsContextBinding`.
+    val KSCONTEXT_BINDING_NOT_KSCONTEXTBINDING: KtDiagnosticFactory1<String>
+        by error1<KtElement, String>()
+
+    // 12: Two @KsContext-meta-annotated annotations on one method whose
+    // bindings declare the same `wireKey`.
+    val KSCONTEXT_DUPLICATE_WIRE_KEY: KtDiagnosticFactory1<String>
+        by error1<KtElement, String>()
+
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = KsrpcDiagnosticRenderers
 }
 
@@ -96,6 +106,8 @@ private object KsrpcDiagnosticRenderers : BaseDiagnosticRendererFactory() {
             map.put(NOTIFICATION_NON_UNIT, "{0}", CommonRenderers.STRING)
             map.put(KSMETHOD_OUTSIDE_KSSERVICE, "{0}", CommonRenderers.STRING)
             map.put(MULTIPLE_KSSERVICE_SUPERTYPES, "{0}", CommonRenderers.STRING)
+            map.put(KSCONTEXT_BINDING_NOT_KSCONTEXTBINDING, "{0}", CommonRenderers.STRING)
+            map.put(KSCONTEXT_DUPLICATE_WIRE_KEY, "{0}", CommonRenderers.STRING)
         }
     }
 }

--- a/compiler/plugin/src/main/java/fir/KsrpcFirCheckersComponent.kt
+++ b/compiler/plugin/src/main/java/fir/KsrpcFirCheckersComponent.kt
@@ -31,9 +31,9 @@ class KsrpcFirCheckersComponent(session: FirSession) : FirAdditionalCheckersExte
 
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
         override val classCheckers: Set<FirDeclarationChecker<FirClass>> =
-            setOf(KsServiceClassChecker)
+            setOf(KsServiceClassChecker, KsContextClassChecker)
 
         override val simpleFunctionCheckers: Set<FirDeclarationChecker<FirNamedFunction>> =
-            setOf(KsMethodFunctionChecker)
+            setOf(KsMethodFunctionChecker, KsContextMethodChecker)
     }
 }

--- a/compiler/plugin/src/test/java/KsContextValidationTest.kt
+++ b/compiler/plugin/src/test/java/KsContextValidationTest.kt
@@ -58,9 +58,8 @@ package com.monkopedia.ksrpc
 
 import kotlin.coroutines.CoroutineContext
 
-interface KsContextBinding<T : CoroutineContext.Element> {
+interface KsContextBinding<T : CoroutineContext.Element> : CoroutineContext.Key<T> {
     val wireKey: String
-    val contextKey: CoroutineContext.Key<T>
     fun toWire(value: T): String
     fun fromWire(encoded: String): T
 }
@@ -82,18 +81,15 @@ import com.monkopedia.ksrpc.RpcService
 import kotlin.coroutines.CoroutineContext
 
 class TraceId(val value: String) : CoroutineContext.Element {
-    override val key: CoroutineContext.Key<*> get() = Key
-    companion object Key : CoroutineContext.Key<TraceId>
+    override val key get() = Key
+    companion object Key : KsContextBinding<TraceId> {
+        override val wireKey: String = "x-trace-id"
+        override fun toWire(value: TraceId): String = value.value
+        override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+    }
 }
 
-object TraceIdBinding : KsContextBinding<TraceId> {
-    override val wireKey: String = "x-trace-id"
-    override val contextKey: CoroutineContext.Key<TraceId> = TraceId.Key
-    override fun toWire(value: TraceId): String = value.value
-    override fun fromWire(encoded: String): TraceId = TraceId(encoded)
-}
-
-@KsContext(binding = TraceIdBinding::class)
+@KsContext(binding = TraceId.Key::class)
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
 annotation class WithTrace
@@ -127,18 +123,15 @@ import com.monkopedia.ksrpc.RpcService
 import kotlin.coroutines.CoroutineContext
 
 class TraceId(val value: String) : CoroutineContext.Element {
-    override val key: CoroutineContext.Key<*> get() = Key
-    companion object Key : CoroutineContext.Key<TraceId>
+    override val key get() = Key
+    companion object Key : KsContextBinding<TraceId> {
+        override val wireKey: String = "x-trace-id"
+        override fun toWire(value: TraceId): String = value.value
+        override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+    }
 }
 
-object TraceIdBinding : KsContextBinding<TraceId> {
-    override val wireKey: String = "x-trace-id"
-    override val contextKey: CoroutineContext.Key<TraceId> = TraceId.Key
-    override fun toWire(value: TraceId): String = value.value
-    override fun fromWire(encoded: String): TraceId = TraceId(encoded)
-}
-
-@KsContext(binding = TraceIdBinding::class)
+@KsContext(binding = TraceId.Key::class)
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
 annotation class WithTrace
@@ -210,34 +203,28 @@ import com.monkopedia.ksrpc.RpcService
 import kotlin.coroutines.CoroutineContext
 
 class TraceId(val value: String) : CoroutineContext.Element {
-    override val key: CoroutineContext.Key<*> get() = Key
-    companion object Key : CoroutineContext.Key<TraceId>
+    override val key get() = Key
+    companion object Key : KsContextBinding<TraceId> {
+        override val wireKey: String = "x-shared"
+        override fun toWire(value: TraceId): String = value.value
+        override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+    }
 }
 class SpanId(val value: String) : CoroutineContext.Element {
-    override val key: CoroutineContext.Key<*> get() = Key
-    companion object Key : CoroutineContext.Key<SpanId>
+    override val key get() = Key
+    companion object Key : KsContextBinding<SpanId> {
+        override val wireKey: String = "x-shared"
+        override fun toWire(value: SpanId): String = value.value
+        override fun fromWire(encoded: String): SpanId = SpanId(encoded)
+    }
 }
 
-object TraceIdBinding : KsContextBinding<TraceId> {
-    override val wireKey: String = "x-shared"
-    override val contextKey: CoroutineContext.Key<TraceId> = TraceId.Key
-    override fun toWire(value: TraceId): String = value.value
-    override fun fromWire(encoded: String): TraceId = TraceId(encoded)
-}
-
-object SpanIdBinding : KsContextBinding<SpanId> {
-    override val wireKey: String = "x-shared"
-    override val contextKey: CoroutineContext.Key<SpanId> = SpanId.Key
-    override fun toWire(value: SpanId): String = value.value
-    override fun fromWire(encoded: String): SpanId = SpanId(encoded)
-}
-
-@KsContext(binding = TraceIdBinding::class)
+@KsContext(binding = TraceId.Key::class)
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
 annotation class WithTrace
 
-@KsContext(binding = SpanIdBinding::class)
+@KsContext(binding = SpanId.Key::class)
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
 annotation class WithSpan

--- a/compiler/plugin/src/test/java/KsContextValidationTest.kt
+++ b/compiler/plugin/src/test/java/KsContextValidationTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Compile-time coverage for the `@KsContext` core API and its FIR-phase
+ * validation (issue #80, part 1 of #28).
+ *
+ * The plugin tests run against an included-build classpath that pins the
+ * published `ksrpc-api` coordinate alongside the locally-built jvmJar
+ * (build.gradle.kts in :compiler:ksrpc-compiler-plugin). To keep this test
+ * self-contained — and to keep the published 0.11.1 coordinate from gating
+ * the test — we re-declare the relevant ksrpc public symbols inline. Only
+ * the FQ names matter to the FIR checker.
+ */
+class KsContextValidationTest {
+
+    private val ksContextSurface = SourceFile.kotlin(
+        "KsContextSurface.kt",
+        """
+package com.monkopedia.ksrpc.annotation
+
+import com.monkopedia.ksrpc.KsContextBinding
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class KsContext(val binding: KClass<out KsContextBinding<*>>)
+"""
+    )
+
+    private val ksContextBinding = SourceFile.kotlin(
+        "KsContextBinding.kt",
+        """
+package com.monkopedia.ksrpc
+
+import kotlin.coroutines.CoroutineContext
+
+interface KsContextBinding<T : CoroutineContext.Element> {
+    val wireKey: String
+    val contextKey: CoroutineContext.Key<T>
+    fun toWire(value: T): String
+    fun fromWire(encoded: String): T
+}
+"""
+    )
+
+    private val supportSources = listOf(ksContextSurface, ksContextBinding)
+
+    @Test
+    fun `@KsContext annotation with valid binding compiles cleanly on a method`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsContext
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.KsContextBinding
+import com.monkopedia.ksrpc.RpcService
+import kotlin.coroutines.CoroutineContext
+
+class TraceId(val value: String) : CoroutineContext.Element {
+    override val key: CoroutineContext.Key<*> get() = Key
+    companion object Key : CoroutineContext.Key<TraceId>
+}
+
+object TraceIdBinding : KsContextBinding<TraceId> {
+    override val wireKey: String = "x-trace-id"
+    override val contextKey: CoroutineContext.Key<TraceId> = TraceId.Key
+    override fun toWire(value: TraceId): String = value.value
+    override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+}
+
+@KsContext(binding = TraceIdBinding::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithTrace
+
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/op")
+    @WithTrace
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(supportSources + source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected @KsContext with a valid binding to compile; messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `@KsContext annotation with valid binding compiles cleanly on a service`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsContext
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.KsContextBinding
+import com.monkopedia.ksrpc.RpcService
+import kotlin.coroutines.CoroutineContext
+
+class TraceId(val value: String) : CoroutineContext.Element {
+    override val key: CoroutineContext.Key<*> get() = Key
+    companion object Key : CoroutineContext.Key<TraceId>
+}
+
+object TraceIdBinding : KsContextBinding<TraceId> {
+    override val wireKey: String = "x-trace-id"
+    override val contextKey: CoroutineContext.Key<TraceId> = TraceId.Key
+    override fun toWire(value: TraceId): String = value.value
+    override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+}
+
+@KsContext(binding = TraceIdBinding::class)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithTrace
+
+@WithTrace
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/op")
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(supportSources + source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected @KsContext on a @KsService to compile; messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `@KsContext binding that does not implement KsContextBinding is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsContext
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+class NotABinding
+
+@KsContext(binding = NotABinding::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithBogus
+
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/op")
+    @WithBogus
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(supportSources + source)
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("KsContextBinding") &&
+                result.messages.contains("NotABinding"),
+            "Expected diagnostic naming KsContextBinding and the offending class; " +
+                "got: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `two @KsContext annotations with the same wireKey on one method is rejected`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsContext
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.KsContextBinding
+import com.monkopedia.ksrpc.RpcService
+import kotlin.coroutines.CoroutineContext
+
+class TraceId(val value: String) : CoroutineContext.Element {
+    override val key: CoroutineContext.Key<*> get() = Key
+    companion object Key : CoroutineContext.Key<TraceId>
+}
+class SpanId(val value: String) : CoroutineContext.Element {
+    override val key: CoroutineContext.Key<*> get() = Key
+    companion object Key : CoroutineContext.Key<SpanId>
+}
+
+object TraceIdBinding : KsContextBinding<TraceId> {
+    override val wireKey: String = "x-shared"
+    override val contextKey: CoroutineContext.Key<TraceId> = TraceId.Key
+    override fun toWire(value: TraceId): String = value.value
+    override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+}
+
+object SpanIdBinding : KsContextBinding<SpanId> {
+    override val wireKey: String = "x-shared"
+    override val contextKey: CoroutineContext.Key<SpanId> = SpanId.Key
+    override fun toWire(value: SpanId): String = value.value
+    override fun fromWire(encoded: String): SpanId = SpanId(encoded)
+}
+
+@KsContext(binding = TraceIdBinding::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithTrace
+
+@KsContext(binding = SpanIdBinding::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithSpan
+
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/op")
+    @WithTrace
+    @WithSpan
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(supportSources + source)
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail; messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("duplicate wireKey") &&
+                result.messages.contains("\"x-shared\""),
+            "Expected duplicate-wireKey diagnostic naming the shared key; " +
+                "got: ${result.messages}"
+        )
+    }
+}

--- a/ksrpc-api/api/ksrpc-api.api
+++ b/ksrpc-api/api/ksrpc-api.api
@@ -1,6 +1,5 @@
-public abstract interface class com/monkopedia/ksrpc/KsContextBinding {
+public abstract interface class com/monkopedia/ksrpc/KsContextBinding : kotlin/coroutines/CoroutineContext$Key {
 	public abstract fun fromWire (Ljava/lang/String;)Lkotlin/coroutines/CoroutineContext$Element;
-	public abstract fun getContextKey ()Lkotlin/coroutines/CoroutineContext$Key;
 	public abstract fun getWireKey ()Ljava/lang/String;
 	public abstract fun toWire (Lkotlin/coroutines/CoroutineContext$Element;)Ljava/lang/String;
 }

--- a/ksrpc-api/api/ksrpc-api.api
+++ b/ksrpc-api/api/ksrpc-api.api
@@ -1,3 +1,10 @@
+public abstract interface class com/monkopedia/ksrpc/KsContextBinding {
+	public abstract fun fromWire (Ljava/lang/String;)Lkotlin/coroutines/CoroutineContext$Element;
+	public abstract fun getContextKey ()Lkotlin/coroutines/CoroutineContext$Key;
+	public abstract fun getWireKey ()Ljava/lang/String;
+	public abstract fun toWire (Lkotlin/coroutines/CoroutineContext$Element;)Ljava/lang/String;
+}
+
 public final class com/monkopedia/ksrpc/RpcFailure {
 	public static final field Companion Lcom/monkopedia/ksrpc/RpcFailure$Companion;
 	public fun <init> (Ljava/lang/String;)V
@@ -38,6 +45,10 @@ public abstract interface class com/monkopedia/ksrpc/SuspendCloseable {
 }
 
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/ExperimentalKsrpc : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsContext : java/lang/annotation/Annotation {
+	public abstract fun binding ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class com/monkopedia/ksrpc/annotation/KsError : java/lang/annotation/Annotation {

--- a/ksrpc-api/api/ksrpc-api.klib.api
+++ b/ksrpc-api/api/ksrpc-api.klib.api
@@ -60,9 +60,7 @@ open annotation class com.monkopedia.ksrpc.annotation/KsrpcInternal : kotlin/Ann
     constructor <init>() // com.monkopedia.ksrpc.annotation/KsrpcInternal.<init>|<init>(){}[0]
 }
 
-abstract interface <#A: kotlin.coroutines/CoroutineContext.Element> com.monkopedia.ksrpc/KsContextBinding { // com.monkopedia.ksrpc/KsContextBinding|null[0]
-    abstract val contextKey // com.monkopedia.ksrpc/KsContextBinding.contextKey|{}contextKey[0]
-        abstract fun <get-contextKey>(): kotlin.coroutines/CoroutineContext.Key<#A> // com.monkopedia.ksrpc/KsContextBinding.contextKey.<get-contextKey>|<get-contextKey>(){}[0]
+abstract interface <#A: kotlin.coroutines/CoroutineContext.Element> com.monkopedia.ksrpc/KsContextBinding : kotlin.coroutines/CoroutineContext.Key<#A> { // com.monkopedia.ksrpc/KsContextBinding|null[0]
     abstract val wireKey // com.monkopedia.ksrpc/KsContextBinding.wireKey|{}wireKey[0]
         abstract fun <get-wireKey>(): kotlin/String // com.monkopedia.ksrpc/KsContextBinding.wireKey.<get-wireKey>|<get-wireKey>(){}[0]
 

--- a/ksrpc-api/api/ksrpc-api.klib.api
+++ b/ksrpc-api/api/ksrpc-api.klib.api
@@ -10,6 +10,13 @@ open annotation class com.monkopedia.ksrpc.annotation/ExperimentalKsrpc : kotlin
     constructor <init>() // com.monkopedia.ksrpc.annotation/ExperimentalKsrpc.<init>|<init>(){}[0]
 }
 
+open annotation class com.monkopedia.ksrpc.annotation/KsContext : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsContext|null[0]
+    constructor <init>(kotlin.reflect/KClass<out com.monkopedia.ksrpc/KsContextBinding<*>>) // com.monkopedia.ksrpc.annotation/KsContext.<init>|<init>(kotlin.reflect.KClass<out|com.monkopedia.ksrpc.KsContextBinding<*>>){}[0]
+
+    final val binding // com.monkopedia.ksrpc.annotation/KsContext.binding|{}binding[0]
+        final fun <get-binding>(): kotlin.reflect/KClass<out com.monkopedia.ksrpc/KsContextBinding<*>> // com.monkopedia.ksrpc.annotation/KsContext.binding.<get-binding>|<get-binding>(){}[0]
+}
+
 open annotation class com.monkopedia.ksrpc.annotation/KsError : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsError|null[0]
     constructor <init>(kotlin/Int, kotlin.reflect/KClass<*>) // com.monkopedia.ksrpc.annotation/KsError.<init>|<init>(kotlin.Int;kotlin.reflect.KClass<*>){}[0]
 
@@ -51,6 +58,16 @@ open annotation class com.monkopedia.ksrpc.annotation/KsTimeout : kotlin/Annotat
 
 open annotation class com.monkopedia.ksrpc.annotation/KsrpcInternal : kotlin/Annotation { // com.monkopedia.ksrpc.annotation/KsrpcInternal|null[0]
     constructor <init>() // com.monkopedia.ksrpc.annotation/KsrpcInternal.<init>|<init>(){}[0]
+}
+
+abstract interface <#A: kotlin.coroutines/CoroutineContext.Element> com.monkopedia.ksrpc/KsContextBinding { // com.monkopedia.ksrpc/KsContextBinding|null[0]
+    abstract val contextKey // com.monkopedia.ksrpc/KsContextBinding.contextKey|{}contextKey[0]
+        abstract fun <get-contextKey>(): kotlin.coroutines/CoroutineContext.Key<#A> // com.monkopedia.ksrpc/KsContextBinding.contextKey.<get-contextKey>|<get-contextKey>(){}[0]
+    abstract val wireKey // com.monkopedia.ksrpc/KsContextBinding.wireKey|{}wireKey[0]
+        abstract fun <get-wireKey>(): kotlin/String // com.monkopedia.ksrpc/KsContextBinding.wireKey.<get-wireKey>|<get-wireKey>(){}[0]
+
+    abstract fun fromWire(kotlin/String): #A // com.monkopedia.ksrpc/KsContextBinding.fromWire|fromWire(kotlin.String){}[0]
+    abstract fun toWire(#A): kotlin/String // com.monkopedia.ksrpc/KsContextBinding.toWire|toWire(1:0){}[0]
 }
 
 abstract interface com.monkopedia.ksrpc/RpcService : com.monkopedia.ksrpc/SuspendCloseable { // com.monkopedia.ksrpc/RpcService|null[0]

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/KsContextBinding.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/KsContextBinding.kt
@@ -24,15 +24,37 @@ import kotlin.coroutines.CoroutineContext
  * meta-annotation and are responsible for:
  *
  *  - identifying the value on the wire ([wireKey]);
- *  - identifying the value in the coroutine context ([contextKey]);
  *  - encoding / decoding the value for transports that carry it as a string
  *    ([toWire] / [fromWire]).
  *
- * On the handler side, propagated values are surfaced through the standard
- * coroutine-context lookup. A handler reads its value back out with:
+ * The binding *is* the [CoroutineContext.Key] for its element — a single
+ * source of truth for both the wire identity and the coroutine-context
+ * identity. The recommended shape is to declare the binding as a named
+ * companion object on the element type itself:
  *
  * ```
- * val value = coroutineContext[SomeBinding.contextKey]
+ * class AuthToken(val token: String) : CoroutineContext.Element {
+ *     override val key get() = Key
+ *
+ *     companion object Key : KsContextBinding<AuthToken> {
+ *         override val wireKey = "x-auth-token"
+ *         override fun toWire(value: AuthToken) = value.token
+ *         override fun fromWire(encoded: String) = AuthToken(encoded)
+ *     }
+ * }
+ * ```
+ *
+ * Reference the binding at the annotation site by its companion name:
+ *
+ * ```
+ * @KsContext(binding = AuthToken.Key::class)
+ * ```
+ *
+ * Handlers then read the propagated value with the standard coroutine-context
+ * lookup, naming the element type directly:
+ *
+ * ```
+ * val token = coroutineContext[AuthToken]
  * ```
  *
  * The element type [T] must be a [CoroutineContext.Element] so it can sit
@@ -41,7 +63,7 @@ import kotlin.coroutines.CoroutineContext
  * Implementations should be stateless and safe to reference from a
  * `KClass`-literal in an annotation argument.
  */
-interface KsContextBinding<T : CoroutineContext.Element> {
+interface KsContextBinding<T : CoroutineContext.Element> : CoroutineContext.Key<T> {
     /**
      * Stable, transport-neutral identifier for this context entry. Transport
      * layers use this string to name the field that carries the encoded
@@ -53,13 +75,6 @@ interface KsContextBinding<T : CoroutineContext.Element> {
      * time.
      */
     val wireKey: String
-
-    /**
-     * Coroutine-context key under which the propagated value is exposed to
-     * handlers. The standard `coroutineContext[binding.contextKey]` lookup
-     * returns the value (or `null` if no value was provided for the call).
-     */
-    val contextKey: CoroutineContext.Key<T>
 
     /** Encode a value of type [T] for transports that carry it as a string. */
     fun toWire(value: T): String

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/KsContextBinding.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/KsContextBinding.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Describes how a single piece of per-call context is propagated across the
+ * wire. Implementations are referenced from [KsContext.binding] on a
+ * meta-annotation and are responsible for:
+ *
+ *  - identifying the value on the wire ([wireKey]);
+ *  - identifying the value in the coroutine context ([contextKey]);
+ *  - encoding / decoding the value for transports that carry it as a string
+ *    ([toWire] / [fromWire]).
+ *
+ * On the handler side, propagated values are surfaced through the standard
+ * coroutine-context lookup. A handler reads its value back out with:
+ *
+ * ```
+ * val value = coroutineContext[SomeBinding.contextKey]
+ * ```
+ *
+ * The element type [T] must be a [CoroutineContext.Element] so it can sit
+ * directly in the running coroutine's context.
+ *
+ * Implementations should be stateless and safe to reference from a
+ * `KClass`-literal in an annotation argument.
+ */
+interface KsContextBinding<T : CoroutineContext.Element> {
+    /**
+     * Stable, transport-neutral identifier for this context entry. Transport
+     * layers use this string to name the field that carries the encoded
+     * value (e.g. as an HTTP header name, a JSON-RPC `meta` key, or a TLV
+     * tag in the packet protocol).
+     *
+     * Two `@KsContext`-meta-annotated annotations applied to the same
+     * `@KsMethod` whose bindings share a [wireKey] are rejected at compile
+     * time.
+     */
+    val wireKey: String
+
+    /**
+     * Coroutine-context key under which the propagated value is exposed to
+     * handlers. The standard `coroutineContext[binding.contextKey]` lookup
+     * returns the value (or `null` if no value was provided for the call).
+     */
+    val contextKey: CoroutineContext.Key<T>
+
+    /** Encode a value of type [T] for transports that carry it as a string. */
+    fun toWire(value: T): String
+
+    /** Decode a value of type [T] from its [toWire] string representation. */
+    fun fromWire(encoded: String): T
+}

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsContext.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsContext.kt
@@ -30,9 +30,10 @@ import kotlin.reflect.KClass
  *
  *  - A stable wire-level key ([KsContextBinding.wireKey]) used by transport
  *    layers to encode the value.
- *  - A coroutine-context [kotlin.coroutines.CoroutineContext.Key] under which
+ *  - The [kotlin.coroutines.CoroutineContext.Key] identity itself —
+ *    [KsContextBinding] extends [kotlin.coroutines.CoroutineContext.Key], so
  *    handlers find the propagated value via the standard
- *    `coroutineContext[SomeBinding.contextKey]` lookup.
+ *    `coroutineContext[SomeBinding]` lookup naming the binding directly.
  *  - String encode / decode functions ([KsContextBinding.toWire] /
  *    [KsContextBinding.fromWire]) used by transport layers that carry the
  *    context value as a textual representation.

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsContext.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsContext.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.annotation
+
+import com.monkopedia.ksrpc.KsContextBinding
+import kotlin.reflect.KClass
+
+/**
+ * Meta-annotation that opts an annotation class into ksrpc's per-call
+ * coroutine-context propagation. Apply this to an annotation class together
+ * with a [binding] referencing a concrete [KsContextBinding] implementation
+ * to declare that the annotated [KsMethod] (or every [KsMethod] inside an
+ * annotated [KsService]) should propagate a [kotlin.coroutines.CoroutineContext.Element]
+ * value across the wire.
+ *
+ * The [binding] supplies:
+ *
+ *  - A stable wire-level key ([KsContextBinding.wireKey]) used by transport
+ *    layers to encode the value.
+ *  - A coroutine-context [kotlin.coroutines.CoroutineContext.Key] under which
+ *    handlers find the propagated value via the standard
+ *    `coroutineContext[SomeBinding.contextKey]` lookup.
+ *  - String encode / decode functions ([KsContextBinding.toWire] /
+ *    [KsContextBinding.fromWire]) used by transport layers that carry the
+ *    context value as a textual representation.
+ *
+ * Compiler validation:
+ *
+ *  - The plugin rejects a `@KsContext`-meta-annotated annotation whose
+ *    [binding] does not implement [KsContextBinding].
+ *  - The plugin rejects a [KsMethod] (or its enclosing [KsService]) when two
+ *    `@KsContext`-meta-annotated annotations apply whose bindings declare the
+ *    same [KsContextBinding.wireKey].
+ *
+ * Code emission for stub-side put-into-context and handler-side
+ * read-from-coroutine-context, plus per-transport wire formats, is handled by
+ * follow-up work and is intentionally not part of this annotation's contract.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class KsContext(val binding: KClass<out KsContextBinding<*>>)


### PR DESCRIPTION
## Summary

Part 1 of 3 of #28 (per-call context propagation). Lands the public type
surface and FIR-phase compile-time validation only — code emission is #81
and per-transport wire formats are #82.

- `ksrpc-api` gains `@KsContext(binding: KClass<out KsContextBinding<*>>)`
  meta-annotation and the `KsContextBinding<T : CoroutineContext.Element>`
  interface (`wireKey`, `contextKey`, `toWire`, `fromWire`). Handlers will
  read propagated values via the standard `coroutineContext[binding.contextKey]`
  lookup once the part-2 codegen lands.
- Compiler plugin gains `KsContextClassChecker` + `KsContextMethodChecker`,
  registered in `KsrpcFirCheckersComponent`. They reject:
  - `@KsContext`-meta-annotated annotations whose `binding` doesn't
    implement `KsContextBinding`.
  - Two `@KsContext`-meta-annotated annotations on one `@KsMethod` whose
    bindings declare the same statically-known `wireKey`.
- Diagnostics route through `KsrpcDiagnostics` for IDE squiggle support
  (see #65).

## Out of scope (intentional)

- No stub-side put-into-context or handler-side read-from-coroutine-context
  IR emission — that's #81.
- No transport changes (HTTP headers, JSON-RPC, packet TLV) — that's #82.

## Test plan

- [x] `:compiler:ksrpc-compiler-plugin:test` (`KsContextValidationTest`)
  - `@KsContext` with valid binding compiles cleanly on a method
  - `@KsContext` with valid binding compiles cleanly on a service
  - `@KsContext` with binding that doesn't implement `KsContextBinding`
    is rejected
  - Two `@KsContext`-meta-annotated annotations sharing `wireKey` on one
    method is rejected
- [x] `:ksrpc-api:apiCheck` / `:ksrpc-core:apiCheck` (BCV regenerated and
  committed)
- [x] `:ksrpc-test:jvmTest` — full pre-existing suite still green
- [x] Full `:compiler:ksrpc-compiler-plugin:test` — pre-existing suite still
  green

🤖 Generated with [Claude Code](https://claude.com/claude-code)