### PR TITLE
Fix #81: @KsContext compiler plugin codegen + runtime propagation

### DIFF
--- a/compiler/plugin/src/main/java/ContextBindingIrBuilder.kt
+++ b/compiler/plugin/src/main/java/ContextBindingIrBuilder.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irGetObject
+import org.jetbrains.kotlin.ir.builders.irVararg
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.expressions.IrClassReference
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.starProjectedType
+import org.jetbrains.kotlin.ir.util.constructors
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+
+/**
+ * Builds IR that materializes the `@KsContext(binding = ...)` meta-annotations
+ * captured on a `@KsMethod` function (and its enclosing `@KsService` interface)
+ * into `List<KsContextMapping>` at runtime, for inclusion in the generated
+ * `RpcMethod` descriptor.
+ *
+ * Each entry emits `KsContextMapping(BindingObject)` where the binding is a
+ * singleton (companion object / named object) resolved via `irGetObject`.
+ *
+ * Pattern follows [ErrorMappingIrBuilder].
+ */
+class ContextBindingIrBuilder(
+    private val env: KsrpcGenerationEnvironment,
+    private val builder: DeclarationIrBuilder,
+    @Suppress("unused") private val report: MessageCollector
+) {
+    init {
+        check(env.contextBindingSupported) {
+            "ksrpc internal: ContextBindingIrBuilder created without context-binding " +
+                "dependencies — caller should guard on env.contextBindingSupported"
+        }
+    }
+
+    private val ksContextMapping = env.ksContextMapping!!
+
+    /**
+     * Build a `listOf(KsContextMapping(...), ...)` IR expression from the
+     * collected `@KsContext`-meta-annotated annotations. Each annotation's
+     * `binding` argument (a KClass literal referencing a singleton) is resolved
+     * to an `irGetObject` call.
+     */
+    fun buildContextBindingList(
+        contextAnnotations: List<IrConstructorCall>
+    ): IrExpression {
+        // Deduplicate by binding class symbol — the same binding can appear from
+        // both class-level and method-level annotations.
+        val seen = mutableSetOf<IrClassSymbol>()
+        val uniqueMappings = contextAnnotations.mapNotNull { annotation ->
+            val bindingSymbol = extractBindingSymbol(annotation) ?: return@mapNotNull null
+            if (!seen.add(bindingSymbol)) return@mapNotNull null
+            buildMapping(bindingSymbol)
+        }
+        return buildListOf(
+            ksContextMapping.starProjectedType,
+            uniqueMappings
+        )
+    }
+
+    /**
+     * Extract the binding class symbol from a `@KsContext(binding = X::class)`
+     * meta-annotation. The meta-annotation is found on the user-facing annotation
+     * class (e.g. `@WithTrace`), and its `binding` argument is the first
+     * (positional) argument of the `@KsContext` annotation.
+     */
+    private fun extractBindingSymbol(
+        userAnnotation: IrConstructorCall
+    ): IrClassSymbol? {
+        // userAnnotation is e.g. @WithTrace — find @KsContext on its annotation class
+        val annotationClass = userAnnotation.type.classOrNull?.owner ?: return null
+        val ksContext = annotationClass.annotations.firstOrNull { metaAnn ->
+            metaAnn.type.classOrNull?.owner?.kotlinFqName
+                ?.asString() == "com.monkopedia.ksrpc.annotation.KsContext"
+        } ?: return null
+        val bindingRef = ksContext.arguments.getOrNull(0) as? IrClassReference ?: return null
+        return bindingRef.classType.classOrNull
+    }
+
+    private fun buildMapping(bindingSymbol: IrClassSymbol): IrExpression {
+        return builder.irCallConstructor(
+            ksContextMapping.constructors.first(),
+            emptyList()
+        ).apply {
+            type = ksContextMapping.starProjectedType
+            putArgs(builder.irGetObject(bindingSymbol))
+        }
+    }
+
+    private fun buildListOf(
+        elementType: org.jetbrains.kotlin.ir.types.IrType,
+        items: List<IrExpression>
+    ): IrExpression = builder.irCall(env.listOfFunction).apply {
+        typeArguments[0] = elementType
+        val varargParameter = env.listOfFunction.owner.parameters
+            .single { it.kind == IrParameterKind.Regular }
+        arguments[varargParameter] = builder.irVararg(elementType, items)
+    }
+}

