### PR TITLE
Fix #108: Migrate @KsService non-interface rejection to FIR checker

### DIFF
--- a/compiler/plugin/src/main/java/fir/KsServiceClassChecker.kt
+++ b/compiler/plugin/src/main/java/fir/KsServiceClassChecker.kt
@@ -16,6 +16,7 @@
 package com.monkopedia.ksrpc.plugin.fir
 
 import com.monkopedia.ksrpc.plugin.FqConstants
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
@@ -39,6 +40,7 @@ import org.jetbrains.kotlin.types.Variance
  * `KsrpcIrGenerationExtension.validateClass` and
  * `ServiceClass.SubclassVisitor`:
  *
+ *  - `@KsService` on a non-interface declaration (class, object, enum, annotation) (#53, #108)
  *  - `@KsService` on a subtype of another `@KsService` (issue #45)
  *  - `@KsService` class without `RpcService` (or `IntrospectableRpcService`) supertype
  *  - Class-level variant type parameter (`out T` / `in T`) — not yet supported
@@ -100,6 +102,25 @@ internal object KsServiceClassChecker :
     ) {
         val source = declaration.source ?: return
         val session = context.session
+
+        // #0: @KsService is contractually interface-only. Generated code (Stub, companion,
+        // Obj) assumes the annotated declaration is an interface. Classes, objects, enums,
+        // and annotation classes all produce malformed generated code. Reject them here so
+        // IDEs show a clean diagnostic instead of confusing crashes downstream (#53, #108).
+        if (declaration.classKind != ClassKind.INTERFACE) {
+            val simpleName = symbol.classId.shortClassName.asString()
+            reporter.reportOn(
+                source,
+                KsrpcDiagnostics.NOT_INTERFACE,
+                "@KsService can only be applied to interfaces. Change `$simpleName` to an " +
+                    "interface.",
+                context
+            )
+            // Bail out early — downstream validations (supertypes, type parameters) assume
+            // the declaration is an interface and would emit noisy secondary diagnostics.
+            return
+        }
+
         val superTypeFqNames = declaration.superTypeRefs
             .mapNotNull { it.toRegularClassSymbol(session)?.classId?.asSingleFqName() }
         val hasRpcServiceSuper = superTypeFqNames.any { it == FQRPC_SERVICE }

--- a/compiler/plugin/src/main/java/fir/KsrpcDiagnostics.kt
+++ b/compiler/plugin/src/main/java/fir/KsrpcDiagnostics.kt
@@ -39,6 +39,9 @@ import org.jetbrains.kotlin.psi.KtElement
 @Suppress("detekt:ObjectPropertyNaming")
 object KsrpcDiagnostics : KtDiagnosticsContainer() {
 
+    // 0: @KsService applied to a non-interface (class, object, enum, annotation)
+    val NOT_INTERFACE: KtDiagnosticFactory1<String> by error1<KtElement, String>()
+
     // 1: @KsService applied to a subtype of another @KsService
     val KSSERVICE_SUBTYPE_OF_KSSERVICE: KtDiagnosticFactory1<String> by error1<KtElement, String>()
 
@@ -94,6 +97,7 @@ private object KsrpcDiagnosticRenderers : BaseDiagnosticRendererFactory() {
         "ksrpc"
     ) { map ->
         with(KsrpcDiagnostics) {
+            map.put(NOT_INTERFACE, "{0}", CommonRenderers.STRING)
             map.put(KSSERVICE_SUBTYPE_OF_KSSERVICE, "{0}", CommonRenderers.STRING)
             map.put(NOT_RPC_SERVICE, "{0}", CommonRenderers.STRING)
             map.put(VARIANT_TYPE_PARAMETER, "{0}", CommonRenderers.STRING)


### PR DESCRIPTION
## Summary
- Added `NOT_INTERFACE` diagnostic to FIR phase — `@KsService` on non-interface declarations (class, object, enum, annotation) now reports at analysis time, not IR generation
- FIR check in `KsServiceClassChecker.checkKsServiceClass()` returns early to avoid noisy secondary diagnostics
- IR-phase check retained as safety net (consistent with codebase convention)
- Existing `KsServiceInterfaceValidationTest` tests pass unchanged

Fixes #108

Generated with [Claude Code](https://claude.com/claude-code)