### PR TITLE
Fix #66: IR builder DSL helpers for compiler plugin

### DIFF
--- a/compiler/plugin/src/main/java/ContextBindingIrBuilder.kt
+++ b/compiler/plugin/src/main/java/ContextBindingIrBuilder.kt
@@ -19,11 +19,7 @@ package com.monkopedia.ksrpc.plugin
 
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.ir.builders.irCall
-import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irGetObject
-import org.jetbrains.kotlin.ir.builders.irVararg
-import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -31,7 +27,6 @@ import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.starProjectedType
-import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 
 /**
@@ -76,7 +71,8 @@ class ContextBindingIrBuilder(
             if (!seen.add(bindingSymbol)) return@mapNotNull null
             buildMapping(bindingSymbol)
         }
-        return buildListOf(
+        return builder.irBuildListOf(
+            env,
             ksContextMapping.starProjectedType,
             uniqueMappings
         )
@@ -102,22 +98,9 @@ class ContextBindingIrBuilder(
     }
 
     private fun buildMapping(bindingSymbol: IrClassSymbol): IrExpression {
-        return builder.irCallConstructor(
-            ksContextMapping.constructors.first(),
-            emptyList()
-        ).apply {
-            type = ksContextMapping.starProjectedType
-            putArgs(builder.irGetObject(bindingSymbol))
-        }
-    }
-
-    private fun buildListOf(
-        elementType: org.jetbrains.kotlin.ir.types.IrType,
-        items: List<IrExpression>
-    ): IrExpression = builder.irCall(env.listOfFunction).apply {
-        typeArguments[0] = elementType
-        val varargParameter = env.listOfFunction.owner.parameters
-            .single { it.kind == IrParameterKind.Regular }
-        arguments[varargParameter] = builder.irVararg(elementType, items)
+        return builder.irConstructOf(
+            ksContextMapping,
+            builder.irGetObject(bindingSymbol)
+        )
     }
 }

--- a/compiler/plugin/src/main/java/ErrorMappingIrBuilder.kt
+++ b/compiler/plugin/src/main/java/ErrorMappingIrBuilder.kt
@@ -20,10 +20,7 @@ package com.monkopedia.ksrpc.plugin
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.irCall
-import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irInt
-import org.jetbrains.kotlin.ir.builders.irVararg
-import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
@@ -31,7 +28,6 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.starProjectedType
 import org.jetbrains.kotlin.ir.types.typeWith
-import org.jetbrains.kotlin.ir.util.constructors
 
 /**
  * Builds IR that materializes the `@KsError(code, type)` annotations captured
@@ -63,7 +59,7 @@ class ErrorMappingIrBuilder(
     private val ksErrorMapping = env.ksErrorMapping!!
 
     fun buildErrorMappingList(errorAnnotations: List<IrConstructorCall>): IrExpression =
-        buildListOf(ksErrorMapping.starProjectedType, errorAnnotations.map { buildMapping(it) })
+        builder.irBuildListOf(env, ksErrorMapping.starProjectedType, errorAnnotations.map { buildMapping(it) })
 
     private fun buildMapping(annotation: IrConstructorCall): IrExpression {
         // Named-arg resolution: @KsError(code: Int, type: KClass<*>). The FIR/IR
@@ -88,26 +84,12 @@ class ErrorMappingIrBuilder(
             typeArguments[0] = errorType
             type = env.kSerializer.typeWith(errorType)
         }
-        return builder.irCallConstructor(
-            ksErrorMapping.constructors.first(),
-            emptyList()
-        ).apply {
-            type = ksErrorMapping.starProjectedType
-            putArgs(
-                builder.irInt(codeValue),
-                typeExpr,
-                serializerCall
-            )
-        }
+        return builder.irConstructOf(
+            ksErrorMapping,
+            builder.irInt(codeValue),
+            typeExpr,
+            serializerCall
+        )
     }
 
-    private fun buildListOf(
-        elementType: org.jetbrains.kotlin.ir.types.IrType,
-        items: List<IrExpression>
-    ): IrExpression = builder.irCall(env.listOfFunction).apply {
-        typeArguments[0] = elementType
-        val varargParameter = env.listOfFunction.owner.parameters
-            .single { it.kind == IrParameterKind.Regular }
-        arguments[varargParameter] = builder.irVararg(elementType, items)
-    }
 }

--- a/compiler/plugin/src/main/java/IntrospectionGeneration.kt
+++ b/compiler/plugin/src/main/java/IntrospectionGeneration.kt
@@ -20,7 +20,6 @@ package com.monkopedia.ksrpc.plugin
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.builders.irBlockBody
-import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -59,17 +58,16 @@ class IntrospectionGeneration(
     private fun buildIntrospectionBody(function: IrSimpleFunction, cls: ServiceClass): IrBlockBody =
         context.irBuilder(function).irBlockBody {
             +irReturn(
-                irCallConstructor(env.introspectionConstructor, emptyList()).apply {
-                    putArgs(
-                        irGetObject(
-                            cls.irClass.companionObject()?.symbol ?: reportInternal(
-                                "companion is missing on " +
-                                    cls.irClass.kotlinFqName.asString() +
-                                    " — CompanionGeneration should have produced it"
-                            )
+                irConstructOf(
+                    env.introspectionImpl,
+                    irGetObject(
+                        cls.irClass.companionObject()?.symbol ?: reportInternal(
+                            "companion is missing on " +
+                                cls.irClass.kotlinFqName.asString() +
+                                " — CompanionGeneration should have produced it"
                         )
                     )
-                }
+                )
             )
         }
 

--- a/compiler/plugin/src/main/java/IrUtils.kt
+++ b/compiler/plugin/src/main/java/IrUtils.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irConcat
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
 import org.jetbrains.kotlin.ir.builders.irGet
@@ -44,6 +45,7 @@ import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrSymbolOwner
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
@@ -51,6 +53,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrStringConcatenationImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.starProjectedType
 import org.jetbrains.kotlin.ir.types.typeWith
@@ -273,4 +276,73 @@ internal fun IrBuilderWithScope.irListOfStrings(
         context.irBuiltIns.stringType,
         values.map { irString(it) }
     )
+}
+
+// ---------------------------------------------------------------------------
+// IR builder DSL helpers (issue #66)
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct an instance of [classSymbol] with no type arguments, setting [IrConstructorCall.type]
+ * to the class's star-projected type and passing [args] as positional value arguments.
+ *
+ * Covers the very common pattern:
+ * ```
+ * irCallConstructor(cls.constructors.first(), emptyList()).apply {
+ *     type = cls.starProjectedType
+ *     putArgs(a, b, c)
+ * }
+ * ```
+ */
+internal fun IrBuilderWithScope.irConstructOf(
+    classSymbol: IrClassSymbol,
+    vararg args: IrExpression
+): IrConstructorCall = irCallConstructor(
+    classSymbol.constructors.first(),
+    emptyList()
+).apply {
+    type = classSymbol.starProjectedType
+    putArgs(*args)
+}
+
+/**
+ * Construct an instance of [classSymbol] with the given [typeArguments], setting
+ * [IrConstructorCall.type] to `classSymbol.typeWith(typeArguments)` and passing [args]
+ * as positional value arguments.
+ *
+ * Covers the pattern:
+ * ```
+ * irCallConstructor(cls.constructors.first(), typeArgs).apply {
+ *     type = cls.typeWith(typeArgs)
+ *     putArgs(a, b, c)
+ * }
+ * ```
+ */
+internal fun IrBuilderWithScope.irConstructOf(
+    classSymbol: IrClassSymbol,
+    typeArguments: List<IrType>,
+    vararg args: IrExpression
+): IrConstructorCall = irCallConstructor(
+    classSymbol.constructors.first(),
+    typeArguments
+).apply {
+    type = classSymbol.typeWith(typeArguments)
+    putArgs(*args)
+}
+
+/**
+ * Emit a `listOf<E>(items...)` IR expression via the vararg overload of
+ * `kotlin.collections.listOf`. Shared by [ErrorMappingIrBuilder],
+ * [ContextBindingIrBuilder], and [MetadataIrBuilder] which all need to
+ * materialize `List<X>` at runtime.
+ */
+internal fun IrBuilderWithScope.irBuildListOf(
+    env: KsrpcGenerationEnvironment,
+    elementType: IrType,
+    items: List<IrExpression>
+): IrExpression = irCall(env.listOfFunction).apply {
+    typeArguments[0] = elementType
+    val varargParameter = env.listOfFunction.owner.parameters
+        .single { it.kind == IrParameterKind.Regular }
+    arguments[varargParameter] = irVararg(elementType, items)
 }

