### PR TITLE
Fix #92: carry type arguments through RpcDataType.Service for generic sub-services

### DIFF
--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -180,6 +180,12 @@ class KsrpcGenerationEnvironment(
         }
             ?: reportInternal("can't resolve kotlin.collections.listOf (vararg overload)")
 
+    val emptyListFunction =
+        context.referenceFunctions(
+            CallableId(FqName("kotlin.collections"), Name.identifier("emptyList"))
+        ).firstOrNull()
+            ?: reportInternal("can't resolve kotlin.collections.emptyList")
+
     // Error-binding (#77) support is optional so the compiler plugin continues
     // to work against older ksrpc-core artifacts that predate the `KsErrorMapping`
     // type. When unresolved, the plugin does not emit the seventh constructor

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -44,6 +44,7 @@ import org.jetbrains.kotlin.ir.builders.irImplicitCast
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.builders.irWhen
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
@@ -63,6 +64,7 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.isMarkedNullable
+import org.jetbrains.kotlin.ir.types.starProjectedType
 import org.jetbrains.kotlin.ir.types.makeNotNull
 import org.jetbrains.kotlin.ir.types.typeOrFail
 import org.jetbrains.kotlin.ir.types.typeOrNull
@@ -386,10 +388,18 @@ internal class GenericMethodIrBuilder(
                 serializerFields,
                 method
             )
+            val typeArgSerializersList = buildTypeArgSerializersList(
+                builder,
+                type,
+                serializerReceiver,
+                serializerFields,
+                method
+            )
             return builder.irConstructOf(
                 env.subserviceTransformer,
                 listOf(type),
-                rpcObjectExpr
+                rpcObjectExpr,
+                typeArgSerializersList
             )
         }
         return builder.irConstructOf(
@@ -715,6 +725,46 @@ internal class GenericMethodIrBuilder(
         }
     }
 
+    /**
+     * Emit a `listOf<KSerializer<*>>(ser0, ser1, ...)` IR expression for the type arguments
+     * of a sub-service type. For non-generic sub-services returns `emptyList()`.
+     * Serializers are composed recursively via [buildSerializer] so they can reference
+     * the outer service's type parameters.
+     */
+    private fun buildTypeArgSerializersList(
+        builder: IrBuilderWithScope,
+        type: IrType,
+        serializerReceiver: IrValueParameter,
+        serializerFields: List<IrField>,
+        method: IrSimpleFunction
+    ): IrExpression {
+        val simple = type as? IrSimpleType
+        val typeArgs = simple?.arguments?.mapNotNull { it.typeOrNull } ?: emptyList()
+        if (typeArgs.isEmpty()) {
+            return builder.irCall(env.emptyListFunction).apply {
+                typeArguments[0] = env.kSerializer.starProjectedType
+                this.type = context.irBuiltIns.listClass.typeWith(
+                    env.kSerializer.starProjectedType
+                )
+            }
+        }
+        val serializerExprs = typeArgs.map { argType ->
+            buildSerializer(builder, argType, serializerReceiver, serializerFields, method)
+        }
+        return builder.irCall(env.listOfFunction).apply {
+            typeArguments[0] = env.kSerializer.starProjectedType
+            val varargParameter = env.listOfFunction.owner.parameters
+                .single { it.kind == org.jetbrains.kotlin.ir.declarations.IrParameterKind.Regular }
+            arguments[varargParameter] = builder.irVararg(
+                env.kSerializer.starProjectedType,
+                serializerExprs
+            )
+            this.type = context.irBuiltIns.listClass.typeWith(
+                env.kSerializer.starProjectedType
+            )
+        }
+    }
+
     fun buildExecutor(referencedFunction: IrSimpleFunction, container: IrClass): IrClass =
         context.buildAnonymousServiceExecutor(env, referencedFunction, container)
 
@@ -768,10 +818,13 @@ internal class GenericMethodIrBuilder(
                 buildSerializer(builder, elementType, serializerReceiver, serializerFields, method)
             )
         }
