### PR TITLE
Fix #128: expand SERVICE_WORKER test catalog

### DIFF
--- a/ksrpc-service-worker-test/src/commonMain/kotlin/com/monkopedia/ksrpc/webworker/test/WorkerTestServices.kt
+++ b/ksrpc-service-worker-test/src/commonMain/kotlin/com/monkopedia/ksrpc/webworker/test/WorkerTestServices.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc.webworker.test
+
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+
+/**
+ * Mirror of `TestInterface` from ksrpc-test. Defined here because the worker
+ * runs in a separate JS bundle that cannot access test source sets.
+ * The wire contract (endpoint name, serialization) must match exactly.
+ */
+@KsService
+interface WorkerTestInterface : RpcService {
+    @KsMethod("/rpc")
+    suspend fun rpc(u: Pair<String, String>): String
+}
+
+/**
+ * Mirror of `TestSubInterface` from ksrpc-test.
+ */
+@KsService
+interface WorkerTestSubInterface : RpcService {
+    @KsMethod("/rpc")
+    suspend fun rpc(u: Pair<String, String>): String
+}
+
+/**
+ * Mirror of `TestRootInterface` from ksrpc-test.
+ */
+@KsService
+interface WorkerTestRootInterface : RpcService {
+    @KsMethod("/rpc")
+    suspend fun rpc(u: Pair<String, String>): String
+
+    @KsMethod("/service")
+    suspend fun subservice(prefix: String): WorkerTestSubInterface
+}

--- a/ksrpc-service-worker-test/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/test/Main.kt
+++ b/ksrpc-service-worker-test/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/test/Main.kt
@@ -21,6 +21,7 @@ import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.channels.registerDefault
 import com.monkopedia.ksrpc.ksrpcEnvironment
+import com.monkopedia.ksrpc.serialized
 import com.monkopedia.ksrpc.webworker.onServiceWorkerConnection
 
 /**
@@ -31,6 +32,23 @@ import com.monkopedia.ksrpc.webworker.onServiceWorkerConnection
 private val serviceCatalog: Map<String, suspend (Connection<String>) -> Unit> = mapOf(
     "WebWorkerTestService" to { connection ->
         connection.registerDefault(WebWorkerTestServiceImpl("js"))
+    },
+    "TestInterface" to { connection ->
+        val service = object : WorkerTestInterface {
+            override suspend fun rpc(u: Pair<String, String>): String = "${u.first} ${u.second}"
+        }
+        connection.registerDefault(service.serialized(ksrpcEnvironment { }))
+    },
+    "TestRootInterface" to { connection ->
+        val service = object : WorkerTestRootInterface {
+            override suspend fun rpc(u: Pair<String, String>): String = "${u.first} ${u.second}"
+            override suspend fun subservice(prefix: String): WorkerTestSubInterface =
+                object : WorkerTestSubInterface {
+                    override suspend fun rpc(u: Pair<String, String>): String =
+                        "$prefix ${u.first} ${u.second}"
+                }
+        }
+        connection.registerDefault(service.serialized(ksrpcEnvironment { }))
     }
 )
 

--- a/ksrpc-test/src/commonTest/kotlin/RpcServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcServiceTest.kt
@@ -78,7 +78,7 @@ class RpcServiceTest :
                 stub.rpc("Hello" to "world")
             )
         },
-        workerServiceName = "WebWorkerTestService"
+        workerServiceName = "TestInterface"
     ) {
     @Test
     fun testCreateInfo() = runBlockingUnit {
@@ -310,7 +310,7 @@ class RpcServiceTwoCallsTest :
                 stub.rpc("Hello" to "world")
             )
         },
-        workerServiceName = "WebWorkerTestService"
+        workerServiceName = "TestInterface"
     )
 
 private var cancelSignal: CompletableDeferred<CompletableDeferred<Unit>>? = null

--- a/ksrpc-test/src/commonTest/kotlin/RpcSubserviceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcSubserviceTest.kt
@@ -61,7 +61,7 @@ class RpcSubserviceTest :
                 stub.subservice("oh,").rpc("Hello" to "world")
             )
         },
-        workerServiceName = "WebWorkerTestService"
+        workerServiceName = "TestRootInterface"
     ) {
     @Test
     fun testCreateInfo() = runBlockingUnit {
@@ -83,7 +83,7 @@ class RpcSubserviceTwoCallsTest :
                 stub.subservice("oh,").rpc("Hello" to "world")
             )
         },
-        workerServiceName = "WebWorkerTestService"
+        workerServiceName = "TestRootInterface"
     )
 
 private var closeCompletion: CompletableDeferred<Unit>? = null


### PR DESCRIPTION
## Summary
- Add `WorkerTestInterface`, `WorkerTestSubInterface`, `WorkerTestRootInterface` as wire-compatible mirrors of test interfaces (needed because the worker runs in a separate JS bundle)
- Register concrete implementations in the service catalog
- Update `RpcServiceTest`/`RpcServiceTwoCallsTest` to use `"TestInterface"` and `RpcSubserviceTest`/`RpcSubserviceTwoCallsTest` to use `"TestRootInterface"`

Fixes #128

## Test plan
- [ ] `./gradlew :ksrpc-service-worker-test:compileKotlinJs` compiles
- [ ] Browser tests with SERVICE_WORKER exercise the correct service shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)