--- a/compiler/plugin/src/main/java/MetadataIrBuilder.kt
+++ b/compiler/plugin/src/main/java/MetadataIrBuilder.kt
@@ -21,11 +21,9 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.irBoolean
 import org.jetbrains.kotlin.ir.builders.irCall
-import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irInt
 import org.jetbrains.kotlin.ir.builders.irLong
 import org.jetbrains.kotlin.ir.builders.irString
-import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConst
@@ -74,10 +72,8 @@ class MetadataIrBuilder(
     private val metadataValueType = metadataValue.starProjectedType
     private val pairType = pair.typeWith(stringType, metadataValueType)
 
-    fun buildMetadataList(metadataAnnotations: List<IrConstructorCall>): IrExpression = buildListOf(
-        methodMetadata.starProjectedType,
-        metadataAnnotations.map { buildMetadata(it) }
-    )
+    fun buildMetadataList(metadataAnnotations: List<IrConstructorCall>): IrExpression =
+        builder.irBuildListOf(env, methodMetadata.starProjectedType, metadataAnnotations.map { buildMetadata(it) })
 
     private fun buildMetadata(annotation: IrConstructorCall): IrExpression {
         val annotationFqName = annotation.type.classFqName?.asString()
@@ -110,20 +106,15 @@ class MetadataIrBuilder(
             pairs.add(buildPair(name, value))
         }
 
-        return builder.irCallConstructor(
-            methodMetadata.constructors.first(),
-            emptyList()
-        ).apply {
-            type = methodMetadata.starProjectedType
-            putArgs(
-                builder.irString(annotationFqName),
-                buildPairsList(pairs)
-            )
-        }
+        return builder.irConstructOf(
+            methodMetadata,
+            builder.irString(annotationFqName),
+            buildPairsList(pairs)
+        )
     }
 
     private fun buildPairsList(pairs: List<IrExpression>): IrExpression =
-        buildListOf(pairType, pairs)
+        builder.irBuildListOf(env, pairType, pairs)
 
     private fun buildPair(name: String, value: IrExpression): IrExpression =
         builder.irCall(toFunction).apply {
@@ -179,23 +170,12 @@ class MetadataIrBuilder(
                 val itemExpr = element as? IrExpression ?: return@mapNotNull null
                 buildMetadataValue(itemExpr)
             }
-            ctor(env.metadataValueList!!, buildListOf(metadataValueType, items))
+            ctor(env.metadataValueList!!, builder.irBuildListOf(env, metadataValueType, items))
         }
 
         else -> null
     }
 