+        val elementSerializerExpr =
+            buildSerializer(builder, elementType, serializerReceiver, serializerFields, method)
         return builder.irConstructOf(
             flowTransformerSymbol,
             listOf(elementType),
-            rpcObjectExpr
+            rpcObjectExpr,
+            elementSerializerExpr
         )
     }
 }

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -49,6 +49,7 @@ import org.jetbrains.kotlin.ir.builders.irImplicitCast
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
@@ -535,7 +536,8 @@ class StubGeneration(
         RpcType.SERVICE -> declarationIrBuilder.irConstructOf(
             env.subserviceTransformer,
             listOf(outputType),
-            buildNonGenericSubserviceRpcObject(outputType, declarationIrBuilder)
+            buildNonGenericSubserviceRpcObject(outputType, declarationIrBuilder),
+            buildTypeArgSerializersList(outputType, declarationIrBuilder)
         )
 
         else -> declarationIrBuilder.irConstructOf(
@@ -581,10 +583,12 @@ class StubGeneration(
             ksFlowServiceSymbol,
             elementType
         )
+        val elementSerializerExpr = getSerializer(declarationIrBuilder, elementType)
         return declarationIrBuilder.irConstructOf(
             flowTransformerSymbol,
             listOf(elementType),
-            rpcObjectExpr
+            rpcObjectExpr,
+            elementSerializerExpr
         )
     }
 
@@ -648,6 +652,39 @@ class StubGeneration(
             this.type = objClass.typeWith(typeArgs)
             val serArgs = typeArgs.map { getSerializer(builder, it) }.toTypedArray()
             putArgs(*serArgs)
+        }
+    }
+
+    /**
+     * Emit a `listOf<KSerializer<*>>(ser0, ser1, ...)` IR expression for the type arguments
+     * of a sub-service type. For non-generic sub-services returns `emptyList()`.
+     */
+    private fun buildTypeArgSerializersList(
+        type: IrType,
+        builder: DeclarationIrBuilder
+    ): IrExpression {
+        val simple = type as? org.jetbrains.kotlin.ir.types.IrSimpleType
+        val typeArgs = simple?.arguments?.mapNotNull { it.typeOrFail } ?: emptyList()
+        if (typeArgs.isEmpty()) {
+            return builder.irCall(env.emptyListFunction).apply {
+                typeArguments[0] = env.kSerializer.starProjectedType
+                this.type = context.irBuiltIns.listClass.typeWith(
+                    env.kSerializer.starProjectedType
+                )
+            }
+        }
+        val serializerExprs = typeArgs.map { getSerializer(builder, it) }
+        return builder.irCall(env.listOfFunction).apply {
+            typeArguments[0] = env.kSerializer.starProjectedType
+            val varargParameter = env.listOfFunction.owner.parameters
+                .single { it.kind == org.jetbrains.kotlin.ir.declarations.IrParameterKind.Regular }
+            arguments[varargParameter] = builder.irVararg(
+                env.kSerializer.starProjectedType,
+                serializerExprs
+            )
+            this.type = context.irBuiltIns.listClass.typeWith(
+                env.kSerializer.starProjectedType
+            )
         }
     }
 

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -3,6 +3,7 @@ public abstract class com/monkopedia/ksrpc/BaseSubserviceTransformer : com/monko
 	protected abstract fun fromService (Lcom/monkopedia/ksrpc/RpcService;)Ljava/lang/Object;
 	public fun getHasContent ()Z
 	public abstract fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
