### PR TITLE
Fix #131: support getIntrospection() on generic @KsService interfaces

### DIFF
--- a/compiler/plugin/src/main/java/IntrospectionGeneration.kt
+++ b/compiler/plugin/src/main/java/IntrospectionGeneration.kt
@@ -20,6 +20,8 @@ package com.monkopedia.ksrpc.plugin
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -28,8 +30,11 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.companionObject
+import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 
 class IntrospectionGeneration(
@@ -57,18 +62,50 @@ class IntrospectionGeneration(
 
     private fun buildIntrospectionBody(function: IrSimpleFunction, cls: ServiceClass): IrBlockBody =
         context.irBuilder(function).irBlockBody {
-            +irReturn(
-                irConstructOf(
-                    env.introspectionImpl,
-                    irGetObject(
-                        cls.irClass.companionObject()?.symbol ?: reportInternal(
-                            "companion is missing on " +
-                                cls.irClass.kotlinFqName.asString() +
-                                " — CompanionGeneration should have produced it"
-                        )
+            val rpcObjectExpr: IrExpression = if (cls.isGeneric) {
+                // For generic services the companion is an RpcObjectFactory, not an
+                // RpcObject. We construct the nested Obj class with dummy
+                // serializer<Any?>() args — introspection never performs actual
+                // (de)serialization, so the concrete serializers are irrelevant.
+                val objClass = cls.irClass.declarations
+                    .filterIsInstance<IrClass>()
+                    .firstOrNull { it.name == FqConstants.OBJ }
+                    ?: reportInternal(
+                        "missing generated Obj class on " +
+                            cls.irClass.kotlinFqName.asString() +
+                            " — FirKsrpcObjGenerator did not run"
+                    )
+                val objConstructor = objClass.constructors.first { it.isPrimary }
+                val arity = cls.irClass.typeParameters.size
+                // Use Unit as the dummy type argument — it is always
+                // @Serializable, unlike Any/Any? which have no serializer.
+                val unitType = context.irBuiltIns.unitType
+                val objTypeArgs = List(arity) { unitType }
+                val serializerFn = env.serializerMethod ?: reportInternal(
+                    "can't resolve kotlinx.serialization.serializer<T>() — " +
+                        "kotlinx-serialization-core must be on the compile classpath"
+                )
+                val dummySerializers = List(arity) {
+                    irCall(serializerFn).apply {
+                        typeArguments[0] = unitType
+                        type = env.kSerializer.typeWith(unitType)
+                    }
+                }
+                irCallConstructor(objConstructor.symbol, objTypeArgs).apply {
+                    type = objClass.typeWith(objTypeArgs)
+                    putArgs(*dummySerializers.toTypedArray())
+                }
+            } else {
+                // Non-generic: companion IS the RpcObject.
+                irGetObject(
+                    cls.irClass.companionObject()?.symbol ?: reportInternal(
+                        "companion is missing on " +
+                            cls.irClass.kotlinFqName.asString() +
+                            " — CompanionGeneration should have produced it"
                     )
                 )
-            )
+            }
+            +irReturn(irConstructOf(env.introspectionImpl, rpcObjectExpr))
         }
 
     override fun generateChildrenForClass(

--- a/ksrpc-test/src/commonTest/kotlin/NestedGenericIntrospectionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/NestedGenericIntrospectionTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
 
 /**
  * Tests for nested generic introspection chains:
@@ -32,9 +33,8 @@ import kotlinx.serialization.Serializable
  * Verifies that type arguments propagate correctly through sub-service
  * boundaries and that introspection reports the right typeArgs at each level.
  *
- * Uses concrete (non-generic) service interfaces that specialize generic
- * parents, since generic @KsService companions are RpcObjectFactory (not
- * RpcObject) and require concrete instantiation.
+ * Includes both concrete (non-generic) services and generic @KsService
+ * interfaces that call getIntrospection() directly (issue #131).
  */
 class NestedGenericIntrospectionTest {
 
@@ -53,6 +53,28 @@ class NestedGenericIntrospectionTest {
     interface NestedService : IntrospectableRpcService {
         @KsMethod("/child")
         suspend fun child(input: String): StreamService
+    }
+
+    /**
+     * Generic @KsService @KsIntrospectable interface — prior to issue #131 this
+     * would ClassCastException when calling getIntrospection() because the
+     * companion is an RpcObjectFactory, not an RpcObject.
+     */
+    @KsService
+    @KsIntrospectable
+    interface GenericInnerService<T> : IntrospectableRpcService {
+        @KsMethod("/echo")
+        suspend fun echo(input: T): T
+    }
+
+    /**
+     * Generic @KsService @KsIntrospectable with a Flow return type.
+     */
+    @KsService
+    @KsIntrospectable
+    interface GenericStreamService<T> : IntrospectableRpcService {
+        @KsMethod("/stream")
+        suspend fun stream(input: String): Flow<T>
     }
 
     private val streamImpl = object : StreamService {
@@ -140,6 +162,59 @@ class NestedGenericIntrospectionTest {
         assertTrue(
             streamOutput.typeArgs[0] is RpcDataType.DataStructure,
             "expected DataStructure for Update type arg"
+        )
+    }
+
+    // ---- Issue #131: generic @KsService @KsIntrospectable getIntrospection() ----
+
+    @Test
+    fun genericServiceIntrospectionReturnsEndpoints() = runBlockingUnit {
+        val impl = object : GenericInnerService<String> {
+            override suspend fun echo(input: String): String = input
+        }
+        val rpcObject = GenericInnerService(String.serializer())
+        val channel = impl.serialized(rpcObject, ksrpcEnvironment { })
+        val stub = rpcObject.createStub(channel)
+        val introspection = stub.getIntrospection()
+        val endpoints = introspection.getEndpoints()
+        assertTrue(
+            "echo" in endpoints,
+            "expected 'echo' in endpoints, got $endpoints"
+        )
+    }
+
+    @Test
+    fun genericServiceIntrospectionServiceName() = runBlockingUnit {
+        val impl = object : GenericInnerService<String> {
+            override suspend fun echo(input: String): String = input
+        }
+        val rpcObject = GenericInnerService(String.serializer())
+        val channel = impl.serialized(rpcObject, ksrpcEnvironment { })
+        val stub = rpcObject.createStub(channel)
+        val introspection = stub.getIntrospection()
+        val name = introspection.getServiceName()
+        assertEquals(
+            "com.monkopedia.ksrpc.NestedGenericIntrospectionTest.GenericInnerService",
+            name
+        )
+    }
+
+    @Test
+    fun genericStreamServiceIntrospection() = runBlockingUnit {
+        val impl = object : GenericStreamService<Update> {
+            override suspend fun stream(input: String): Flow<Update> = emptyFlow()
+        }
+        val rpcObject = GenericStreamService(Update.serializer())
+        val channel = impl.serialized(rpcObject, ksrpcEnvironment { })
+        val stub = rpcObject.createStub(channel)
+        val introspection = stub.getIntrospection()
+        val endpoints = introspection.getEndpoints()
+        assertTrue("stream" in endpoints, "expected 'stream' in endpoints, got $endpoints")
+        val info = introspection.getEndpointInfo("stream")
+        val output = info.output
+        assertTrue(
+            output is RpcDataType.Service,
+            "expected /stream output to be RpcDataType.Service (KsFlowService), got $output"
         )
     }
 }


### PR DESCRIPTION
## Summary
Generic `@KsService @KsIntrospectable` interfaces threw `ClassCastException` on `getIntrospection()` because the compiler plugin cast the companion to `RpcObject`, but generic services have an `RpcObjectFactory` companion.

Fix: for generic services, the plugin now constructs the nested `Obj<Unit, ...>` class with dummy `Unit` serializers. Introspection metadata (endpoint names, types) is type-arg-independent so this is safe.

Fixes #131

## Test plan
- [x] `genericServiceIntrospectionReturnsEndpoints` — getIntrospection() works on generic service
- [x] `genericServiceIntrospectionServiceName` — correct service name returned
- [x] `genericStreamServiceIntrospection` — works on generic service with Flow<T>
- [x] Existing non-generic introspection tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)