-    private fun buildListOf(elementType: IrType, items: List<IrExpression>): IrExpression =
-        builder.irCall(env.listOfFunction).apply {
-            typeArguments[0] = elementType
-            val varargParameter = env.listOfFunction.owner.parameters
-                .single { it.kind == IrParameterKind.Regular }
-            arguments[varargParameter] = builder.irVararg(elementType, items)
-        }
-
     private fun ctor(symbol: IrClassSymbol, vararg args: IrExpression): IrExpression =
-        builder.irCallConstructor(symbol.constructors.first(), emptyList()).apply {
-            type = symbol.starProjectedType
-            putArgs(*args)
-        }
+        builder.irConstructOf(symbol, *args)
 }

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -354,12 +354,10 @@ internal class GenericMethodIrBuilder(
                 )
                 // Fall back to `Unit` serializer transformer so codegen doesn't crash
                 // after reporting the diagnostic.
-                return builder.irCallConstructor(
-                    env.serializerTransformer.constructors.first(),
+                return builder.irConstructOf(
+                    env.serializerTransformer,
                     listOf(context.irBuiltIns.unitType)
-                ).apply {
-                    this.type = env.serializerTransformer.typeWith(context.irBuiltIns.unitType)
-                }
+                )
             }
             return builder.irGetObject(transformer)
         }
@@ -388,21 +386,17 @@ internal class GenericMethodIrBuilder(
                 serializerFields,
                 method
             )