+	public fun getTypeArgSerializers ()Ljava/util/List;
 	protected abstract fun toService (Ljava/lang/Object;)Lcom/monkopedia/ksrpc/RpcService;
 	public fun transform (Ljava/lang/Object;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun untransform (Lcom/monkopedia/ksrpc/channels/CallData;Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -302,9 +303,11 @@ public final class com/monkopedia/ksrpc/ServiceNameKt {
 }
 
 public final class com/monkopedia/ksrpc/SubserviceTransformer : com/monkopedia/ksrpc/BaseSubserviceTransformer {
-	public fun <init> (Lcom/monkopedia/ksrpc/RpcObject;)V
+	public fun <init> (Lcom/monkopedia/ksrpc/RpcObject;Ljava/util/List;)V
+	public synthetic fun <init> (Lcom/monkopedia/ksrpc/RpcObject;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun fromService (Lcom/monkopedia/ksrpc/RpcService;)Ljava/lang/Object;
 	public fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
+	public fun getTypeArgSerializers ()Ljava/util/List;
 	public synthetic fun toService (Ljava/lang/Object;)Lcom/monkopedia/ksrpc/RpcService;
 }
 

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -148,6 +148,8 @@ abstract class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?> com.monkop
 
     abstract val serviceObject // com.monkopedia.ksrpc/BaseSubserviceTransformer.serviceObject|{}serviceObject[0]
         abstract fun <get-serviceObject>(): com.monkopedia.ksrpc/RpcObject<#A> // com.monkopedia.ksrpc/BaseSubserviceTransformer.serviceObject.<get-serviceObject>|<get-serviceObject>(){}[0]
+    open val typeArgSerializers // com.monkopedia.ksrpc/BaseSubserviceTransformer.typeArgSerializers|{}typeArgSerializers[0]
+        open fun <get-typeArgSerializers>(): kotlin.collections/List<kotlinx.serialization/KSerializer<*>> // com.monkopedia.ksrpc/BaseSubserviceTransformer.typeArgSerializers.<get-typeArgSerializers>|<get-typeArgSerializers>(){}[0]
 
     abstract fun fromService(#A): #B // com.monkopedia.ksrpc/BaseSubserviceTransformer.fromService|fromService(1:0){}[0]
     abstract fun toService(#B): #A // com.monkopedia.ksrpc/BaseSubserviceTransformer.toService|toService(1:1){}[0]
@@ -182,10 +184,12 @@ final class <#A: com.monkopedia.ksrpc/RpcService, #B: kotlin/Any?, #C: kotlin/An
 }
 
 final class <#A: com.monkopedia.ksrpc/RpcService> com.monkopedia.ksrpc/SubserviceTransformer : com.monkopedia.ksrpc/BaseSubserviceTransformer<#A, #A> { // com.monkopedia.ksrpc/SubserviceTransformer|null[0]
-    constructor <init>(com.monkopedia.ksrpc/RpcObject<#A>) // com.monkopedia.ksrpc/SubserviceTransformer.<init>|<init>(com.monkopedia.ksrpc.RpcObject<1:0>){}[0]
+    constructor <init>(com.monkopedia.ksrpc/RpcObject<#A>, kotlin.collections/List<kotlinx.serialization/KSerializer<*>> = ...) // com.monkopedia.ksrpc/SubserviceTransformer.<init>|<init>(com.monkopedia.ksrpc.RpcObject<1:0>;kotlin.collections.List<kotlinx.serialization.KSerializer<*>>){}[0]
 
     final val serviceObject // com.monkopedia.ksrpc/SubserviceTransformer.serviceObject|{}serviceObject[0]
         final fun <get-serviceObject>(): com.monkopedia.ksrpc/RpcObject<#A> // com.monkopedia.ksrpc/SubserviceTransformer.serviceObject.<get-serviceObject>|<get-serviceObject>(){}[0]
+    final val typeArgSerializers // com.monkopedia.ksrpc/SubserviceTransformer.typeArgSerializers|{}typeArgSerializers[0]
+        final fun <get-typeArgSerializers>(): kotlin.collections/List<kotlinx.serialization/KSerializer<*>> // com.monkopedia.ksrpc/SubserviceTransformer.typeArgSerializers.<get-typeArgSerializers>|<get-typeArgSerializers>(){}[0]
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc.internal/ClientChannelContext : kotlin.coroutines/CoroutineContext.Element { // com.monkopedia.ksrpc.internal/ClientChannelContext|null[0]

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -134,6 +134,15 @@ object BinaryTransformer :
 abstract class BaseSubserviceTransformer<T : RpcService, O> : Transformer<O> {
     abstract val serviceObject: RpcObject<T>
 
+    /**
+     * Serializers for the type arguments of the sub-service, in declaration order.
+     * For example, `FlowSubserviceTransformer<Update>` returns the `KSerializer<Update>`.
+     * Non-generic sub-services return an empty list (the default).
+     *
+     * Used by introspection to populate [RpcDataType.Service.typeArgs].
+     */
+    open val typeArgSerializers: List<KSerializer<*>> get() = emptyList()
+
     protected abstract fun toService(value: O): T
     protected abstract fun fromService(service: T): O
 
@@ -156,7 +165,8 @@ abstract class BaseSubserviceTransformer<T : RpcService, O> : Transformer<O> {
 
 @OptIn(KsrpcInternal::class)
 class SubserviceTransformer<T : RpcService>(
-    override val serviceObject: RpcObject<T>
+    override val serviceObject: RpcObject<T>,
+    override val typeArgSerializers: List<KSerializer<*>> = emptyList()
 ) : BaseSubserviceTransformer<T, T>() {
     override fun toService(value: T): T = value
     override fun fromService(service: T): T = service

--- a/ksrpc-flow/api/ksrpc-flow.api
+++ b/ksrpc-flow/api/ksrpc-flow.api
@@ -8,9 +8,11 @@ public final class com/monkopedia/ksrpc/flow/AutoClosingFlow : kotlinx/coroutine
 }
 
 public final class com/monkopedia/ksrpc/flow/FlowSubserviceTransformer : com/monkopedia/ksrpc/BaseSubserviceTransformer {
-	public fun <init> (Lcom/monkopedia/ksrpc/RpcObject;)V
+	public fun <init> (Lcom/monkopedia/ksrpc/RpcObject;Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun <init> (Lcom/monkopedia/ksrpc/RpcObject;Lkotlinx/serialization/KSerializer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun fromService (Lcom/monkopedia/ksrpc/RpcService;)Ljava/lang/Object;
 	public fun getServiceObject ()Lcom/monkopedia/ksrpc/RpcObject;
+	public fun getTypeArgSerializers ()Ljava/util/List;
 	public synthetic fun toService (Ljava/lang/Object;)Lcom/monkopedia/ksrpc/RpcService;
 }
 

--- a/ksrpc-flow/api/ksrpc-flow.klib.api
+++ b/ksrpc-flow/api/ksrpc-flow.klib.api
@@ -113,10 +113,12 @@ final class <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/AutoClosingFlow : kotlin
 }
 
 final class <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/FlowSubserviceTransformer : com.monkopedia.ksrpc/BaseSubserviceTransformer<com.monkopedia.ksrpc.flow/KsFlowService<#A>, kotlinx.coroutines.flow/Flow<#A>> { // com.monkopedia.ksrpc.flow/FlowSubserviceTransformer|null[0]
-    constructor <init>(com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowService<#A>>) // com.monkopedia.ksrpc.flow/FlowSubserviceTransformer.<init>|<init>(com.monkopedia.ksrpc.RpcObject<com.monkopedia.ksrpc.flow.KsFlowService<1:0>>){}[0]
+    constructor <init>(com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowService<#A>>, kotlinx.serialization/KSerializer<#A>? = ...) // com.monkopedia.ksrpc.flow/FlowSubserviceTransformer.<init>|<init>(com.monkopedia.ksrpc.RpcObject<com.monkopedia.ksrpc.flow.KsFlowService<1:0>>;kotlinx.serialization.KSerializer<1:0>?){}[0]
 
     final val serviceObject // com.monkopedia.ksrpc.flow/FlowSubserviceTransformer.serviceObject|{}serviceObject[0]
         final fun <get-serviceObject>(): com.monkopedia.ksrpc/RpcObject<com.monkopedia.ksrpc.flow/KsFlowService<#A>> // com.monkopedia.ksrpc.flow/FlowSubserviceTransformer.serviceObject.<get-serviceObject>|<get-serviceObject>(){}[0]
+    final val typeArgSerializers // com.monkopedia.ksrpc.flow/FlowSubserviceTransformer.typeArgSerializers|{}typeArgSerializers[0]
+        final fun <get-typeArgSerializers>(): kotlin.collections/List<kotlinx.serialization/KSerializer<*>> // com.monkopedia.ksrpc.flow/FlowSubserviceTransformer.typeArgSerializers.<get-typeArgSerializers>|<get-typeArgSerializers>(){}[0]
 }
 
 final fun <#A: kotlin/Any?> (kotlinx.coroutines.flow/Flow<#A>).com.monkopedia.ksrpc.flow/asKsFlow(): com.monkopedia.ksrpc.flow/KsFlowService<#A> // com.monkopedia.ksrpc.flow/asKsFlow|asKsFlow@kotlinx.coroutines.flow.Flow<0:0>(){0§<kotlin.Any?>}[0]

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/FlowSubserviceTransformer.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/FlowSubserviceTransformer.kt
@@ -47,8 +47,11 @@ import kotlinx.coroutines.flow.Flow
 @OptIn(KsrpcInternal::class)
 @KsrpcInternal
 class FlowSubserviceTransformer<T>(
-    override val serviceObject: RpcObject<KsFlowService<T>>
+    override val serviceObject: RpcObject<KsFlowService<T>>,
+    private val elementSerializer: kotlinx.serialization.KSerializer<T>? = null
 ) : BaseSubserviceTransformer<KsFlowService<T>, Flow<T>>() {
+    override val typeArgSerializers: List<kotlinx.serialization.KSerializer<*>>
+        get() = listOfNotNull(elementSerializer)
     override fun toService(value: Flow<T>): KsFlowService<T> = if (value is KsFlowService<*>) {
         @Suppress("UNCHECKED_CAST")
         value as KsFlowService<T>

--- a/ksrpc-introspection/api/ksrpc-introspection.api
+++ b/ksrpc-introspection/api/ksrpc-introspection.api
@@ -133,12 +133,15 @@ public final class com/monkopedia/ksrpc/RpcDataType$DataStructure$Companion {
 
 public final class com/monkopedia/ksrpc/RpcDataType$Service : com/monkopedia/ksrpc/RpcDataType {
 	public static final field Companion Lcom/monkopedia/ksrpc/RpcDataType$Service$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcDataType$Service;
-	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/RpcDataType$Service;Ljava/lang/String;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/RpcDataType$Service;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/monkopedia/ksrpc/RpcDataType$Service;
+	public static synthetic fun copy$default (Lcom/monkopedia/ksrpc/RpcDataType$Service;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/monkopedia/ksrpc/RpcDataType$Service;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getQualifiedName ()Ljava/lang/String;
+	public final fun getTypeArgs ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/ksrpc-introspection/api/ksrpc-introspection.klib.api
+++ b/ksrpc-introspection/api/ksrpc-introspection.klib.api
@@ -186,13 +186,16 @@ sealed class com.monkopedia.ksrpc/RpcDataType { // com.monkopedia.ksrpc/RpcDataT
     }
 
     final class Service : com.monkopedia.ksrpc/RpcDataType { // com.monkopedia.ksrpc/RpcDataType.Service|null[0]
-        constructor <init>(kotlin/String) // com.monkopedia.ksrpc/RpcDataType.Service.<init>|<init>(kotlin.String){}[0]
+        constructor <init>(kotlin/String, kotlin.collections/List<com.monkopedia.ksrpc/RpcDataType> = ...) // com.monkopedia.ksrpc/RpcDataType.Service.<init>|<init>(kotlin.String;kotlin.collections.List<com.monkopedia.ksrpc.RpcDataType>){}[0]
 
         final val qualifiedName // com.monkopedia.ksrpc/RpcDataType.Service.qualifiedName|{}qualifiedName[0]
             final fun <get-qualifiedName>(): kotlin/String // com.monkopedia.ksrpc/RpcDataType.Service.qualifiedName.<get-qualifiedName>|<get-qualifiedName>(){}[0]
+        final val typeArgs // com.monkopedia.ksrpc/RpcDataType.Service.typeArgs|{}typeArgs[0]
+            final fun <get-typeArgs>(): kotlin.collections/List<com.monkopedia.ksrpc/RpcDataType> // com.monkopedia.ksrpc/RpcDataType.Service.typeArgs.<get-typeArgs>|<get-typeArgs>(){}[0]
 
         final fun component1(): kotlin/String // com.monkopedia.ksrpc/RpcDataType.Service.component1|component1(){}[0]
-        final fun copy(kotlin/String = ...): com.monkopedia.ksrpc/RpcDataType.Service // com.monkopedia.ksrpc/RpcDataType.Service.copy|copy(kotlin.String){}[0]
+        final fun component2(): kotlin.collections/List<com.monkopedia.ksrpc/RpcDataType> // com.monkopedia.ksrpc/RpcDataType.Service.component2|component2(){}[0]
+        final fun copy(kotlin/String = ..., kotlin.collections/List<com.monkopedia.ksrpc/RpcDataType> = ...): com.monkopedia.ksrpc/RpcDataType.Service // com.monkopedia.ksrpc/RpcDataType.Service.copy|copy(kotlin.String;kotlin.collections.List<com.monkopedia.ksrpc.RpcDataType>){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.ksrpc/RpcDataType.Service.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // com.monkopedia.ksrpc/RpcDataType.Service.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // com.monkopedia.ksrpc/RpcDataType.Service.toString|toString(){}[0]
@@ -207,6 +210,8 @@ sealed class com.monkopedia.ksrpc/RpcDataType { // com.monkopedia.ksrpc/RpcDataT
         }
 
         final object Companion { // com.monkopedia.ksrpc/RpcDataType.Service.Companion|null[0]
+            final val $childSerializers // com.monkopedia.ksrpc/RpcDataType.Service.Companion.$childSerializers|{}$childSerializers[0]
+
             final fun serializer(): kotlinx.serialization/KSerializer<com.monkopedia.ksrpc/RpcDataType.Service> // com.monkopedia.ksrpc/RpcDataType.Service.Companion.serializer|serializer(){}[0]
         }
     }

--- a/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/RpcEndpointInfo.kt
+++ b/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/RpcEndpointInfo.kt
@@ -60,7 +60,10 @@ sealed class RpcDataType {
     object BinaryData : RpcDataType()
 
     @Serializable
-    data class Service(val qualifiedName: String) : RpcDataType()
+    data class Service(
+        val qualifiedName: String,
+        val typeArgs: List<RpcDataType> = emptyList()
+    ) : RpcDataType()
 }
 
 /**
@@ -161,8 +164,13 @@ internal val Transformer<*>.rpcDataType: RpcDataType
         // `KsFlowService<T>` sub-service. All such transformers expose the
         // underlying `RpcObject<T>` via `serviceObject`, so introspection can
         // recover the real sub-service name regardless of the user-facing
-        // wrapper shape.
-        is BaseSubserviceTransformer<*, *> -> RpcDataType.Service(serviceObject.serviceName)
+        // wrapper shape. Type arguments (if any) are derived from the
+        // transformer's `typeArgSerializers` so callers can see the full
+        // parameterization (e.g. `KsFlowService<Update>`).
+        is BaseSubserviceTransformer<*, *> -> RpcDataType.Service(
+            qualifiedName = serviceObject.serviceName,
+            typeArgs = typeArgSerializers.map { RpcDataType.DataStructure(it) }
+        )
 
         // Truly unknown transformer — fall back to the simple class name so
         // at least something is reported. Callers will not be able to

--- a/ksrpc-test/src/commonTest/kotlin/FlowIntrospectionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/FlowIntrospectionTest.kt
@@ -72,6 +72,25 @@ class FlowIntrospectionTest {
     }
 
     @Test
+    fun flowReturnEndpointInfoCarriesTypeArgs() = runBlockingUnit {
+        val channel = impl.serialized<FlowIntrospectionService, String>(ksrpcEnvironment { })
+        val stub = channel.toStub<FlowIntrospectionService, String>()
+        val introspection = stub.getIntrospection()
+        val info = introspection.getEndpointInfo("updates")
+        val output = info.output
+        assertTrue(
+            output is RpcDataType.Service,
+            "expected Flow<Update> to surface as RpcDataType.Service, got $output"
+        )
+        assertEquals(1, output.typeArgs.size, "expected 1 type arg for KsFlowService<Update>")
+        val typeArg = output.typeArgs[0]
+        assertTrue(
+            typeArg is RpcDataType.DataStructure,
+            "expected type arg to be DataStructure, got $typeArg"
+        )
+    }
+
+    @Test
     fun flowReturnGetIntrospectionForResolvesKsFlowService() = runBlockingUnit {
         val channel = impl.serialized<FlowIntrospectionService, String>(ksrpcEnvironment { })
         val stub = channel.toStub<FlowIntrospectionService, String>()

--- a/ksrpc-test/src/commonTest/kotlin/NestedGenericIntrospectionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/NestedGenericIntrospectionTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsIntrospectable
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.serialization.Serializable
+
+/**
+ * Tests for nested generic introspection chains:
+ * `OuterService<T> -> InnerService<T> -> Flow<T>`
+ *
+ * Verifies that type arguments propagate correctly through sub-service
+ * boundaries and that introspection reports the right typeArgs at each level.
+ *
+ * Uses concrete (non-generic) service interfaces that specialize generic
+ * parents, since generic @KsService companions are RpcObjectFactory (not
+ * RpcObject) and require concrete instantiation.
+ */
+class NestedGenericIntrospectionTest {
+
+    @Serializable
+    data class Update(val msg: String)
+
+    @KsService
+    @KsIntrospectable
+    interface StreamService : IntrospectableRpcService {
+        @KsMethod("/stream")
+        suspend fun stream(input: String): Flow<Update>
+    }
+
+    @KsService
+    @KsIntrospectable
+    interface NestedService : IntrospectableRpcService {
+        @KsMethod("/child")
+        suspend fun child(input: String): StreamService
+    }
+
+    private val streamImpl = object : StreamService {
+        override suspend fun stream(input: String): Flow<Update> = emptyFlow()
+    }
+
+    private val nestedImpl = object : NestedService {
+        override suspend fun child(input: String): StreamService = streamImpl
+    }
+
+    @Test
+    fun nestedServiceChildEndpointIsService() = runBlockingUnit {
+        val channel =
+            nestedImpl.serialized<NestedService, String>(ksrpcEnvironment { })
+        val stub = channel.toStub<NestedService, String>()
+        val introspection = stub.getIntrospection()
+        val info = introspection.getEndpointInfo("child")
+        val output = info.output
+        assertTrue(
+            output is RpcDataType.Service,
+            "expected /child output to be RpcDataType.Service, got $output"
+        )
+    }
+
+    @Test
+    fun streamEndpointHasFlowTypeArgs() = runBlockingUnit {
+        val channel =
+            streamImpl.serialized<StreamService, String>(ksrpcEnvironment { })
+        val stub = channel.toStub<StreamService, String>()
+        val introspection = stub.getIntrospection()
+        val info = introspection.getEndpointInfo("stream")
+        val output = info.output
+        assertTrue(
+            output is RpcDataType.Service,
+            "expected /stream output to be RpcDataType.Service (KsFlowService), got $output"
+        )
+        assertEquals(
+            "com.monkopedia.ksrpc.flow.KsFlowService",
+            output.qualifiedName,
+            "expected KsFlowService for Flow<Update>"
+        )
+        assertEquals(
+            1,
+            output.typeArgs.size,
+            "expected 1 type arg on KsFlowService<Update>, got ${output.typeArgs}"
+        )
+        val typeArg = output.typeArgs[0]
+        assertTrue(
+            typeArg is RpcDataType.DataStructure,
+            "expected type arg to be DataStructure for Update, got $typeArg"
+        )
+    }
+
+    @Test
+    fun nestedChainIntrospectionResolves() = runBlockingUnit {
+        val channel =
+            nestedImpl.serialized<NestedService, String>(ksrpcEnvironment { })
+        val stub = channel.toStub<NestedService, String>()
+        val introspection = stub.getIntrospection()
+
+        // Verify the child endpoint returns a Service type
+        val childInfo = introspection.getEndpointInfo("child")
+        val childOutput = childInfo.output
+        assertTrue(childOutput is RpcDataType.Service)
+
+        // Navigate to the child's introspection
+        val childIntrospection = introspection.getIntrospectionFor(childOutput.qualifiedName)
+        val streamInfo = childIntrospection.getEndpointInfo("stream")
+        val streamOutput = streamInfo.output
+
+        // The stream endpoint should be KsFlowService with Update type arg
+        assertTrue(
+            streamOutput is RpcDataType.Service,
+            "expected nested /stream to be RpcDataType.Service, got $streamOutput"
+        )
+        assertEquals(
+            "com.monkopedia.ksrpc.flow.KsFlowService",
+            streamOutput.qualifiedName
+        )
+        assertEquals(
+            1,
+            streamOutput.typeArgs.size,
+            "expected 1 type arg on nested KsFlowService<Update>"
+        )
+        assertTrue(
+            streamOutput.typeArgs[0] is RpcDataType.DataStructure,
+            "expected DataStructure for Update type arg"
+        )
+    }
+}

--- a/ksrpc-test/src/commonTest/kotlin/RpcServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcServiceTest.kt
@@ -240,6 +240,32 @@ class RpcServiceTest :
     }
 
     @Test
+    fun nonGenericSubserviceHasEmptyTypeArgs() = runBlockingUnit {
+        val channel =
+            testIntrospectionParentImpl.serialized<TestIntrospectionParent, String>(
+                ksrpcEnvironment {
+                }
+            )
+        val stub = channel.toStub<TestIntrospectionParent, String>()
+        val introspection = stub.getIntrospection()
+        val info = introspection.getEndpointInfo("child_service")
+        val output = info.output
+        assertTrue(
+            output is RpcDataType.Service,
+            "expected sub-service to surface as RpcDataType.Service, got $output"
+        )
+        assertEquals(
+            "com.monkopedia.ksrpc.TestIntrospectionChild",
+            output.qualifiedName
+        )
+        assertEquals(
+            emptyList(),
+            output.typeArgs,
+            "non-generic sub-service should have empty typeArgs"
+        )
+    }
+
+    @Test
     fun testIntrospectionForServiceMissing() = runBlockingUnit {
         val channel =
             testIntrospectionParentImpl.serialized<TestIntrospectionParent, String>(


### PR DESCRIPTION
## Summary
- Extends `RpcDataType.Service` with a `typeArgs: List<RpcDataType>` field (defaults to `emptyList()`) so introspection callers can discover the full parameterization of generic sub-services
- Adds `typeArgSerializers` open property to `BaseSubserviceTransformer`, overridden in `FlowSubserviceTransformer` and `SubserviceTransformer` to thread serializer info through
- Updates both compiler plugin codegen paths (StubGeneration for non-generic services, ObjGeneration/GenericMethodIrBuilder for generic services) to pass element serializers when constructing transformers
- Updates BCV API dumps for ksrpc-introspection, ksrpc-core, and ksrpc-flow

## Test plan
- [x] `flowReturnEndpointInfoCarriesTypeArgs` - verifies `Flow<Update>` surfaces as `RpcDataType.Service("KsFlowService", typeArgs=[DataStructure for Update])`
- [x] `nonGenericSubserviceHasEmptyTypeArgs` - verifies non-generic sub-service `TestIntrospectionChild` has empty `typeArgs`
- [x] All existing tests pass (JVM test suite + compiler plugin tests)
- [x] `apiCheck` passes after dump update

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)