--- a/compiler/plugin/src/main/java/FqConstants.kt
+++ b/compiler/plugin/src/main/java/FqConstants.kt
@@ -131,6 +131,11 @@ object FqConstants {
     // `List<KsErrorMapping>` at codegen time.
     val KS_ERROR_MAPPING = ClassId(FQPKG, Name.identifier("KsErrorMapping"))
 
+    // Ksrpc runtime class used to materialize @KsContext bindings into
+    // `List<KsContextMapping>` at codegen time.
+    val KS_CONTEXT_MAPPING = ClassId(FQPKG, Name.identifier("KsContextMapping"))
+    val KS_CONTEXT = FqName("com.monkopedia.ksrpc.annotation.KsContext")
+
     val METHOD_METADATA = ClassId(FQPKG, Name.identifier("MethodMetadata"))
     val METADATA_VALUE = ClassId(FQPKG, Name.identifier("MetadataValue"))
     val METADATA_VALUE_STRING =

--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -194,6 +194,20 @@ class KsrpcGenerationEnvironment(
     val errorMappingSupported: Boolean get() = ksErrorMapping != null &&
         rpcMethod.constructors.first().owner.parameters.size >= 6
 
+    // Context-binding (#81) support is optional so the compiler plugin continues
+    // to work against older ksrpc-core artifacts that predate the `KsContextMapping`
+    // type. When unresolved, the plugin does not emit the eighth constructor
+    // argument on `RpcMethod` and the generated service carries no context bindings.
+    val ksContextMapping = maybeReferenceClass(FqConstants.KS_CONTEXT_MAPPING)
+
+    /**
+     * True when `KsContextMapping` was resolved — the ksrpc-core on the compile
+     * classpath supports the `@KsContext` context propagation (issue #81).
+     * Also requires the 7-argument `RpcMethod` constructor.
+     */
+    val contextBindingSupported: Boolean get() = ksContextMapping != null &&
+        rpcMethod.constructors.first().owner.parameters.size >= 7
+
     // Metadata propagation support is optional so the compiler plugin continues
     // to work against older ksrpc-core artifacts that predate #11.
     val methodMetadata = maybeReferenceClass(FqConstants.METHOD_METADATA)

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -232,6 +232,7 @@ class ObjGeneration(
                             method.function,
                             method.metadataAnnotations,
                             method.errorAnnotations,
+                            method.contextAnnotations,
                             executor = executor
                         )
                     )
@@ -273,6 +274,7 @@ internal class GenericMethodIrBuilder(
         method: IrSimpleFunction,
         metadataAnnotations: List<IrConstructorCall>,
         errorAnnotations: List<IrConstructorCall>,
+        contextAnnotations: List<IrConstructorCall> = emptyList(),
         executor: IrClass
     ): IrConstructorCall {
         // 0-arg @KsMethod functions fall back to Unit as the input type.
@@ -320,6 +322,10 @@ internal class GenericMethodIrBuilder(
         if (env.errorMappingSupported) {
             args += ErrorMappingIrBuilder(env, decl, report)
                 .buildErrorMappingList(errorAnnotations)
+        }
+        if (env.contextBindingSupported) {
+            args += ContextBindingIrBuilder(env, decl, report)
+                .buildContextBindingList(contextAnnotations)
         }
         call.putArgs(*args.toTypedArray())
         return call

--- a/compiler/plugin/src/main/java/ServiceClass.kt
+++ b/compiler/plugin/src/main/java/ServiceClass.kt
@@ -41,6 +41,7 @@ private class Visitor(private val messageCollector: MessageCollector) : IrElemen
     private val service = FqName("com.monkopedia.ksrpc.annotation.KsService")
     private val metadataMarker = FqConstants.KS_METHOD_METADATA
     private val ksError = FqConstants.KS_ERROR
+    private val ksContext = FqConstants.KS_CONTEXT
 
     override fun visitClass(declaration: IrClass): IrStatement {
         val annotation = declaration.annotations.find { annotation ->
@@ -83,12 +84,25 @@ private class Visitor(private val messageCollector: MessageCollector) : IrElemen
                 val errorAnnotations = declaration.annotations.filter {
                     it.type.classFqName == ksError
                 }
+                // Capture @KsContext-meta-annotated annotations from both the
+                // method and its enclosing @KsService class. Union of both.
+                val isKsContextMeta = { ann: IrConstructorCall ->
+                    ann.type.classOrNull?.owner?.annotations?.any {
+                        it.type.classFqName == ksContext
+                    } == true
+                }
+                val methodContextAnnotations = declaration.annotations
+                    .filter(isKsContextMeta)
+                val classContextAnnotations = currentService?.irClass?.annotations
+                    ?.filter(isKsContextMeta) ?: emptyList()
+                val contextAnnotations = classContextAnnotations + methodContextAnnotations
                 current.methods.add(
                     ServiceMethod(
                         function = declaration,
                         ksMethodAnnotation = annotation,
                         metadataAnnotations = metadataAnnotations,
-                        errorAnnotations = errorAnnotations
+                        errorAnnotations = errorAnnotations,
+                        contextAnnotations = contextAnnotations
                     )
                 )
             } else if (!declaration.isFakeOverride) {
@@ -147,7 +161,14 @@ data class ServiceMethod(
      * compiler plugin emits one [com.monkopedia.ksrpc.KsErrorMapping] entry per
      * annotation into the generated `RpcMethod.errorMappings` list. See #77.
      */
-    val errorAnnotations: List<IrConstructorCall> = emptyList()
+    val errorAnnotations: List<IrConstructorCall> = emptyList(),
+    /**
+     * `@KsContext`-meta-annotated annotations captured from both the method
+     * and its enclosing `@KsService` class. The compiler plugin emits one
+     * [com.monkopedia.ksrpc.KsContextMapping] entry per unique binding into
+     * the generated `RpcMethod.contextBindings` list. See #81.
+     */
+    val contextAnnotations: List<IrConstructorCall> = emptyList()
 )
 
 data class ServiceClass(

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -148,6 +148,7 @@ class StubGeneration(
                             endpoint,
                             serviceMethod.metadataAnnotations,
                             serviceMethod.errorAnnotations,
+                            serviceMethod.contextAnnotations,
                             service,
                             genericBuilder
                         )
@@ -159,6 +160,7 @@ class StubGeneration(
                             serviceMethod.ksMethodAnnotation,
                             serviceMethod.metadataAnnotations,
                             serviceMethod.errorAnnotations,
+                            serviceMethod.contextAnnotations,
                             companion,
                             service
                         )
@@ -186,6 +188,7 @@ class StubGeneration(
         endpoint: String,
         metadataAnnotations: List<IrConstructorCall>,
         errorAnnotations: List<IrConstructorCall>,
+        contextAnnotations: List<IrConstructorCall>,
         service: ServiceClass,
         builder: GenericMethodIrBuilder
     ): IrFunction {
@@ -224,6 +227,7 @@ class StubGeneration(
                             method,
                             metadataAnnotations,
                             errorAnnotations,
+                            contextAnnotations,
                             executor = executor
                         ),
                         irGetField(irGet(thisParam), service.channel),
@@ -329,6 +333,7 @@ class StubGeneration(
         annotation: IrConstructorCall,
         metadataAnnotations: List<IrConstructorCall>,
         errorAnnotations: List<IrConstructorCall>,
+        contextAnnotations: List<IrConstructorCall>,
         companion: IrClass,
         service: ServiceClass
     ): IrFunction {
@@ -344,7 +349,8 @@ class StubGeneration(
                 this,
                 companion,
                 metadataAnnotations,
-                errorAnnotations
+                errorAnnotations,
+                contextAnnotations
             )
 
         service.addEndpoint(endpoint, methodField)
@@ -393,7 +399,8 @@ class StubGeneration(
         serviceInterface: IrClass,
         companion: IrClass,
         metadataAnnotations: List<IrConstructorCall>,
-        errorAnnotations: List<IrConstructorCall>
+        errorAnnotations: List<IrConstructorCall>,
+        contextAnnotations: List<IrConstructorCall>
     ): IrFunction {
         val field = companion.addField {
             startOffset = SYNTHETIC_OFFSET
@@ -428,7 +435,8 @@ class StubGeneration(
                             endpoint,
                             method,
                             metadataAnnotations,
-                            errorAnnotations
+                            errorAnnotations,
+                            contextAnnotations
                         )
                     )
                 )
@@ -442,7 +450,8 @@ class StubGeneration(
         endpoint: String,
         method: IrSimpleFunction,
         metadataAnnotations: List<IrConstructorCall>,
-        errorAnnotations: List<IrConstructorCall>
+        errorAnnotations: List<IrConstructorCall>,
+        contextAnnotations: List<IrConstructorCall>
     ): IrConstructorCall {
         // 0-arg @KsMethod functions have no user-declared input; fall back to Unit
         // so the generated RpcMethod is shaped as `RpcMethod<Service, Unit, Out>`.
@@ -487,6 +496,10 @@ class StubGeneration(
             if (supportsErrorMapping) {
                 args += ErrorMappingIrBuilder(env, this@irCreateRpcMethod, messageCollector)
                     .buildErrorMappingList(errorAnnotations)
+            }
+            if (env.contextBindingSupported) {
+                args += ContextBindingIrBuilder(env, this@irCreateRpcMethod, messageCollector)
+                    .buildContextBindingList(contextAnnotations)
             }
             putArgs(*args.toTypedArray())
         }

--- a/compiler/plugin/src/test/java/KsContextCodegenTest.kt
+++ b/compiler/plugin/src/test/java/KsContextCodegenTest.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Tests for #81 — compiler plugin captures `@KsContext`-meta-annotated bindings
+ * on `@KsMethod` functions (and enclosing `@KsService` interfaces) and emits a
+ * `List<KsContextMapping>` into the generated `RpcMethod` descriptor.
+ *
+ * Uses the same reflection-based introspection strategy as [KsErrorBindingTest].
+ */
+class KsContextCodegenTest {
+
+    @Test
+    fun `method-level @KsContext binding populates contextBindings`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsContext
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.KsContextBinding
+import com.monkopedia.ksrpc.RpcService
+import kotlin.coroutines.CoroutineContext
+
+class TraceId(val value: String) : CoroutineContext.Element {
+    override val key get() = Key
+    companion object Key : KsContextBinding<TraceId> {
+        override val wireKey: String = "x-trace-id"
+        override fun toWire(value: TraceId): String = value.value
+        override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+    }
+}
+
+@KsContext(binding = TraceId.Key::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithTrace
+
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/op")
+    @WithTrace
+    suspend fun op(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+        val bindings = findEndpointContextBindings(result, "MyService", "op")
+        assertEquals(1, bindings.size, "Expected exactly one context binding, got $bindings")
+        assertEquals("x-trace-id", bindings.single().wireKey)
+    }
+
+    @Test
+    fun `class-level @KsContext binding populates contextBindings on all methods`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsContext
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.KsContextBinding
+import com.monkopedia.ksrpc.RpcService
+import kotlin.coroutines.CoroutineContext
+
+class AuthToken(val token: String) : CoroutineContext.Element {
+    override val key get() = Key
+    companion object Key : KsContextBinding<AuthToken> {
+        override val wireKey: String = "x-auth-token"
+        override fun toWire(value: AuthToken): String = value.token
+        override fun fromWire(encoded: String): AuthToken = AuthToken(encoded)
+    }
+}
+
+@KsContext(binding = AuthToken.Key::class)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithAuth
+
+@WithAuth
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/op1")
+    suspend fun op1(input: String): String
+
+    @KsMethod("/op2")
+    suspend fun op2(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+        val bindings1 = findEndpointContextBindings(result, "MyService", "op1")
+        assertEquals(1, bindings1.size)
+        assertEquals("x-auth-token", bindings1.single().wireKey)
+
+        val bindings2 = findEndpointContextBindings(result, "MyService", "op2")
+        assertEquals(1, bindings2.size)
+        assertEquals("x-auth-token", bindings2.single().wireKey)
+    }
+
+    @Test
+    fun `class-level and method-level @KsContext annotations are unioned`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsContext
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.KsContextBinding
+import com.monkopedia.ksrpc.RpcService
+import kotlin.coroutines.CoroutineContext
+
+class AuthToken(val token: String) : CoroutineContext.Element {
+    override val key get() = Key
+    companion object Key : KsContextBinding<AuthToken> {
+        override val wireKey: String = "x-auth-token"
+        override fun toWire(value: AuthToken): String = value.token
+        override fun fromWire(encoded: String): AuthToken = AuthToken(encoded)
+    }
+}
+
+class TraceId(val value: String) : CoroutineContext.Element {
+    override val key get() = Key
+    companion object Key : KsContextBinding<TraceId> {
+        override val wireKey: String = "x-trace-id"
+        override fun toWire(value: TraceId): String = value.value
+        override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+    }
+}
+
+@KsContext(binding = AuthToken.Key::class)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithAuth
+
+@KsContext(binding = TraceId.Key::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithTrace
+
+@WithAuth
+@KsService
+interface MyService : RpcService {
+    @KsMethod("/op")
+    @WithTrace
+    suspend fun op(input: String): String
+
+    @KsMethod("/plain")
+    suspend fun plain(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+        // /op has class-level @WithAuth + method-level @WithTrace
+        val opBindings = findEndpointContextBindings(result, "MyService", "op")
+        assertEquals(2, opBindings.size, "Expected 2 bindings, got $opBindings")
+        val wireKeys = opBindings.map { it.wireKey }.toSet()
+        assertTrue("x-auth-token" in wireKeys, "Missing x-auth-token; got $wireKeys")
+        assertTrue("x-trace-id" in wireKeys, "Missing x-trace-id; got $wireKeys")
+
+        // /plain only has the class-level @WithAuth
+        val plainBindings = findEndpointContextBindings(result, "MyService", "plain")
+        assertEquals(1, plainBindings.size)
+        assertEquals("x-auth-token", plainBindings.single().wireKey)
+    }
+
+    @Test
+    fun `method without @KsContext has empty contextBindings`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface NoContextService : RpcService {
+    @KsMethod("/plain")
+    suspend fun plain(input: String): String
+}
+"""
+        )
+        val result = compile(listOf(source))
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
+        )
+        val bindings = findEndpointContextBindings(result, "NoContextService", "plain")
+        assertTrue(
+            bindings.isEmpty(),
+            "Expected empty contextBindings when no @KsContext present, got $bindings"
+        )
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private data class BindingSnapshot(val wireKey: String)
+
+    private fun findEndpointContextBindings(
+        result: JvmCompilationResult,
+        serviceFqName: String,
+        endpointName: String
+    ): List<BindingSnapshot> {
+        val serviceClass = result.classLoader.loadClass(serviceFqName)
+        val companion = serviceClass.getField("Companion").get(null)
+        val findEndpoint = companion.javaClass.methods.single { it.name == "findEndpoint" }
+        val rpcMethod = findEndpoint.invoke(companion, endpointName)
+            ?: error("findEndpoint($endpointName) returned null on $serviceFqName")
+        val getBindings = rpcMethod.javaClass.methods.singleOrNull {
+            it.name == "getContextBindings"
+        } ?: error(
+            "RpcMethod for $serviceFqName.$endpointName has no getContextBindings() — " +
+                "plugin did not emit the contextBindings constructor argument"
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val rawList = getBindings.invoke(rpcMethod) as List<Any>
+        return rawList.map { raw ->
+            val cls = raw.javaClass
+            val binding = cls.getMethod("getBinding").invoke(raw)!!
+            val wireKey = binding.javaClass.getMethod("getWireKey").invoke(binding) as String
+            BindingSnapshot(wireKey = wireKey)
+        }
+    }
+}

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -28,6 +28,11 @@ public abstract interface class com/monkopedia/ksrpc/ErrorListener {
 	public abstract fun onError (Ljava/lang/Throwable;)V
 }
 
+public final class com/monkopedia/ksrpc/KsContextMapping {
+	public fun <init> (Lcom/monkopedia/ksrpc/KsContextBinding;)V
+	public final fun getBinding ()Lcom/monkopedia/ksrpc/KsContextBinding;
+}
+
 public final class com/monkopedia/ksrpc/KsErrorMapping {
 	public fun <init> (ILkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
 	public final fun getCode ()I
@@ -232,13 +237,14 @@ public final class com/monkopedia/ksrpc/RpcExceptionKt {
 }
 
 public final class com/monkopedia/ksrpc/RpcMethod {
-	public fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/internal/ServiceExecutor;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/internal/ServiceExecutor;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/internal/ServiceExecutor;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/Transformer;Lcom/monkopedia/ksrpc/internal/ServiceExecutor;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun call (Lcom/monkopedia/ksrpc/channels/SerializedService;Lcom/monkopedia/ksrpc/RpcService;Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/RpcCallId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun callChannel (Lcom/monkopedia/ksrpc/channels/SerializedService;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun decodeError (Lcom/monkopedia/ksrpc/channels/CallData$Error;Lcom/monkopedia/ksrpc/KsrpcEnvironment;)Ljava/lang/Throwable;
 	public final fun encodeError (Ljava/lang/Throwable;Lcom/monkopedia/ksrpc/KsrpcEnvironment;)Lcom/monkopedia/ksrpc/channels/CallData$Error;
 	public final fun findSubserviceTransformers ()Ljava/util/List;
+	public final fun getContextBindings ()Ljava/util/List;
 	public final fun getEndpoint ()Ljava/lang/String;
 	public final fun getErrorMappings ()Ljava/util/List;
 	public final fun getHasReturnType ()Z
@@ -515,6 +521,26 @@ public abstract interface class com/monkopedia/ksrpc/channels/SingleChannelConne
 
 public abstract interface class com/monkopedia/ksrpc/channels/SingleChannelHost : com/monkopedia/ksrpc/KsrpcEnvironment$Element {
 	public abstract fun registerDefault (Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/channels/WireContextCallId : com/monkopedia/ksrpc/channels/RpcCallId {
+	public fun <init> (Lcom/monkopedia/ksrpc/channels/RpcCallId;Lcom/monkopedia/ksrpc/channels/WireContextMap;)V
+	public final fun getDelegate ()Lcom/monkopedia/ksrpc/channels/RpcCallId;
+	public final fun getWireContextMap ()Lcom/monkopedia/ksrpc/channels/WireContextMap;
+}
+
+public final class com/monkopedia/ksrpc/channels/WireContextMap : kotlin/coroutines/CoroutineContext$Element {
+	public static final field Key Lcom/monkopedia/ksrpc/channels/WireContextMap$Key;
+	public fun <init> (Ljava/util/Map;)V
+	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
+	public fun getKey ()Lkotlin/coroutines/CoroutineContext$Key;
+	public final fun getValues ()Ljava/util/Map;
+	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
+	public fun plus (Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
+}
+
+public final class com/monkopedia/ksrpc/channels/WireContextMap$Key : kotlin/coroutines/CoroutineContext$Key {
 }
 
 public final class com/monkopedia/ksrpc/internal/ClientChannelContext : kotlin/coroutines/CoroutineContext$Element {

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -156,8 +156,10 @@ abstract class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> com.monkop
 }
 
 final class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?, #C: kotlin/Any?> com.monkopedia.ksrpc/RpcMethod { // com.monkopedia.ksrpc/RpcMethod|null[0]
-    constructor <init>(kotlin/String, com.monkopedia.ksrpc/Transformer<#B>, com.monkopedia.ksrpc/Transformer<#C>, com.monkopedia.ksrpc.internal/ServiceExecutor, kotlin.collections/List<com.monkopedia.ksrpc/MethodMetadata>, kotlin.collections/List<com.monkopedia.ksrpc/KsErrorMapping> = ...) // com.monkopedia.ksrpc/RpcMethod.<init>|<init>(kotlin.String;com.monkopedia.ksrpc.Transformer<1:1>;com.monkopedia.ksrpc.Transformer<1:2>;com.monkopedia.ksrpc.internal.ServiceExecutor;kotlin.collections.List<com.monkopedia.ksrpc.MethodMetadata>;kotlin.collections.List<com.monkopedia.ksrpc.KsErrorMapping>){}[0]
+    constructor <init>(kotlin/String, com.monkopedia.ksrpc/Transformer<#B>, com.monkopedia.ksrpc/Transformer<#C>, com.monkopedia.ksrpc.internal/ServiceExecutor, kotlin.collections/List<com.monkopedia.ksrpc/MethodMetadata>, kotlin.collections/List<com.monkopedia.ksrpc/KsErrorMapping> = ..., kotlin.collections/List<com.monkopedia.ksrpc/KsContextMapping> = ...) // com.monkopedia.ksrpc/RpcMethod.<init>|<init>(kotlin.String;com.monkopedia.ksrpc.Transformer<1:1>;com.monkopedia.ksrpc.Transformer<1:2>;com.monkopedia.ksrpc.internal.ServiceExecutor;kotlin.collections.List<com.monkopedia.ksrpc.MethodMetadata>;kotlin.collections.List<com.monkopedia.ksrpc.KsErrorMapping>;kotlin.collections.List<com.monkopedia.ksrpc.KsContextMapping>){}[0]
 
+    final val contextBindings // com.monkopedia.ksrpc/RpcMethod.contextBindings|{}contextBindings[0]
+        final fun <get-contextBindings>(): kotlin.collections/List<com.monkopedia.ksrpc/KsContextMapping> // com.monkopedia.ksrpc/RpcMethod.contextBindings.<get-contextBindings>|<get-contextBindings>(){}[0]
     final val endpoint // com.monkopedia.ksrpc/RpcMethod.endpoint|{}endpoint[0]
         final fun <get-endpoint>(): kotlin/String // com.monkopedia.ksrpc/RpcMethod.endpoint.<get-endpoint>|<get-endpoint>(){}[0]
     final val errorMappings // com.monkopedia.ksrpc/RpcMethod.errorMappings|{}errorMappings[0]
@@ -302,6 +304,33 @@ final class com.monkopedia.ksrpc.channels/CurrentRpcCallElement : kotlin.corouti
     final fun toString(): kotlin/String // com.monkopedia.ksrpc.channels/CurrentRpcCallElement.toString|toString(){}[0]
 
     final object CurrentRpcCall : kotlin.coroutines/CoroutineContext.Key<com.monkopedia.ksrpc.channels/CurrentRpcCallElement> // com.monkopedia.ksrpc.channels/CurrentRpcCallElement.CurrentRpcCall|null[0]
+}
+
+final class com.monkopedia.ksrpc.channels/WireContextCallId : com.monkopedia.ksrpc.channels/RpcCallId { // com.monkopedia.ksrpc.channels/WireContextCallId|null[0]
+    constructor <init>(com.monkopedia.ksrpc.channels/RpcCallId?, com.monkopedia.ksrpc.channels/WireContextMap?) // com.monkopedia.ksrpc.channels/WireContextCallId.<init>|<init>(com.monkopedia.ksrpc.channels.RpcCallId?;com.monkopedia.ksrpc.channels.WireContextMap?){}[0]
+
+    final val delegate // com.monkopedia.ksrpc.channels/WireContextCallId.delegate|{}delegate[0]
+        final fun <get-delegate>(): com.monkopedia.ksrpc.channels/RpcCallId? // com.monkopedia.ksrpc.channels/WireContextCallId.delegate.<get-delegate>|<get-delegate>(){}[0]
+    final val wireContextMap // com.monkopedia.ksrpc.channels/WireContextCallId.wireContextMap|{}wireContextMap[0]
+        final fun <get-wireContextMap>(): com.monkopedia.ksrpc.channels/WireContextMap? // com.monkopedia.ksrpc.channels/WireContextCallId.wireContextMap.<get-wireContextMap>|<get-wireContextMap>(){}[0]
+}
+
+final class com.monkopedia.ksrpc.channels/WireContextMap : kotlin.coroutines/CoroutineContext.Element { // com.monkopedia.ksrpc.channels/WireContextMap|null[0]
+    constructor <init>(kotlin.collections/Map<kotlin/String, kotlin/String>) // com.monkopedia.ksrpc.channels/WireContextMap.<init>|<init>(kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+
+    final val key // com.monkopedia.ksrpc.channels/WireContextMap.key|{}key[0]
+        final fun <get-key>(): kotlin.coroutines/CoroutineContext.Key<*> // com.monkopedia.ksrpc.channels/WireContextMap.key.<get-key>|<get-key>(){}[0]
+    final val values // com.monkopedia.ksrpc.channels/WireContextMap.values|{}values[0]
+        final fun <get-values>(): kotlin.collections/Map<kotlin/String, kotlin/String> // com.monkopedia.ksrpc.channels/WireContextMap.values.<get-values>|<get-values>(){}[0]
+
+    final object Key : kotlin.coroutines/CoroutineContext.Key<com.monkopedia.ksrpc.channels/WireContextMap> // com.monkopedia.ksrpc.channels/WireContextMap.Key|null[0]
+}
+
+final class com.monkopedia.ksrpc/KsContextMapping { // com.monkopedia.ksrpc/KsContextMapping|null[0]
+    constructor <init>(com.monkopedia.ksrpc/KsContextBinding<*>) // com.monkopedia.ksrpc/KsContextMapping.<init>|<init>(com.monkopedia.ksrpc.KsContextBinding<*>){}[0]
+
+    final val binding // com.monkopedia.ksrpc/KsContextMapping.binding|{}binding[0]
+        final fun <get-binding>(): com.monkopedia.ksrpc/KsContextBinding<*> // com.monkopedia.ksrpc/KsContextMapping.binding.<get-binding>|<get-binding>(){}[0]
 }
 
 final class com.monkopedia.ksrpc/KsErrorMapping { // com.monkopedia.ksrpc/KsErrorMapping|null[0]

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -24,11 +24,16 @@ import com.monkopedia.ksrpc.channels.CurrentRpcCallElement
 import com.monkopedia.ksrpc.channels.RpcBinaryData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.channels.WireContextCallId
+import com.monkopedia.ksrpc.channels.WireContextMap
 import com.monkopedia.ksrpc.channels.registerHost
 import com.monkopedia.ksrpc.internal.ServiceExecutor
 import com.monkopedia.ksrpc.internal.client
 import com.monkopedia.ksrpc.internal.host
 import com.monkopedia.ksrpc.internal.randomUuid
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlin.reflect.KClass
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -169,6 +174,22 @@ class SubserviceTransformer<T : RpcService>(
 class KsErrorMapping(val code: Int, val dataType: KClass<*>, val dataSerializer: KSerializer<*>)
 
 /**
+ * Describes one `@KsContext`-meta-annotated binding captured by the ksrpc
+ * compiler plugin on a `@KsMethod` function or its enclosing `@KsService`
+ * interface. Each entry holds a reference to the [KsContextBinding] singleton
+ * that knows how to encode/decode the context element for wire transport.
+ *
+ * At call time the stub reads the current [kotlin.coroutines.CoroutineContext]
+ * for each binding, encodes present values via [KsContextBinding.toWire], and
+ * installs a [WireContextMap] so transports can propagate them. On the server
+ * side [RpcMethod.call] reverses the process: it reads [WireContextMap] from
+ * the coroutine context, decodes values via [KsContextBinding.fromWire], and
+ * installs them as real [kotlin.coroutines.CoroutineContext.Element]s so
+ * handlers see them via the standard `coroutineContext[MyElement]` lookup.
+ */
+class KsContextMapping(val binding: KsContextBinding<*>)
+
+/**
  * Forward lookup built from [RpcMethod.errorMappings]: code → mapping. Used by
  * the client-side error-decoder to resolve an incoming wire-level code back to
  * the captured [KSerializer] for deserializing the payload. Entries from later
@@ -202,6 +223,12 @@ val RpcMethod<*, *, *>.reverseErrorMap: Map<KClass<*>, KsErrorMapping>
  * [KSerializer]. Runtime routing (see [forwardErrorMap] / [reverseErrorMap])
  * uses these to translate between thrown exception data and wire-level error
  * envelopes.
+ *
+ * The optional [contextBindings] list carries `@KsContext`-meta-annotated
+ * bindings captured by the compiler plugin from the source method and its
+ * enclosing `@KsService` interface. Each entry holds a [KsContextBinding]
+ * singleton used to propagate per-call coroutine-context values across the
+ * wire. See [KsContextMapping] for details.
  */
 class RpcMethod<T : RpcService, I, O>(
     val endpoint: String,
@@ -209,7 +236,8 @@ class RpcMethod<T : RpcService, I, O>(
     val outputTransform: Transformer<O>,
     private val method: ServiceExecutor,
     val metadata: List<MethodMetadata>,
-    val errorMappings: List<KsErrorMapping> = emptyList()
+    val errorMappings: List<KsErrorMapping> = emptyList(),
+    val contextBindings: List<KsContextMapping> = emptyList()
 ) {
 
     val hasReturnType: Boolean
@@ -235,8 +263,18 @@ class RpcMethod<T : RpcService, I, O>(
         // just pass the id through. Nested outbound calls that re-enter RpcMethod.call on the
         // far side naturally get a fresh element installed, so no caller-side stripping is
         // needed.
-        val currentCall = CurrentRpcCallElement(method = this, id = callId)
-        return withContext(channel.context.minusKey(Job) + currentCall) {
+        // Extract the real callId and WireContextMap from a WireContextCallId wrapper
+        // if present. The in-process channel path passes context this way because
+        // intermediate withContext switches may lose the WireContextMap from
+        // coroutineContext. Transport paths (PIPE, HTTP) install WireContextMap in
+        // coroutineContext directly.
+        val wireCallId = callId as? WireContextCallId
+        val realCallId = wireCallId?.delegate ?: callId
+        val wireCtx = wireCallId?.wireContextMap
+            ?: coroutineContext[WireContextMap]
+        val currentCall = CurrentRpcCallElement(method = this, id = realCallId)
+        val contextElements = decodeWireContextFrom(wireCtx)
+        return withContext(currentCall + contextElements) {
             try {
                 val transformedInput = inputTransform.untransform(input, channel)
                 val logId = randomUuid()
@@ -261,11 +299,17 @@ class RpcMethod<T : RpcService, I, O>(
     @Suppress("UNCHECKED_CAST")
     suspend fun <S> callChannel(channel: SerializedService<S>, input: Any?): Any? {
         val timeout = timeoutMillis
+        // Build a WireContextMap from the CALLER's coroutineContext BEFORE switching
+        // to the channel's context — the withContext below replaces the context, so
+        // the caller's context elements would be lost if we read them inside.
+        val wireCtx = buildWireContext(coroutineContext)
         // Drop the Job element from the channel's context so the caller's Job remains the
         // parent for cancellation propagation — otherwise cancelling the caller wouldn't
         // surface inside the remote call (it would only cancel this [withContext] body's
         // own child scope, which is unreachable from the caller's cancel signal).
-        return withContext(channel.context.minusKey(Job)) {
+        val baseContext = channel.context.minusKey(Job)
+        val channelContext = if (wireCtx != null) baseContext + wireCtx else baseContext
+        return withContext(channelContext) {
             val body: suspend () -> Any? = {
                 val input = inputTransform.transform(input as I, channel)
                 val id = randomUuid()
@@ -277,8 +321,16 @@ class RpcMethod<T : RpcService, I, O>(
                 // wire-level id at the transport if needed, and any server-side handler
                 // reached via the remote transport will have its own
                 // CurrentRpcCallElement installed by that transport's RpcMethod.call
-                // invocation.
-                val transformedOutput = channel.call(this@RpcMethod, input, callId = null)
+                // invocation. For the in-process path, we forward the WireContextMap
+                // via a WireContextCallId wrapper so RpcMethod.call can decode
+                // @KsContext bindings even if the coroutine context doesn't survive
+                // through intermediate withContext switches.
+                val wireCallId = if (wireCtx != null) {
+                    WireContextCallId(delegate = null, wireContextMap = wireCtx)
+                } else {
+                    null
+                }
+                val transformedOutput = channel.call(this@RpcMethod, input, callId = wireCallId)
                 channel.env.logger.debug(
                     "Transformer",
                     "($id) Completed remote endpoint $endpoint"
@@ -398,4 +450,41 @@ class RpcMethod<T : RpcService, I, O>(
             inputTransform as? BaseSubserviceTransformer<*, *>,
             outputTransform as? BaseSubserviceTransformer<*, *>
         )
+
+    /**
+     * Client-side: extract context values from the current [CoroutineContext]
+     * using this method's [contextBindings] and build a [WireContextMap] for
+     * transports to propagate. Returns null if no bindings are declared or no
+     * context elements are present.
+     */
+    @Suppress("UNCHECKED_CAST")
+    @OptIn(KsrpcInternal::class)
+    private fun buildWireContext(context: CoroutineContext): WireContextMap? {
+        if (contextBindings.isEmpty()) return null
+        val map = mutableMapOf<String, String>()
+        for (mapping in contextBindings) {
+            val binding = mapping.binding as KsContextBinding<CoroutineContext.Element>
+            val element = context[binding] ?: continue
+            map[binding.wireKey] = binding.toWire(element)
+        }
+        return if (map.isEmpty()) null else WireContextMap(map)
+    }
+
+    /**
+     * Server-side: decode [WireContextMap] values into real
+     * [CoroutineContext.Element]s using this method's [contextBindings].
+     * Returns [EmptyCoroutineContext] if no bindings are declared or the
+     * wire context map is null.
+     */
+    @OptIn(KsrpcInternal::class)
+    private fun decodeWireContextFrom(wireCtx: WireContextMap?): CoroutineContext {
+        if (contextBindings.isEmpty() || wireCtx == null) return EmptyCoroutineContext
+        val wireMap = wireCtx.values
+        var result: CoroutineContext = EmptyCoroutineContext
+        for (mapping in contextBindings) {
+            val encoded = wireMap[mapping.binding.wireKey] ?: continue
+            result += mapping.binding.fromWire(encoded)
+        }
+        return result
+    }
 }

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -274,7 +274,7 @@ class RpcMethod<T : RpcService, I, O>(
             ?: coroutineContext[WireContextMap]
         val currentCall = CurrentRpcCallElement(method = this, id = realCallId)
         val contextElements = decodeWireContextFrom(wireCtx)
-        return withContext(currentCall + contextElements) {
+        return withContext(channel.context.minusKey(Job) + currentCall + contextElements) {
             try {
                 val transformedInput = inputTransform.untransform(input, channel)
                 val logId = randomUuid()

--- a/ksrpc-core/src/commonMain/kotlin/channels/WireContextMap.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/WireContextMap.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.channels
+
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Coroutine-context element that carries wire-encoded `@KsContext` values
+ * through the call chain. The stub-side [com.monkopedia.ksrpc.RpcMethod.callChannel]
+ * builds a [WireContextMap] from the caller's coroutine context (encoding each
+ * present [com.monkopedia.ksrpc.KsContextBinding] via `toWire`) and installs it
+ * so transports can read the values and propagate them across the wire.
+ *
+ * On the server side, the transport installs a [WireContextMap] extracted from
+ * the incoming wire frame. [com.monkopedia.ksrpc.RpcMethod.call] then decodes
+ * each entry via `fromWire` and installs real [CoroutineContext.Element]s so
+ * handlers see them via the standard `coroutineContext[MyElement]` lookup.
+ *
+ * This class is transport plumbing and not part of the public API.
+ */
+@KsrpcInternal
+class WireContextMap(val values: Map<String, String>) : CoroutineContext.Element {
+    override val key: CoroutineContext.Key<*> get() = Key
+
+    companion object Key : CoroutineContext.Key<WireContextMap>
+}
+
+/**
+ * An [RpcCallId] wrapper that carries a [WireContextMap] alongside the
+ * original (possibly null) call id. Used by [com.monkopedia.ksrpc.RpcMethod.callChannel]
+ * to forward wire-encoded context values through the call chain without
+ * depending on coroutine context propagation, which may not survive through
+ * intermediate `withContext` switches in the in-process channel path.
+ */
+@KsrpcInternal
+class WireContextCallId(
+    val delegate: RpcCallId?,
+    val wireContextMap: WireContextMap?
+) : RpcCallId

--- a/ksrpc-packets/api/ksrpc-packets.api
+++ b/ksrpc-packets/api/ksrpc-packets.api
@@ -5,12 +5,13 @@ public final class com/monkopedia/ksrpc/packets/internal/ConstantsKt {
 
 public final class com/monkopedia/ksrpc/packets/internal/Packet {
 	public static final field Companion Lcom/monkopedia/ksrpc/packets/internal/Packet$Companion;
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;)V
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;)V
-	public synthetic fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (ZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBinary ()Z
 	public final fun getCancel ()Z
+	public final fun getContextMap ()Ljava/util/Map;
 	public final fun getData ()Ljava/lang/Object;
 	public final fun getEndpoint ()Ljava/lang/String;
 	public final fun getErrorCode ()Ljava/lang/Integer;

--- a/ksrpc-packets/api/ksrpc-packets.klib.api
+++ b/ksrpc-packets/api/ksrpc-packets.klib.api
@@ -35,13 +35,15 @@ abstract class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/PacketCha
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/Packet { // com.monkopedia.ksrpc.packets.internal/Packet|null[0]
-    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/String, kotlin/String, kotlin/String, #A, kotlin/Int? = ..., kotlin/String? = ...) // com.monkopedia.ksrpc.packets.internal/Packet.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.String;kotlin.String;kotlin.String;1:0;kotlin.Int?;kotlin.String?){}[0]
-    constructor <init>(kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, #A, kotlin/Int? = ..., kotlin/String? = ...) // com.monkopedia.ksrpc.packets.internal/Packet.<init>|<init>(kotlin.Int;kotlin.String;kotlin.String;kotlin.String;1:0;kotlin.Int?;kotlin.String?){}[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/String, kotlin/String, kotlin/String, #A, kotlin/Int? = ..., kotlin/String? = ..., kotlin.collections/Map<kotlin/String, kotlin/String>? = ...) // com.monkopedia.ksrpc.packets.internal/Packet.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.String;kotlin.String;kotlin.String;1:0;kotlin.Int?;kotlin.String?;kotlin.collections.Map<kotlin.String,kotlin.String>?){}[0]
+    constructor <init>(kotlin/Int = ..., kotlin/String, kotlin/String, kotlin/String, #A, kotlin/Int? = ..., kotlin/String? = ..., kotlin.collections/Map<kotlin/String, kotlin/String>? = ...) // com.monkopedia.ksrpc.packets.internal/Packet.<init>|<init>(kotlin.Int;kotlin.String;kotlin.String;kotlin.String;1:0;kotlin.Int?;kotlin.String?;kotlin.collections.Map<kotlin.String,kotlin.String>?){}[0]
 
     final val binary // com.monkopedia.ksrpc.packets.internal/Packet.binary|{}binary[0]
         final fun <get-binary>(): kotlin/Boolean // com.monkopedia.ksrpc.packets.internal/Packet.binary.<get-binary>|<get-binary>(){}[0]
     final val cancel // com.monkopedia.ksrpc.packets.internal/Packet.cancel|{}cancel[0]
         final fun <get-cancel>(): kotlin/Boolean // com.monkopedia.ksrpc.packets.internal/Packet.cancel.<get-cancel>|<get-cancel>(){}[0]
+    final val contextMap // com.monkopedia.ksrpc.packets.internal/Packet.contextMap|{}contextMap[0]
+        final fun <get-contextMap>(): kotlin.collections/Map<kotlin/String, kotlin/String>? // com.monkopedia.ksrpc.packets.internal/Packet.contextMap.<get-contextMap>|<get-contextMap>(){}[0]
     final val data // com.monkopedia.ksrpc.packets.internal/Packet.data|{}data[0]
         final fun <get-data>(): #A // com.monkopedia.ksrpc.packets.internal/Packet.data.<get-data>|<get-data>(){}[0]
     final val endpoint // com.monkopedia.ksrpc.packets.internal/Packet.endpoint|{}endpoint[0]
@@ -79,6 +81,7 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc.packets.internal/Packet { // 
     final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.monkopedia.ksrpc.packets.internal/Packet.Companion|null[0]
         final val $cachedDescriptor // com.monkopedia.ksrpc.packets.internal/Packet.Companion.$cachedDescriptor|{}$cachedDescriptor[0]
             final fun <get-$cachedDescriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.monkopedia.ksrpc.packets.internal/Packet.Companion.$cachedDescriptor.<get-$cachedDescriptor>|<get-$cachedDescriptor>(){}[0]
+        final val $childSerializers // com.monkopedia.ksrpc.packets.internal/Packet.Companion.$childSerializers|{}$childSerializers[0]
 
         final fun <#A2: kotlin/Any?> serializer(kotlinx.serialization/KSerializer<#A2>): kotlinx.serialization/KSerializer<com.monkopedia.ksrpc.packets.internal/Packet<#A2>> // com.monkopedia.ksrpc.packets.internal/Packet.Companion.serializer|serializer(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
         final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.monkopedia.ksrpc.packets.internal/Packet.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]

--- a/ksrpc-packets/src/commonMain/kotlin/Packet.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/Packet.kt
@@ -50,7 +50,16 @@ class Packet<T>(
      * [errorCode] is non-null; null otherwise.
      */
     @SerialName("em")
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    /**
+     * Optional map of wire-encoded `@KsContext` values. When non-null on an input frame,
+     * the receiver installs a [com.monkopedia.ksrpc.channels.WireContextMap] so the
+     * handler's [com.monkopedia.ksrpc.RpcMethod.call] can decode the values and install
+     * them as real coroutine-context elements. Older peers that don't understand this field
+     * tolerate it via `ignoreUnknownKeys` on [PACKET_JSON].
+     */
+    @SerialName("cx")
+    val contextMap: Map<String, String>? = null
 ) {
     val input: Boolean get() = (type and 1) != 0
     val binary: Boolean get() = (type and 2) != 0
@@ -79,7 +88,8 @@ class Packet<T>(
         endpoint: String,
         data: T,
         errorCode: Int? = null,
-        errorMessage: String? = null
+        errorMessage: String? = null,
+        contextMap: Map<String, String>? = null
     ) : this(
         (if (input) 1 else 0) or
             (if (binary) 2 else 0) or
@@ -90,7 +100,8 @@ class Packet<T>(
         endpoint,
         data,
         errorCode,
-        errorMessage
+        errorMessage,
+        contextMap
     )
 }
 

--- a/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
@@ -27,6 +27,7 @@ import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.channels.RpcBinaryData
 import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.channels.WireContextMap
 import com.monkopedia.ksrpc.channels.awaitRequestCancellable
 import com.monkopedia.ksrpc.internal.ClientChannelContext
 import com.monkopedia.ksrpc.internal.HostChannelContext
@@ -35,6 +36,7 @@ import com.monkopedia.ksrpc.internal.MultiChannel
 import com.monkopedia.ksrpc.internal.SubserviceChannel
 import com.monkopedia.ksrpc.internal.randomUuid
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -150,7 +152,15 @@ abstract class PacketChannelBase<T>(
                             // the cancellation must flow through into serviceChannel.call.
                             // The CurrentRpcCallElement is installed centrally in
                             // RpcMethod.call via the callId we pass through here.
-                            val response = withContext(context.minusKey(Job)) {
+                            // Install WireContextMap from the packet so RpcMethod.call can
+                            // decode @KsContext bindings into real coroutine-context elements.
+                            val wireCtx = p.contextMap?.let { WireContextMap(it) }
+                            val handlerContext = if (wireCtx != null) {
+                                context.minusKey(Job) + wireCtx
+                            } else {
+                                context.minusKey(Job)
+                            }
+                            val response = withContext(handlerContext) {
                                 serviceChannel.call(
                                     ChannelId(p.id),
                                     p.endpoint,
@@ -189,7 +199,8 @@ abstract class PacketChannelBase<T>(
         id: String,
         messageId: String,
         endpoint: String,
-        response: CallData<T>
+        response: CallData<T>,
+        contextMap: Map<String, String>? = null
     ) {
         if (response.isBinary) {
             val binaryChannel = randomUuid()
@@ -208,7 +219,8 @@ abstract class PacketChannelBase<T>(
                     data = env.serialization.createCallData(
                         String.serializer(),
                         binaryChannel
-                    ).readSerialized()
+                    ).readSerialized(),
+                    contextMap = contextMap
                 )
             )
             launch {
@@ -295,7 +307,8 @@ abstract class PacketChannelBase<T>(
                     id = id,
                     messageId = messageId,
                     endpoint = endpoint,
-                    data = response.readSerialized()
+                    data = response.readSerialized(),
+                    contextMap = contextMap
                 )
             )
         }
@@ -372,7 +385,8 @@ abstract class PacketChannelBase<T>(
             "SerializedChannel",
             "Sending call ${channelId.id}/$endpoint -  $messageId"
         )
-        scope.sendPacket(true, channelId.id, messageId, endpoint, data)
+        val wireCtx = coroutineContext[WireContextMap]?.values
+        scope.sendPacket(true, channelId.id, messageId, endpoint, data, contextMap = wireCtx)
         val packet = try {
             awaitRequestCancellable(wireCallId, response)
         } catch (t: CancellationException) {

--- a/ksrpc-test/src/commonTest/kotlin/KsContextPropagationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsContextPropagationTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(KsrpcInternal::class)
+
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsContext
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// --- Context element + binding ---
+
+class AuthToken(val token: String) : CoroutineContext.Element {
+    override val key get() = Key
+
+    companion object Key : KsContextBinding<AuthToken> {
+        override val wireKey: String = "x-auth-token"
+        override fun toWire(value: AuthToken): String = value.token
+        override fun fromWire(encoded: String): AuthToken = AuthToken(encoded)
+    }
+}
+
+class TraceId(val value: String) : CoroutineContext.Element {
+    override val key get() = Key
+
+    companion object Key : KsContextBinding<TraceId> {
+        override val wireKey: String = "x-trace-id"
+        override fun toWire(value: TraceId): String = value.value
+        override fun fromWire(encoded: String): TraceId = TraceId(encoded)
+    }
+}
+
+// --- Annotations ---
+
+@KsContext(binding = AuthToken.Key::class)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class Auth
+
+@KsContext(binding = TraceId.Key::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class WithTrace
+
+// --- Service ---
+
+@Auth
+@KsService
+interface ContextService : RpcService {
+    @KsMethod("/greet")
+    @WithTrace
+    suspend fun greet(input: String): String
+
+    @KsMethod("/auth_only")
+    suspend fun authOnly(input: String): String
+}
+
+/**
+ * Tests for #81 — compile-time verification and runtime infrastructure for
+ * `@KsContext` context propagation. These tests verify:
+ * - The compiler plugin populates `contextBindings` on the generated `RpcMethod`
+ * - The `WireContextMap` and `KsContextMapping` runtime classes work correctly
+ * - Class-level and method-level annotations are unioned correctly
+ */
+class KsContextPropagationTest {
+
+    @Test
+    fun contextBindingsPopulated() {
+        val rpcObject = rpcObject<ContextService>()
+        val greetMethod = rpcObject.findEndpoint("greet")
+        val bindings = greetMethod.contextBindings
+        assertEquals(
+            2,
+            bindings.size,
+            "Expected 2 context bindings on /greet, got ${bindings.map { it.binding.wireKey }}"
+        )
+        val wireKeys = bindings.map { it.binding.wireKey }.toSet()
+        assertTrue("x-auth-token" in wireKeys, "Missing x-auth-token; got $wireKeys")
+        assertTrue("x-trace-id" in wireKeys, "Missing x-trace-id; got $wireKeys")
+
+        val authOnlyMethod = rpcObject.findEndpoint("auth_only")
+        val authOnlyBindings = authOnlyMethod.contextBindings
+        assertEquals(
+            1,
+            authOnlyBindings.size,
+            "Expected 1 context binding on /auth_only, got " +
+                authOnlyBindings.map { it.binding.wireKey }
+        )
+        assertEquals("x-auth-token", authOnlyBindings.single().binding.wireKey)
+    }
+
+    // noContextServiceHasEmptyBindings tested via the compiler plugin test
+    // (KsContextCodegenTest.`method without @KsContext has empty contextBindings`)
+}
+
+// TODO(#81 follow-up): Round-trip pipe-transport test for context propagation.
+// The runtime CoroutineContext propagation through intermediate withContext switches
+// in the channel call chain needs investigation — the WireContextMap installed by
+// callChannel is not surviving to RpcMethod.call via coroutineContext. The
+// WireContextCallId workaround is in place but untested end-to-end pending that fix.

--- a/ksrpc-test/src/commonTest/kotlin/KsContextPropagationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsContextPropagationTest.kt
@@ -21,11 +21,14 @@ import com.monkopedia.ksrpc.annotation.KsContext
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsService
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
+import com.monkopedia.ksrpc.internal.asClient
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.withContext
 
 // --- Context element + binding ---
 
@@ -74,12 +77,44 @@ interface ContextService : RpcService {
     suspend fun authOnly(input: String): String
 }
 
+// --- Concrete handler implementations (NOT anonymous objects) ---
+// Anonymous objects declared inside a CoroutineScope capture the scope's
+// coroutineContext instead of reading from the suspend continuation. Using
+// concrete top-level classes avoids this Kotlin limitation.
+
+class GreetHandler : ContextService {
+    override suspend fun greet(input: String): String {
+        val auth = coroutineContext[AuthToken.Key]
+            ?: return "no-auth"
+        val trace = coroutineContext[TraceId.Key]
+            ?: return "auth=${auth.token},no-trace"
+        return "auth=${auth.token},trace=${trace.value}"
+    }
+
+    override suspend fun authOnly(input: String): String {
+        val auth = coroutineContext[AuthToken.Key]
+            ?: return "no-auth"
+        return "auth=${auth.token}"
+    }
+}
+
+class AuthOnlyHandler : ContextService {
+    override suspend fun greet(input: String): String = error("unused")
+    override suspend fun authOnly(input: String): String {
+        val auth = coroutineContext[AuthToken.Key]
+        val trace = coroutineContext[TraceId.Key]
+        return "auth=${auth?.token},trace=${trace?.value}"
+    }
+}
+
 /**
- * Tests for #81 — compile-time verification and runtime infrastructure for
- * `@KsContext` context propagation. These tests verify:
- * - The compiler plugin populates `contextBindings` on the generated `RpcMethod`
- * - The `WireContextMap` and `KsContextMapping` runtime classes work correctly
- * - Class-level and method-level annotations are unioned correctly
+ * Tests for #81 — compile-time verification and runtime propagation for
+ * `@KsContext` context bindings.
+ *
+ * Note: handler-side context lookup uses `coroutineContext[AuthToken.Key]`
+ * (the named companion), not `coroutineContext[AuthToken]` (the class name).
+ * With a named companion pattern, Kotlin resolves the bare class name to
+ * the type, not to the companion object.
  */
 class KsContextPropagationTest {
 
@@ -108,12 +143,96 @@ class KsContextPropagationTest {
         assertEquals("x-auth-token", authOnlyBindings.single().binding.wireKey)
     }
 
-    // noContextServiceHasEmptyBindings tested via the compiler plugin test
-    // (KsContextCodegenTest.`method without @KsContext has empty contextBindings`)
+    @Test
+    fun contextPropagatesInProcess() = runBlockingUnit {
+        withInProcessChannel(GreetHandler()) { stub ->
+            withContext(AuthToken("secret-123") + TraceId("abc-def")) {
+                val result = stub.greet("hello")
+                assertEquals("auth=secret-123,trace=abc-def", result)
+            }
+        }
+    }
+
+    @Test
+    fun absentContextSurfacesAsNull() = runBlockingUnit {
+        withInProcessChannel(GreetHandler()) { stub ->
+            // No context installed — handler should see nulls
+            val result = stub.greet("hello")
+            assertEquals("no-auth", result)
+        }
+    }
+
+    @Test
+    fun partialContextPropagates() = runBlockingUnit {
+        withInProcessChannel(GreetHandler()) { stub ->
+            withContext(AuthToken("only-auth")) {
+                val result = stub.greet("hello")
+                assertEquals("auth=only-auth,no-trace", result)
+            }
+        }
+    }
+
+    @Test
+    fun authOnlyMethodStillSeesUnboundContext() = runBlockingUnit {
+        // In-process: the caller's full coroutineContext propagates through,
+        // including elements not bound on the method. Wire-level filtering
+        // (only encoding bound elements) is a transport concern tested by the
+        // pipe test below.
+        withInProcessChannel(AuthOnlyHandler()) { stub ->
+            withContext(AuthToken("token-1") + TraceId("unbound-but-visible")) {
+                val result = stub.authOnly("hello")
+                assertEquals("auth=token-1,trace=unbound-but-visible", result)
+            }
+        }
+    }
+
+    @Test
+    fun authTokenElementRoundTrips() {
+        val original = AuthToken("secret")
+        val wire = AuthToken.Key.toWire(original)
+        assertEquals("secret", wire)
+        val decoded = AuthToken.Key.fromWire(wire)
+        assertEquals("secret", decoded.token)
+    }
+
+    private suspend fun withInProcessChannel(
+        service: ContextService,
+        body: suspend (ContextService) -> Unit
+    ) {
+        val env = ksrpcEnvironment { }
+        val channel = HostSerializedChannelImpl(env)
+        try {
+            channel.registerDefault(service.serialized(env))
+            val stub = channel.asClient.defaultChannel().toStub<ContextService, String>()
+            body(stub)
+        } finally {
+            try {
+                channel.close()
+            } catch (_: Throwable) {
+            }
+        }
+    }
 }
 
-// TODO(#81 follow-up): Round-trip pipe-transport test for context propagation.
-// The runtime CoroutineContext propagation through intermediate withContext switches
-// in the channel call chain needs investigation — the WireContextMap installed by
-// callChannel is not surviving to RpcMethod.call via coroutineContext. The
-// WireContextCallId workaround is in place but untested end-to-end pending that fix.
+/**
+ * Round-trip pipe-transport coverage for context propagation: exercises the full
+ * encode / wire / decode flow over a real socket pipe so we verify the context
+ * map survives packet serialization. The Packet wire grew an optional `cx` field.
+ */
+class KsContextPropagationPipeTest :
+    RpcFunctionalityTest(
+        supportedTypes = listOf(
+            TestType.PIPE,
+            TestType.SERIALIZE
+        ),
+        serializedChannel = {
+            GreetHandler().serialized(ksrpcEnvironment { })
+        },
+        verifyOnChannel = { channel ->
+            val stub = channel.toStub<ContextService, String>()
+            withContext(AuthToken("pipe-token") + TraceId("pipe-trace")) {
+                val result = stub.greet("hello")
+                assertEquals("auth=pipe-token,trace=pipe-trace", result)
+            }
+        }
+    )


### PR DESCRIPTION
## Summary
- Compiler plugin discovers `@KsContext`-meta-annotated annotations on `@KsService` classes and methods, emits `contextBindings` on generated `RpcMethod` descriptors
- Runtime: `RpcMethod.callChannel` (client) extracts context values from caller's `coroutineContext`, encodes via `toWire`, forwards as `WireContextMap`
- Runtime: `RpcMethod.call` (server) decodes `WireContextMap` via `fromWire`, installs decoded elements in handler's `coroutineContext`
- Packet wire format: optional `cx` field on `Packet` carries context map over PIPE transport
- `PacketChannelBase` threads `WireContextMap` through send/receive paths

## New types
- `KsContextMapping` — holds a `KsContextBinding<*>` singleton, stored on `RpcMethod.contextBindings`
- `WireContextMap` — `@KsrpcInternal` coroutine context element carrying wire-encoded context values
- `WireContextCallId` — `@KsrpcInternal` wrapper forwarding context through in-process call chain
- `ContextBindingIrBuilder` — compiler plugin IR builder (follows `ErrorMappingIrBuilder` pattern)

## Tests
- 4 compiler plugin codegen tests (`KsContextCodegenTest`)
- 6 in-process propagation tests (`KsContextPropagationTest`)
- 2 PIPE transport round-trip tests (`KsContextPropagationPipeTest`)

## Notes
- Handler-side lookup uses `coroutineContext[AuthToken.Key]` (named companion), not `coroutineContext[AuthToken]` (class name)
- Handler implementations must be concrete classes, not anonymous objects declared inside a `CoroutineScope` — anonymous objects capture the outer scope's `coroutineContext` instead of reading from the suspend continuation
- HTTP/JSON-RPC transport wire formats deferred to #82

Fixes #81

Generated with [Claude Code](https://claude.com/claude-code)