-            return builder.irCallConstructor(
-                env.subserviceTransformer.constructors.first(),
-                listOf(type)
-            ).apply {
-                this.type = env.subserviceTransformer.typeWith(type)
-                putArgs(rpcObjectExpr)
-            }
+            return builder.irConstructOf(
+                env.subserviceTransformer,
+                listOf(type),
+                rpcObjectExpr
+            )
         }
-        return builder.irCallConstructor(
-            env.serializerTransformer.constructors.first(),
-            listOf(type)
-        ).apply {
-            this.type = env.serializerTransformer.typeWith(type)
-            putArgs(buildSerializer(builder, type, serializerReceiver, serializerFields, method))
-        }
+        return builder.irConstructOf(
+            env.serializerTransformer,
+            listOf(type),
+            buildSerializer(builder, type, serializerReceiver, serializerFields, method)
+        )
     }
 
     /** True iff [this] has `com.monkopedia.ksrpc.RpcService` anywhere in its supertype chain. */
@@ -774,12 +768,10 @@ internal class GenericMethodIrBuilder(
                 buildSerializer(builder, elementType, serializerReceiver, serializerFields, method)
             )
         }
-        return builder.irCallConstructor(
-            flowTransformerSymbol.constructors.first(),
-            listOf(elementType)
-        ).apply {
-            this.type = flowTransformerSymbol.typeWith(elementType)
-            putArgs(rpcObjectExpr)
-        }
+        return builder.irConstructOf(
+            flowTransformerSymbol,
+            listOf(elementType),
+            rpcObjectExpr
+        )
     }
 }

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -532,21 +532,17 @@ class StubGeneration(
 
         RpcType.FLOW -> buildFlowSubserviceTransformer(outputType, declarationIrBuilder)
 
-        RpcType.SERVICE -> declarationIrBuilder.irCallConstructor(
-            env.subserviceTransformer.constructors.first(),
-            listOf(outputType)
-        ).apply {
-            type = env.subserviceTransformer.typeWith(outputType)
-            putArgs(buildNonGenericSubserviceRpcObject(outputType, declarationIrBuilder))
-        }
+        RpcType.SERVICE -> declarationIrBuilder.irConstructOf(
+            env.subserviceTransformer,
+            listOf(outputType),
+            buildNonGenericSubserviceRpcObject(outputType, declarationIrBuilder)
+        )
 
-        else -> declarationIrBuilder.irCallConstructor(
-            env.serializerTransformer.constructors.first(),
-            listOf(outputType)
-        ).apply {
-            type = env.serializerTransformer.typeWith(outputType)
-            putArgs(getSerializer(declarationIrBuilder, outputType))
-        }
+        else -> declarationIrBuilder.irConstructOf(
+            env.serializerTransformer,
+            listOf(outputType),
+            getSerializer(declarationIrBuilder, outputType)
+        )
     }
 
     /**
@@ -585,13 +581,11 @@ class StubGeneration(
             ksFlowServiceSymbol,
             elementType
         )
-        return declarationIrBuilder.irCallConstructor(
-            flowTransformerSymbol.constructors.first(),
-            listOf(elementType)
-        ).apply {
-            type = flowTransformerSymbol.typeWith(elementType)
-            putArgs(rpcObjectExpr)
-        }
+        return declarationIrBuilder.irConstructOf(
+            flowTransformerSymbol,
+            listOf(elementType),
+            rpcObjectExpr
+        )
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `irConstructOf(classSymbol, ...)` and `irBuildListOf(env, elementType, items)` helper functions to `IrUtils.kt`, wrapping the two most common IR-construction patterns in the compiler plugin
- Migrate 14 call sites across 6 files: `ErrorMappingIrBuilder`, `ContextBindingIrBuilder`, `MetadataIrBuilder`, `IntrospectionGeneration`, `ObjGeneration`, and `StubGeneration`
- Eliminate three identical private `buildListOf` implementations that were copy-pasted across the IR builder classes

## Test plan
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:test` — all compiler plugin tests pass
- [x] `./gradlew jvmTest` — all JVM tests pass (exercises generated code end-to-end)
- [x] `./gradlew apiCheck` — zero BCV API diff (pure internal refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)