### PR TITLE
Add runtime tier check to JSON-RPC transport

### DIFF
--- a/ksrpc-core/src/commonMain/kotlin/ServiceTier.kt
+++ b/ksrpc-core/src/commonMain/kotlin/ServiceTier.kt
@@ -72,11 +72,17 @@ fun <T : RpcService> requireTier(
             )
         }
         if (required == ServiceTier.BIDI && method.outputTransform is BaseSubserviceTransformer<*, *>) {
-            // Check if the output sub-service itself requires bidi
             throw IllegalArgumentException(
                 "${rpcObject.serviceName} requires bidirectional transport " +
                     "(method '$endpoint' returns a bidirectional sub-service), " +
                     "but $transportName does not support this."
+            )
+        }
+        if (required == ServiceTier.HOST && method.outputTransform is BaseSubserviceTransformer<*, *>) {
+            throw IllegalArgumentException(
+                "${rpcObject.serviceName} requires HOST transport " +
+                    "(method '$endpoint' returns a sub-service), " +
+                    "but $transportName only supports SIMPLE services."
             )
         }
     }

--- a/ksrpc-core/src/commonMain/kotlin/channels/SerializedChannel.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/SerializedChannel.kt
@@ -21,11 +21,13 @@ import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.RpcMethod
 import com.monkopedia.ksrpc.RpcObject
 import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.ServiceTier
 import com.monkopedia.ksrpc.SuspendCloseableObservable
 import com.monkopedia.ksrpc.annotation.KsMethod
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.ChannelClient.Companion.DEFAULT
 import com.monkopedia.ksrpc.internal.HostSerializedServiceImpl
+import com.monkopedia.ksrpc.requireTier
 import com.monkopedia.ksrpc.rpcObject
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -41,8 +43,11 @@ suspend inline fun <reified T : RpcService, S> ChannelHost<S>.registerHost(servi
 /**
  * Register a service to be hosted on the default channel.
  */
-suspend inline fun <reified T : RpcService, S> SingleChannelHost<S>.registerDefault(service: T) =
-    registerDefault(service, rpcObject())
+suspend inline fun <reified T : RpcService, S> SingleChannelHost<S>.registerDefault(service: T) {
+    val obj = rpcObject<T>()
+    requireTier(obj, supportedTier, transportName)
+    registerDefault(service, obj)
+}
 
 /**
  * Register a service to be hosted, the [ChannelId] ollocated to this service
@@ -69,6 +74,21 @@ suspend fun <T : RpcService, S> SingleChannelHost<S>.registerDefault(
  * SerializedService.
  */
 interface SingleChannelHost<T> : KsrpcEnvironment.Element<T> {
+    /**
+     * The maximum [ServiceTier] this host supports. Defaults to [ServiceTier.BIDI]
+     * (full capability). Implementations with limited transport capabilities should
+     * override this to a lower tier.
+     */
+    val supportedTier: ServiceTier
+        get() = ServiceTier.BIDI
+
+    /**
+     * A human-readable name for this transport, used in error messages when a
+     * service exceeds the [supportedTier].
+     */
+    val transportName: String
+        get() = this::class.simpleName ?: "unknown transport"
+
     /**
      * Register the primary service to be hosted on this communication channel.
      *

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
@@ -18,6 +18,7 @@
 package com.monkopedia.ksrpc.jsonrpc.internal
 
 import com.monkopedia.ksrpc.KsrpcEnvironment
+import com.monkopedia.ksrpc.ServiceTier
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.channels.CancellationSupport
 import com.monkopedia.ksrpc.channels.RpcCallId
@@ -60,6 +61,9 @@ class JsonRpcWriterBase(
 ) : JsonRpcChannel,
     SingleChannelConnection<String>,
     CancellationSupport {
+    override val supportedTier: ServiceTier = ServiceTier.SIMPLE
+    override val transportName: String = "JSON-RPC (SingleChannelConnection)"
+
     private val json = (env.serialization as? Json) ?: Json
 
     companion object {

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcTierCheckTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcTierCheckTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(KsrpcInternal::class)
+
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.channels.registerDefault
+import com.monkopedia.ksrpc.jsonrpc.asJsonRpcConnection
+import io.ktor.utils.io.ByteChannel
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class JsonRpcTierCheckTest {
+
+    @Test
+    fun registeringHostServiceOnJsonRpcThrows() = runBlockingUnit {
+        val inputChannel = ByteChannel()
+        val outputChannel = ByteChannel()
+        val connection = (inputChannel to outputChannel).asJsonRpcConnection(
+            ksrpcEnvironment { }
+        )
+
+        val hostService = object : TestRootInterface {
+            override suspend fun rpc(u: Pair<String, String>): String = "${u.first} ${u.second}"
+            override suspend fun subservice(prefix: String): TestSubInterface =
+                error("unreachable")
+        }
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            connection.registerDefault(hostService)
+        }
+        assertTrue(
+            exception.message!!.contains("sub-service"),
+            "Error message should mention sub-service, got: ${exception.message}"
+        )
+        assertTrue(
+            exception.message!!.contains("JSON-RPC"),
+            "Error message should mention JSON-RPC, got: ${exception.message}"
+        )
+    }
+
+    @Test
+    fun registeringSimpleServiceOnJsonRpcSucceeds() = runBlockingUnit {
+        val inputChannel = ByteChannel()
+        val outputChannel = ByteChannel()
+        val connection = (inputChannel to outputChannel).asJsonRpcConnection(
+            ksrpcEnvironment { }
+        )
+
+        val simpleService = object : TestSubInterface {
+            override suspend fun rpc(u: Pair<String, String>): String = "${u.first} ${u.second}"
+        }
+
+        // Should not throw — simple services are fine on JSON-RPC
+        connection.registerDefault(simpleService)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `supportedTier` and `transportName` properties to `SingleChannelHost` (defaulting to `BIDI` so existing transports are unaffected)
- Overrides `supportedTier` to `SIMPLE` in `JsonRpcWriterBase` since JSON-RPC cannot host sub-services
- Adds tier validation in the reified `registerDefault` extension so registration fails immediately with a clear error
- Improves `requireTier` to produce a specific error message for HOST-tier violations (naming the offending method)

## Test plan
- [x] New `JsonRpcTierCheckTest` verifies that registering a HOST service on JSON-RPC throws `IllegalArgumentException` with a descriptive message
- [x] New test verifies that registering a SIMPLE service on JSON-RPC still succeeds
- [x] Full `:ksrpc-test:jvmTest` suite passes (no regressions)

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)