### PR TITLE
Fix #136: Use RpcObjectFactory for non-generic subtype companions

### DIFF
--- a/compiler/plugin/src/main/java/FirSubtypeCompanionGenerator.kt
+++ b/compiler/plugin/src/main/java/FirSubtypeCompanionGenerator.kt
@@ -34,12 +34,10 @@ import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.plugin.createCompanionObject
 import org.jetbrains.kotlin.fir.plugin.createConeType
 import org.jetbrains.kotlin.fir.plugin.createConstructor
-import org.jetbrains.kotlin.fir.plugin.createDefaultPrivateConstructor
 import org.jetbrains.kotlin.fir.plugin.createMemberFunction
 import org.jetbrains.kotlin.fir.plugin.createMemberProperty
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
-import org.jetbrains.kotlin.fir.scopes.impl.toConeType
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
@@ -255,7 +253,13 @@ class FirSubtypeCompanionGenerator(session: FirSession) :
         val isGeneric = regularOwner.typeParameterSymbols.isNotEmpty()
 
         return if (!isGeneric) {
-            // Scenario 1: non-generic subtype — companion implements RpcObject<Subtype>
+            // Scenario 1: non-generic subtype — companion implements RpcObjectFactory<Subtype>
+            // with arity 0. Using RpcObjectFactory instead of RpcObject avoids a JVM bridge-
+            // method ClassCastException: the parent's Stub class doesn't implement the subtype
+            // interface, so a direct RpcObject<Subtype>.createStub() would fail the checkcast
+            // inserted by the JVM bridge. With a factory, rpcObject<Subtype>() calls
+            // factory.create(emptyList()) which returns the parent's actual RpcObject whose
+            // createStub() returns the parent's Stub (no subtype checkcast). See issue #136.
             createCompanionObject(
                 owner,
                 Key(
@@ -264,7 +268,14 @@ class FirSubtypeCompanionGenerator(session: FirSession) :
                     isGeneric = false
                 )
             ) {
-                superType(RPC_OBJECT.createConeType(session, arrayOf(owner.defaultType())))
+                if (factorySupported) {
+                    superType(
+                        RPC_OBJECT_FACTORY.createConeType(
+                            session,
+                            arrayOf(owner.defaultType())
+                        )
+                    )
+                }
             }.symbol
         } else {
             // Scenario 2: generic subtype — companion implements RpcObjectFactory<Subtype<*,...>>
@@ -315,19 +326,7 @@ class FirSubtypeCompanionGenerator(session: FirSession) :
     ): List<FirNamedFunctionSymbol> {
         val ownerKey = context?.let(::checkOwnerKey) ?: return emptyList()
         return when (callableId.callableName) {
-            FqConstants.FIND_ENDPOINT -> if (!ownerKey.isGeneric) {
-                createFindEndpoint(callableId, context.owner, ownerKey)
-            } else {
-                emptyList()
-            }
-
-            FqConstants.CREATE_STUB -> if (!ownerKey.isGeneric) {
-                createCreateStub(callableId, context.owner, ownerKey)
-            } else {
-                emptyList()
-            }
-
-            CREATE -> if (ownerKey.isGeneric && factorySupported) {
+            CREATE -> if (factorySupported) {
                 createCreateFactory(callableId, context.owner, ownerKey)
             } else {
                 emptyList()
@@ -342,100 +341,15 @@ class FirSubtypeCompanionGenerator(session: FirSession) :
         context: MemberGenerationContext?
     ): List<FirPropertySymbol> {
         val ownerKey = context?.let(::checkOwnerKey) ?: return emptyList()
-        if (ownerKey.isGeneric) {
-            return when (callableId.callableName) {
-                FqConstants.ARITY -> if (factorySupported) {
-                    createArity(callableId, context.owner, ownerKey)
-                } else {
-                    emptyList()
-                }
-
-                else -> emptyList()
-            }
-        }
         return when (callableId.callableName) {
-            FqConstants.SERVICE_NAME -> createServiceName(callableId, context.owner, ownerKey)
-            FqConstants.ENDPOINTS -> createEndpoints(callableId, context.owner, ownerKey)
+            FqConstants.ARITY -> if (factorySupported) {
+                createArity(callableId, context.owner, ownerKey)
+            } else {
+                emptyList()
+            }
+
             else -> emptyList()
         }
-    }
-
-    private fun createCreateStub(
-        callableId: CallableId,
-        owner: FirClassSymbol<*>,
-        ownerKey: Key
-    ): List<FirNamedFunctionSymbol> {
-        val retType = ownerKey.subtypeClassId.createConeType(session)
-        val function =
-            createMemberFunction(owner, ownerKey, callableId.callableName, retType) {
-                modality = Modality.FINAL
-                typeParameter(Name.identifier("S"))
-                valueParameter(
-                    Name.identifier("channel"),
-                    { types ->
-                        FqConstants.SERIALIZED_SERVICE.createConeType(
-                            session,
-                            arrayOf(types[0].toConeType())
-                        )
-                    }
-                )
-            }
-        return listOf(function.symbol)
-    }
-
-    private fun createFindEndpoint(
-        callableId: CallableId,
-        owner: FirClassSymbol<*>,
-        ownerKey: Key
-    ): List<FirNamedFunctionSymbol> {
-        val retType =
-            FqConstants.RPC_METHOD.createConeType(session, Array(3) { ConeStarProjection })
-        val function = createMemberFunction(owner, ownerKey, callableId.callableName, retType) {
-            modality = Modality.FINAL
-            valueParameter(
-                Name.identifier("endpoint"),
-                session.builtinTypes.stringType.coneType
-            )
-        }
-        return listOf(function.symbol)
-    }
-
-    private fun createServiceName(
-        callableId: CallableId,
-        owner: FirClassSymbol<*>,
-        ownerKey: Key
-    ): List<FirPropertySymbol> {
-        val property = createMemberProperty(
-            owner,
-            ownerKey,
-            callableId.callableName,
-            session.builtinTypes.stringType.coneType,
-            isVal = true,
-            hasBackingField = false
-        ) {
-            modality = Modality.FINAL
-        }
-        return listOf(property.symbol)
-    }
-
-    private fun createEndpoints(
-        callableId: CallableId,
-        owner: FirClassSymbol<*>,
-        ownerKey: Key
-    ): List<FirPropertySymbol> {
-        val listType = LIST_CLASS_ID
-            .createConeType(session, arrayOf(session.builtinTypes.stringType.coneType))
-        val property = createMemberProperty(
-            owner,
-            ownerKey,
-            callableId.callableName,
-            listType,
-            isVal = true,
-            hasBackingField = false
-        ) {
-            modality = Modality.FINAL
-        }
-        return listOf(property.symbol)
     }
 
     private fun createArity(
@@ -469,12 +383,21 @@ class FirSubtypeCompanionGenerator(session: FirSession) :
                 as? FirRegularClassSymbol
                 ?: return emptyList()
         val subtypeTypeParams = subtypeSymbol.typeParameterSymbols
-        if (subtypeTypeParams.isEmpty()) return emptyList()
-        val starProjections = Array<org.jetbrains.kotlin.fir.types.ConeTypeProjection>(
-            subtypeTypeParams.size
-        ) { ConeStarProjection }
-        val subtypeStarType = ownerKey.subtypeClassId.createConeType(session, starProjections)
-        val retType = RPC_OBJECT.createConeType(session, arrayOf(subtypeStarType))
+        val retType = if (subtypeTypeParams.isEmpty()) {
+            // Non-generic subtype: RpcObject<Subtype>
+            RPC_OBJECT.createConeType(
+                session,
+                arrayOf(ownerKey.subtypeClassId.createConeType(session))
+            )
+        } else {
+            // Generic subtype: RpcObject<Subtype<*,...>>
+            val starProjections = Array<org.jetbrains.kotlin.fir.types.ConeTypeProjection>(
+                subtypeTypeParams.size
+            ) { ConeStarProjection }
+            val subtypeStarType =
+                ownerKey.subtypeClassId.createConeType(session, starProjections)
+            RPC_OBJECT.createConeType(session, arrayOf(subtypeStarType))
+        }
         val listOfKType =
             LIST_CLASS_ID.createConeType(session, arrayOf(KTYPE.createConeType(session)))
         val function = createMemberFunction(owner, ownerKey, callableId.callableName, retType) {
@@ -501,20 +424,10 @@ class FirSubtypeCompanionGenerator(session: FirSession) :
 
         val origin = classSymbol.origin as? FirDeclarationOrigin.Plugin
         val key = origin?.key as? Key ?: return emptySet()
-        return if (key.isGeneric) {
-            if (factorySupported) {
-                setOf(CREATE, FqConstants.ARITY, SpecialNames.INIT)
-            } else {
-                setOf(SpecialNames.INIT)
-            }
+        return if (factorySupported) {
+            setOf(CREATE, FqConstants.ARITY, SpecialNames.INIT)
         } else {
-            setOf(
-                FqConstants.FIND_ENDPOINT,
-                FqConstants.CREATE_STUB,
-                FqConstants.SERVICE_NAME,
-                FqConstants.ENDPOINTS,
-                SpecialNames.INIT
-            )
+            setOf(SpecialNames.INIT)
         }
     }
 

--- a/compiler/plugin/src/main/java/SubtypeCompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/SubtypeCompanionGeneration.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.backend.js.utils.isDispatchReceiver
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
-import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
@@ -103,61 +102,18 @@ class SubtypeCompanionGeneration(
 
         declaration.isCompanion = true
 
-        if (!k.isGeneric) {
-            // Scenario 1: non-generic subtype — eagerly emit property bodies.
-            emitScenario1PropertyBodies(declaration, subtypeClass, k)
-        } else {
-            // Scenario 2: generic subtype — set arity property body
-            declaration.declarations
-                .filterIsInstance<IrProperty>()
-                .firstOrNull { it.name == FqConstants.ARITY }
-                ?.let { property ->
-                    val arity = subtypeClass.typeParameters.size
-                    property.getter?.body = context.irBuilder(property.getter!!).irSynthBody {
-                        +irReturn(irInt(arity))
-                    }
+        // Both generic and non-generic subtypes use RpcObjectFactory with arity property.
+        val arity = subtypeClass.typeParameters.size
+        declaration.declarations
+            .filterIsInstance<IrProperty>()
+            .firstOrNull { it.name == FqConstants.ARITY }
+            ?.let { property ->
+                property.getter?.body = context.irBuilder(property.getter!!).irSynthBody {
+                    +irReturn(irInt(arity))
                 }
-        }
+            }
 
         return emptyList()
-    }
-
-    private fun emitScenario1PropertyBodies(
-        declaration: IrClass,
-        subtypeClass: IrClass,
-        key: FirSubtypeCompanionGenerator.Key
-    ) {
-        val parentServiceClass = findIrClass(key.parentServiceClassId) ?: return
-
-        declaration.declarations
-            .filterIsInstance<IrProperty>()
-            .firstOrNull { it.name == FqConstants.SERVICE_NAME }
-            ?.let { property ->
-                property.getter?.body = context.irBuilder(property.getter!!).irSynthBody {
-                    val rpcObj = buildParentRpcObjectExpr(
-                        this, subtypeClass, parentServiceClass
-                    )
-                    val getter = findRpcObjectPropertyGetter(FqConstants.SERVICE_NAME)
-                    +irReturn(
-                        irCall(getter).apply { dispatchReceiver = rpcObj }
-                    )
-                }
-            }
-
-        declaration.declarations
-            .filterIsInstance<IrProperty>()
-            .firstOrNull { it.name == FqConstants.ENDPOINTS }
-            ?.let { property ->
-                property.getter?.body = context.irBuilder(property.getter!!).irSynthBody {
-                    val rpcObj = buildParentRpcObjectExpr(
-                        this, subtypeClass, parentServiceClass
-                    )
-                    val getter = findRpcObjectPropertyGetter(FqConstants.ENDPOINTS)
-                    +irReturn(
-                        irCall(getter).apply { dispatchReceiver = rpcObj }
-                    )
-                }
-            }
     }
 
     private fun createRpcObjectAnnotation(
@@ -184,16 +140,6 @@ class SubtypeCompanionGeneration(
 
         // Handle property getters
         function.correspondingPropertySymbol?.owner?.name?.let { propertyName ->
-            if (propertyName == FqConstants.SERVICE_NAME) {
-                return generateDelegatingPropertyBody(
-                    function, k, subtypeClass, FqConstants.SERVICE_NAME
-                )
-            }
-            if (propertyName == FqConstants.ENDPOINTS) {
-                return generateDelegatingPropertyBody(
-                    function, k, subtypeClass, FqConstants.ENDPOINTS
-                )
-            }
             if (propertyName == FqConstants.ARITY) {
                 return context.irBuilder(function).irSynthBody {
                     +irReturn(irInt(subtypeClass.typeParameters.size))
@@ -202,84 +148,23 @@ class SubtypeCompanionGeneration(
         }
 
         return when (function.name) {
-            FqConstants.CREATE_STUB -> generateCreateStubBody(function, k, subtypeClass)
-            FqConstants.FIND_ENDPOINT -> generateFindEndpointBody(function, k, subtypeClass)
             FqConstants.CREATE -> generateCreateBody(function, k, subtypeClass)
             else -> null
         }
     }
 
-    private fun generateDelegatingPropertyBody(
-        function: IrSimpleFunction,
-        key: FirSubtypeCompanionGenerator.Key,
-        subtypeClass: IrClass,
-        propertyName: Name
-    ): IrBody {
-        val parentServiceClass = findIrClass(key.parentServiceClassId)
-            ?: reportInternal(
-                "Can't find parent service ${key.parentServiceClassId} for subtype " +
-                    "${subtypeClass.kotlinFqName.asString()}"
-            )
-        return context.irBuilder(function).irSynthBody {
-            val rpcObj = buildParentRpcObjectExpr(this, subtypeClass, parentServiceClass)
-            val getter = findRpcObjectPropertyGetter(propertyName)
-            +irReturn(
-                irCall(getter).apply { dispatchReceiver = rpcObj }
-            )
-        }
-    }
-
-    private fun generateCreateStubBody(
-        function: IrSimpleFunction,
-        key: FirSubtypeCompanionGenerator.Key,
-        subtypeClass: IrClass
-    ): IrBody {
-        val parentServiceClass = findIrClass(key.parentServiceClassId)
-            ?: reportInternal(
-                "Can't find parent service ${key.parentServiceClassId} for subtype " +
-                    "${subtypeClass.kotlinFqName.asString()}"
-            )
-        return context.irBuilder(function).irSynthBody {
-            val rpcObj = buildParentRpcObjectExpr(this, subtypeClass, parentServiceClass)
-            val createStubMethod = findRpcObjectMethod(FqConstants.CREATE_STUB)
-            val channelParam = function.parameters.first { !it.isDispatchReceiver }
-            +irReturn(
-                irCall(createStubMethod).apply {
-                    dispatchReceiver = rpcObj
-                    typeArguments[0] = channelParam.type
-                    arguments[1] = irGet(channelParam)
-                }
-            )
-        }
-    }
-
-    private fun generateFindEndpointBody(
-        function: IrSimpleFunction,
-        key: FirSubtypeCompanionGenerator.Key,
-        subtypeClass: IrClass
-    ): IrBody {
-        val parentServiceClass = findIrClass(key.parentServiceClassId)
-            ?: reportInternal(
-                "Can't find parent service ${key.parentServiceClassId} for subtype " +
-                    "${subtypeClass.kotlinFqName.asString()}"
-            )
-        return context.irBuilder(function).irSynthBody {
-            val rpcObj = buildParentRpcObjectExpr(this, subtypeClass, parentServiceClass)
-            val findEndpointMethod = findRpcObjectMethod(FqConstants.FIND_ENDPOINT)
-            val endpointParam = function.parameters.first { !it.isDispatchReceiver }
-            +irReturn(
-                irCall(findEndpointMethod).apply {
-                    dispatchReceiver = rpcObj
-                    arguments[1] = irGet(endpointParam)
-                }
-            )
-        }
-    }
-
     /**
-     * Scenario 2: generate body for `create(typeArgs: List<KType>): RpcObject<Subtype<*,...>>`
-     * Delegates to the parent service's factory with the type args mapped through the
-     * subtype->parent substitution.
+     * Generate body for `create(typeArgs: List<KType>): RpcObject<...>`.
+     *
+     * - **Non-generic subtype** (e.g. `interface TypedFoo : GenericEcho<String>`):
+     *   Ignores `typeArgs` (arity is 0), constructs the parent's `Obj<String>(serializer<String>())`
+     *   directly, returning it as the `RpcObject`. This avoids the JVM bridge-method
+     *   ClassCastException that would occur if the companion's `createStub` tried to return the
+     *   parent's Stub as the subtype (see issue #136).
+     *
+     * - **Generic subtype** (e.g. `interface TypedFooT<T> : GenericEcho<T>`):
+     *   Maps `typeArgs` through the subtype-to-parent type-arg substitution and delegates
+     *   to the parent's `create(mappedTypeArgs)`.
      */
     private fun generateCreateBody(
         function: IrSimpleFunction,
@@ -291,6 +176,17 @@ class SubtypeCompanionGeneration(
                 "Can't find parent service ${key.parentServiceClassId} for subtype " +
                     "${subtypeClass.kotlinFqName.asString()}"
             )
+
+        if (!key.isGeneric) {
+            // Non-generic subtype: construct the parent's RpcObject directly with baked-in
+            // type args from the subtype's supertype reference.
+            return context.irBuilder(function).irSynthBody {
+                val rpcObj = buildParentRpcObjectExpr(this, subtypeClass, parentServiceClass)
+                +irReturn(rpcObj)
+            }
+        }
+
+        // Generic subtype: delegate to parent's factory with mapped type args.
         val parentCompanion = parentServiceClass.companionObject()
             ?: reportInternal(
                 "Parent service ${parentServiceClass.kotlinFqName.asString()} has no companion"
@@ -454,32 +350,6 @@ class SubtypeCompanionGeneration(
 
     private fun findIrClass(classId: ClassId): IrClass? =
         context.referenceClass(classId)?.owner
-
-    private fun findRpcObjectPropertyGetter(propertyName: Name): IrSimpleFunction {
-        val rpcObjectClass = context.referenceClass(FqConstants.RPC_OBJECT)?.owner
-            ?: reportInternal("Can't resolve RpcObject class")
-        val property = rpcObjectClass.declarations
-            .filterIsInstance<IrProperty>()
-            .firstOrNull { it.name == propertyName }
-            ?: reportInternal(
-                "Can't find property ${propertyName.asString()} on RpcObject"
-            )
-        return property.getter
-            ?: reportInternal(
-                "Property ${propertyName.asString()} on RpcObject has no getter"
-            )
-    }
-
-    private fun findRpcObjectMethod(name: Name): IrSimpleFunction {
-        val rpcObjectClass = context.referenceClass(FqConstants.RPC_OBJECT)?.owner
-            ?: reportInternal("Can't resolve RpcObject class")
-        return rpcObjectClass.declarations
-            .filterIsInstance<IrSimpleFunction>()
-            .firstOrNull { it.name == name }
-            ?: reportInternal(
-                "Can't find method ${name.asString()} on RpcObject"
-            )
-    }
 
     override fun generateBodyForConstructor(
         constructor: IrConstructor,

--- a/ksrpc-test/src/jvmTest/kotlin/GenericServiceSubtypeJvmTest.kt
+++ b/ksrpc-test/src/jvmTest/kotlin/GenericServiceSubtypeJvmTest.kt
@@ -27,28 +27,13 @@ import kotlin.test.assertTrue
  * another `@KsService` (the validation in `KsrpcIrGenerationExtension.validateClass`
  * looks only at direct super-types for `RpcService`/`IntrospectableRpcService`).
  *
- * The supported pattern for subtype-specialization today is to rely on the parent's
- * `@KsService` annotation and reach the parent's `RpcObjectFactory` companion via
- * `rpcObject()` supertype walking. The resulting `RpcObject`/`Stub` is the parent's
- * (e.g. `GenericEcho<String>`), not the subtype's — so callers cannot expect a
- * `rpcObject<TypedGenericEchoJvm>()` result to be usable as a stub for
- * `TypedGenericEchoJvm` directly. Generating a dedicated companion/stub for
- * `@KsService` subtypes of generic services is tracked as a follow-up.
- *
- * JVM-only: the kotlin.reflect-based supertype walk in `rpcObject()`'s JVM actual picks
- * up `GenericEcho<String>` from `TypedGenericEchoJvm`'s supertypes with `String`
- * preserved in `KType.arguments`, then feeds that to `GenericEcho.create(...)`. On
- * Native/JS/WASM `findAssociatedObject<RpcObjectKey>()` returns the parent's factory but
- * `typeOf<Subtype>().arguments` is empty (the subtype has no type params), so the
- * resulting `factory.create(emptyList())` throws an arity mismatch. Lifting this path
- * to all platforms requires either new FIR-phase declaration generation on the subtype
- * (to synthesize a per-subtype companion with baked-in type args) or runtime access to
- * the subtype's supertype `KType` without `kotlin.reflect.full.allSupertypes` (which
- * isn't available on Native/JS/WASM). Tracked as a follow-up off issue #64.
- *
- * Cross-platform callers should today use the `RpcObjectFactory` route instead —
- * `GenericEcho.create(listOf(typeOf<String>()))` works on every platform (see
- * `GenericServiceSubtypeTest.scenario1_factoryCreateWithConcreteArg`).
+ * The compiler plugin synthesizes an `RpcObjectFactory` companion (with arity 0) on this
+ * subtype, so `rpcObject<TypedGenericEchoJvm>()` resolves on all platforms. The factory's
+ * `create(emptyList())` constructs the parent's `Obj<String>` directly, returning the
+ * parent's `RpcObject` — whose `createStub()` returns `GenericEcho.Stub<String>`. This
+ * avoids the JVM bridge-method `ClassCastException` that would occur if the companion
+ * directly implemented `RpcObject<TypedGenericEchoJvm>` (the parent's Stub doesn't
+ * implement `TypedGenericEchoJvm`). See issue #136.
  */
 internal interface TypedGenericEchoJvm : GenericEcho<String>
 
@@ -61,10 +46,10 @@ private class TypedGenericEchoJvmImpl : GenericEcho<String> {
 class GenericServiceSubtypeJvmTest {
 
     /**
-     * `rpcObject<TypedGenericEchoJvm>()` should find no direct companion on
-     * `TypedGenericEchoJvm`, walk its supertypes, discover `GenericEcho`'s
-     * `RpcObjectFactory` companion, extract `String` from the `GenericEcho<String>`
-     * supertype, and return a working `RpcObject` for that specialization.
+     * `rpcObject<TypedGenericEchoJvm>()` should find the synthesized `RpcObjectFactory`
+     * companion on `TypedGenericEchoJvm`, call `create(emptyList())`, and get back the
+     * parent's `RpcObject<GenericEcho<String>>` — a fully working `RpcObject` whose
+     * `createStub` returns `GenericEcho.Stub<String>`.
      */
     @Test
     fun rpcObjectResolvesGenericSupertype() = runBlockingUnit {


### PR DESCRIPTION
## Summary
- Non-generic subtypes of `@KsService` interfaces (e.g. `interface TypedFoo : GenericEcho<String>`) had their synthesized companion implement `RpcObject<TypedFoo>` directly, causing a `ClassCastException` on JVM: the parent's `Stub` class doesn't implement the subtype interface, and the JVM bridge method for `createStub()` inserted a failing checkcast.
- Changed the companion to implement `RpcObjectFactory<TypedFoo>` with arity 0 instead. Now `rpcObject<TypedFoo>()` calls `factory.create(emptyList())` which returns the parent's actual `RpcObject`, whose `createStub()` returns the parent's Stub without any subtype checkcast.
- This unifies the non-generic and generic subtype companion strategies -- both now use `RpcObjectFactory`, simplifying the FIR/IR code and removing ~230 lines of now-unnecessary delegation logic.

## Test plan
- [x] `GenericServiceSubtypeJvmTest.rpcObjectResolvesGenericSupertype` now passes (was the failing test)
- [x] Full `:ksrpc-test:jvmTest` suite passes (no regressions)
- [x] `:ksrpc-compiler-plugin:test` passes (compiler plugin unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)