### PR TITLE
Fix #31: deterministic synchronization in PacketCancellationTest

### DIFF
--- a/ksrpc-test/src/commonTest/kotlin/PacketCancellationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/PacketCancellationTest.kt
@@ -66,25 +66,28 @@ private object PendingCallCounter {
 private class TrackingCancelService : CancelTestService {
     val started = CompletableDeferred<Unit>()
 
-    // Plain volatile-style flags; tests run on a single-thread test dispatcher and only do
-    // simple read/write so a value class slot is sufficient. Avoids hitting the atomicfu
-    // transformer's restriction against `atomic(...)` outside class init in lambda scopes.
-    private val state = BooleanArray(2)
-    val cancelled: Boolean get() = state[0]
-    val completed: Boolean get() = state[1]
+    // Deterministic latches: tests await these directly rather than poll a Boolean. The
+    // earlier polling-with-`yield` pattern was timing-sensitive (see issue #31) — switching
+    // to explicit `CompletableDeferred` lets the test wait on the exact signal the handler
+    // produces, with no busy-wait between handler completion and observation.
+    val cancelObserved = CompletableDeferred<Unit>()
+    val completedObserved = CompletableDeferred<Unit>()
+
+    val cancelled: Boolean get() = cancelObserved.isCompleted
+    val completed: Boolean get() = completedObserved.isCompleted
 
     override suspend fun blockForever(value: String): String {
         started.complete(Unit)
         try {
             awaitCancellation()
         } catch (t: CancellationException) {
-            state[0] = true
+            cancelObserved.complete(Unit)
             throw t
         }
     }
 
     override suspend fun finishesQuickly(value: String): String {
-        state[1] = true
+        completedObserved.complete(Unit)
         return "echo:$value"
     }
 }
@@ -125,12 +128,11 @@ class PacketCancellationTest {
                 // expected
             }
 
-            // Server handler must be cancelled by the cancel frame.
-            withTimeout(5_000) {
-                while (!service.cancelled) {
-                    yield()
-                }
-            }
+            // Server handler must be cancelled by the cancel frame. Await the latch the
+            // handler completes inside its CancellationException catch block — this fires
+            // exactly when the handler observes the cancel, with no polling window between
+            // completion and observation.
+            withTimeout(5_000) { service.cancelObserved.await() }
             assertTrue(service.cancelled, "server handler must observe cancellation")
 
             // Subsequent unrelated calls still work — the connection stays healthy.


### PR DESCRIPTION
## Summary

- Replaces the `while (!service.cancelled) yield()` polling loop in `PacketCancellationTest.callerCancellationCancelsServerHandlerOverPipeTransport` with a `CompletableDeferred<Unit>` latch the handler completes inside its `CancellationException` catch block. The test now `await()`s the exact signal under the same 5s timeout budget — no polling window between handler completion and test observation.
- Also converts the symmetric `completed` Boolean to a `CompletableDeferred` latch for consistency. The `cancelled`/`completed` accessors stay as `isCompleted` views so the happy-path assertion (`assertFalse(service.cancelled, ...)`) is unchanged.
- Test-only change: no production code touched.

## Why

Polling on a Boolean after coroutine cancellation is timing-sensitive — nothing orders "handler observed cancellation" against the awaiter's resumption, so a slow first run could race assertions ahead of the handler's catch block. Replacing the polling with a latch eliminates the race surface that #31 calls out.

## Test plan

- [x] `:ksrpc-test:jvmTest --tests PacketCancellationTest.callerCancellationCancelsServerHandlerOverPipeTransport --rerun-tasks` x50 in an isolated worktree: 50 PASS / 0 FAIL
- [x] `:ksrpc-test:jvmTest --tests PacketCancellationTest --rerun-tasks` (all 3 tests in the class) — PASS
- [x] `:ksrpc-test:linuxX64Test --tests PacketCancellationTest --rerun-tasks` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)