### PR TITLE
Fix #139: correct documentation code errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class GreetingServiceImpl : GreetingService {
 // Host over HTTP
 val env = ksrpcEnvironment { }
 embeddedServer(Netty, 8080) {
-    routing { serve("/api", GreetingServiceImpl(), env) }
+    routing { serveHttp("/api", GreetingServiceImpl(), env) }
 }.start()
 
 // Call from any platform

--- a/dokka/guides/bidirectional.md
+++ b/dokka/guides/bidirectional.md
@@ -15,14 +15,14 @@ Both provide `registerDefault` (host a service for incoming calls) and `defaultC
 
 ```kotlin
 val env = ksrpcEnvironment { }
-val connection = stdInConnection(env)
+withStdInOut(env) { connection ->
+    // Host a service for the remote side to call
+    connection.registerDefault(MyHostServiceImpl())
 
-// Host a service for the remote side to call
-connection.registerDefault(MyHostServiceImpl())
-
-// Get a stub for calling the remote side's service
-val remoteService = connection.defaultChannel().toStub<RemoteService>()
-val result = remoteService.someMethod("hello")
+    // Get a stub for calling the remote side's service
+    val remoteService = connection.defaultChannel().toStub<RemoteService>()
+    val result = remoteService.someMethod("hello")
+}
 ```
 
 ## The connect helper
@@ -30,18 +30,23 @@ val result = remoteService.someMethod("hello")
 The `connect<Host, Client>` extension combines `registerDefault` and `defaultChannel` into a single call. The lambda receives the client stub and returns the host service implementation:
 
 ```kotlin
