### PR TITLE
Fix #102: Walk transitive supertypes when validating @KsService

### DIFF
--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -138,6 +138,8 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
+import org.jetbrains.kotlin.ir.util.getAllSuperclasses
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.types.Variance
@@ -200,10 +202,12 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
             // the declaration is an interface and would emit noisy secondary diagnostics.
             return false
         }
-        val superTypeNames = irClass.superTypes.map { it.classFqName }
-        val hasRpcServiceSuper = superTypeNames.contains(FQRPC_SERVICE)
+        val allSuperFqNames = (irClass.superTypes.mapNotNull { it.classFqName } +
+            irClass.getAllSuperclasses().map { it.fqNameForIrSerialization })
+            .toSet()
+        val hasRpcServiceSuper = allSuperFqNames.contains(FQRPC_SERVICE)
         val hasIntrospectableSuper =
-            superTypeNames.contains(INTROSPECTABLE_RPC_SERVICE.asSingleFqName())
+            allSuperFqNames.contains(INTROSPECTABLE_RPC_SERVICE.asSingleFqName())
         // Reject `@KsService` applied to a subtype of another `@KsService` interface.
         // The parent's @KsService annotation already drives codegen, and `rpcObject<Sub>()`
         // walks supertypes to find the parent's `RpcObject`/`RpcObjectFactory` companion

--- a/compiler/plugin/src/main/java/fir/KsServiceClassChecker.kt
+++ b/compiler/plugin/src/main/java/fir/KsServiceClassChecker.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.FirTypeParameter
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
 import org.jetbrains.kotlin.fir.declarations.utils.classId
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.types.toRegularClassSymbol
 import org.jetbrains.kotlin.name.ClassId
@@ -121,10 +122,9 @@ internal object KsServiceClassChecker :
             return
         }
 
-        val superTypeFqNames = declaration.superTypeRefs
-            .mapNotNull { it.toRegularClassSymbol(session)?.classId?.asSingleFqName() }
-        val hasRpcServiceSuper = superTypeFqNames.any { it == FQRPC_SERVICE }
-        val hasIntrospectableSuper = superTypeFqNames.any { it == FQ_INTROSPECTABLE_RPC_SERVICE }
+        val allSuperFqNames = collectAllSuperFqNames(declaration, session)
+        val hasRpcServiceSuper = allSuperFqNames.contains(FQRPC_SERVICE)
+        val hasIntrospectableSuper = allSuperFqNames.contains(FQ_INTROSPECTABLE_RPC_SERVICE)
 
         val ksServiceSuper = ksServiceSuperSymbols.firstOrNull()
         if (ksServiceSuper != null) {
@@ -173,5 +173,29 @@ internal object KsServiceClassChecker :
                 }
             }
         }
+    }
+
+    /**
+     * Collect FQ names of all transitive supertypes of [declaration], including direct ones.
+     */
+    @OptIn(SymbolInternals::class)
+    private fun collectAllSuperFqNames(
+        declaration: FirClass,
+        session: org.jetbrains.kotlin.fir.FirSession
+    ): Set<FqName> {
+        val result = mutableSetOf<FqName>()
+        val queue = ArrayDeque<FirClass>()
+        queue.add(declaration)
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            for (superRef in current.superTypeRefs) {
+                val superSymbol = superRef.toRegularClassSymbol(session) ?: continue
+                val fqName = superSymbol.classId.asSingleFqName()
+                if (result.add(fqName)) {
+                    superSymbol.fir.let { queue.add(it) }
+                }
+            }
+        }
+        return result
     }
 }

--- a/compiler/plugin/src/test/java/GenericServiceTest.kt
+++ b/compiler/plugin/src/test/java/GenericServiceTest.kt
@@ -644,17 +644,11 @@ interface GenericWithAudit<T> : RpcService {
     }
 
     @Test
-    fun `generic ksservice reached through deep super chain is rejected`() {
-        // Shape (2) in issue #57 — `@KsService` on `D<T>` where `RpcService` is reached
+    fun `generic ksservice reached through deep super chain compiles`() {
+        // Issue #102 — `@KsService` on `D<T>` where `RpcService` is reached
         // transitively through two plain-Kotlin intermediate interfaces
-        // (`D -> C -> B -> A -> RpcService`). `KsrpcIrGenerationExtension.validateClass`
-        // only looks at direct supertypes for `RpcService`/`IntrospectableRpcService`,
-        // so the deep chain is currently rejected with a clear diagnostic.
-        //
-        // This test pins the user-facing behaviour: deep-chain `@KsService` emits a
-        // "does not extend com.monkopedia.ksrpc.RpcService" diagnostic rather than
-        // crashing in codegen. Supporting transitive ancestry detection on the
-        // generic-service path is tracked as a follow-up.
+        // (`D -> C -> B -> A -> RpcService`). The plugin now walks transitive
+        // supertypes so this shape compiles successfully.
         val source = SourceFile.kotlin(
             "main.kt",
             """
@@ -674,18 +668,10 @@ interface D<T> : C {
 """
         )
         val result = compile(sourceFile = source)
-        assertTrue(
-            result.exitCode != KotlinCompilation.ExitCode.OK,
-            "Expected compilation to fail for deep-chain @KsService, got: ${result.exitCode}"
-        )
-        assertTrue(
-            result.messages.contains("does not extend com.monkopedia.ksrpc.RpcService"),
-            "Expected RpcService-extends diagnostic, got: ${result.messages}"
-        )
-        // Confirm we do not see an internal-failure shape.
-        assertTrue(
-            !result.messages.contains("Invalid synthetic declaration"),
-            "Plugin must emit a user diagnostic, not crash on deep chains: ${result.messages}"
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "messages: ${result.messages}"
         )
     }
 


### PR DESCRIPTION
## Summary
- Both IR and FIR phase validation now walk transitive supertypes (BFS) instead of only checking direct supertypes when verifying `@KsService` extends `RpcService`
- Fixes rejection of valid interfaces like `D<T> -> C -> B -> A -> RpcService` where `RpcService` is reached through intermediate plain-Kotlin interfaces
- Updated existing test from expecting compilation failure to expecting success

Fixes #102

Generated with [Claude Code](https://claude.com/claude-code)