-val connection = stdInConnection(env)
-connection.connect<MyHostService, MyClientService> { client ->
-    // client is a MyClientService stub for calling the remote side
-    MyHostServiceImpl(client) // returned value is registered as the hosted service
+withStdInOut(env) { connection ->
+    connection.connect<MyHostService, MyClientService> { client ->
+        // client is a MyClientService stub for calling the remote side
+        MyHostServiceImpl(client) // returned value is registered as the hosted service
+    }
 }
 ```
+
+The first type parameter is the service you host (returned by the lambda); the second is the remote service you call (passed into the lambda).
 
 This is equivalent to:
 
 ```kotlin
-val client = connection.defaultChannel().toStub<MyClientService>()
-connection.registerDefault(MyHostServiceImpl(client))
+withStdInOut(env) { connection ->
+    val client = connection.defaultChannel().toStub<MyClientService>()
+    connection.registerDefault(MyHostServiceImpl(client))
+}
 ```
 
 ## Sub-service callbacks

--- a/dokka/guides/flow-streaming.md
+++ b/dokka/guides/flow-streaming.md
@@ -12,7 +12,7 @@ Add the flow dependency:
 implementation("com.monkopedia.ksrpc:ksrpc-flow:$KSRPC_VERSION")
 ```
 
-Flow streaming requires a bidirectional transport (WebSockets, sockets, or service workers) because the flow protocol uses sub-services internally.
+> **Important**: Flow streaming requires a bidirectional transport (WebSockets, sockets, or service workers) because the flow protocol uses sub-services internally. HTTP does **not** support `Flow<T>` and will fail at runtime. If you need streaming over HTTP, consider a polling pattern or switch to a WebSocket transport.
 
 ## Using Flow in service signatures
 

--- a/dokka/guides/getting-started.md
+++ b/dokka/guides/getting-started.md
@@ -4,7 +4,7 @@
 
 ## Gradle setup
 
-Add the ksrpc compiler plugin and runtime dependency to your `build.gradle.kts`:
+Add the ksrpc compiler plugin and runtime dependency to your `build.gradle.kts`. Replace `$KSRPC_VERSION` with the latest release version from [Maven Central](https://search.maven.org/artifact/com.monkopedia.ksrpc/ksrpc-core) or [GitHub Releases](https://github.com/Monkopedia/ksrpc/releases):
 
 ```kotlin
 plugins {
@@ -113,15 +113,14 @@ suspend fun main() {
 All channels share a [`KsrpcEnvironment`](https://monkopedia.github.io/ksrpc/ksrpc-core/com.monkopedia.ksrpc/-ksrpc-environment/index.html) that holds the serialization format, default coroutine scope, and error handling:
 
 ```kotlin
-val env = ksrpcEnvironment {
-    serialization = Json {
-        encodeDefaults = true
-    }
+val env = ksrpcEnvironment(Json { encodeDefaults = true }) {
     errorListener = ErrorListener { t ->
         t.printStackTrace()
     }
 }
 ```
+
+The first argument to `ksrpcEnvironment` is a `StringFormat` (defaulting to `Json`). Custom serialization settings are passed there, not inside the builder block. The builder block configures other environment properties like `errorListener` and `logger`.
 
 See [`KsrpcEnvironment`](https://monkopedia.github.io/ksrpc/ksrpc-core/com.monkopedia.ksrpc/-ksrpc-environment/index.html) in the API docs for the full set of configurable fields.
 

--- a/dokka/guides/service-declaration.md
+++ b/dokka/guides/service-declaration.md
@@ -20,6 +20,8 @@ interface MyService : RpcService {
 
 The compiler plugin generates a companion [`RpcObject`](https://monkopedia.github.io/ksrpc/ksrpc-core/com.monkopedia.ksrpc/-rpc-object/index.html) that provides stub creation and serialization adapters. Any method on the interface that is not annotated with `@KsMethod` will produce a compiler warning.
 
+> **One-parameter limit**: `@KsMethod` functions may accept at most one parameter (plus the implicit receiver). To pass multiple values, wrap them in a `@Serializable` data class.
+
 The `@KsMethod` name is the wire-level identifier. It must be unique within a single service but does not need to be globally unique. Choose stable names -- renaming breaks wire compatibility.
 
 ## Primitive types
@@ -131,7 +133,7 @@ interface EntityService : RpcService {
     suspend fun getName(): String
 
     @KsMethod("/content")
-    suspend fun getContent(): RpcBinaryData
+    suspend fun getContent(): ByteReadChannel
 }
 
 @KsService

--- a/dokka/guides/transport-jsonrpc.md
+++ b/dokka/guides/transport-jsonrpc.md
@@ -79,6 +79,8 @@ interface MyLspService : RpcService {
 - Request/response correlation uses the JSON-RPC `id` field
 - Binary data is not supported (JSON-only wire format)
 
+> **Path convention**: JSON-RPC method names map verbatim to the wire. The conventional style for JSON-RPC is `namespace/method` without a leading `/` (e.g., `textDocument/completion`), while other ksrpc transports typically use `/path` style (e.g., `/greet`). Choose your `@KsMethod` names to match the protocol conventions of the transport you are targeting.
+
 ## Error mapping
 
 JSON-RPC errors use the standard `error` object with `code`, `message`, and optional `data` fields. ksrpc maps [`@KsError`](https://monkopedia.github.io/ksrpc/ksrpc-api/com.monkopedia.ksrpc.annotation/-ks-error/index.html) codes to JSON-RPC error codes. See the [error handling guide](error-handling.md) for details on defining custom error types.


### PR DESCRIPTION
## Summary
- Fix `serve()` to `serveHttp()` in README Quick Start to match actual API
- Replace nonexistent `stdInConnection(env)` with correct `withStdInOut(env) { }` block-scoped pattern in bidirectional guide
- Fix `ksrpcEnvironment { serialization = Json { } }` to correct `ksrpcEnvironment(Json { }) { }` form in getting-started guide
- Replace `RpcBinaryData` with `ByteReadChannel` in sub-services example (service-declaration guide)
- Add one-parameter constraint note for `@KsMethod` functions
- Document `connect<Host, Client>` type parameter ordering
- Emphasize that `Flow<T>` requires bidirectional transport (HTTP fails at runtime)
- Explain `$KSRPC_VERSION` placeholder
- Document JSON-RPC path naming convention

## Test plan
- [ ] Read through each modified file to verify examples are consistent
- [ ] Verify code examples match actual API signatures in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)