### PR TITLE
Fix JSON-RPC 2.0 spec compliance: notification id and null result

### DIFF
--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -144,7 +145,7 @@ class JsonRpcWriterBase(
                 comm.send(
                     json.encodeToJsonElement(
                         JsonRpcResponse(
-                            result = response,
+                            result = response ?: JsonNull,
                             id = id
                         )
                     )
@@ -207,7 +208,7 @@ class JsonRpcWriterBase(
         val request = JsonRpcRequest(
             method = method,
             params = message,
-            id = JsonPrimitive(wireId)
+            id = wireId?.let { JsonPrimitive(it) }
         )
         val wireCtx = coroutineContext[WireContextMap]
         val requestJson = injectContext(json.encodeToJsonElement(request), wireCtx, message)


### PR DESCRIPTION
## Summary

Audit of the JSON-RPC 2.0 implementation against the [official specification](https://www.jsonrpc.org/specification) per #134. Two fixable compliance issues found and corrected:

- **Notification `id` field**: Previously sent `"id": null` on the wire; now omits the field entirely. The spec defines a notification as "a Request object without an 'id' member" (section 4.1).
- **Success response `result` field**: Previously omitted `result` when a method returned null; now always includes `"result": null`. The spec says "This member MUST exist" on success (section 5).

### Full Audit Results

| Requirement | Status |
|---|---|
| Request: `jsonrpc` MUST be "2.0" | COMPLIANT — `@Required val jsonrpc = "2.0"` ensures always serialized |
| Request: `method` MUST be present (string) | COMPLIANT |
| Request: `params` MAY be omitted | COMPLIANT — nullable field with default null |
| Request: `id` MUST be present for requests | COMPLIANT — allocated via `MultiChannel.allocateReceive()` |
| Notification: no `id` field | **FIXED** — was `"id": null`, now omitted |
| Notification: server MUST NOT reply | COMPLIANT — `if (id == null) return@launch` |
| Response: `jsonrpc` MUST be "2.0" | COMPLIANT |
| Response: `result` MUST exist on success | **FIXED** — now sends `JsonNull` when method returns null |
| Response: `error` MUST exist on failure | COMPLIANT |
| Response: MUST NOT contain both `result` and `error` | COMPLIANT — mutually exclusive construction |
| Response: `id` MUST match request | COMPLIANT |
| Error: `code` (integer) MUST be present | COMPLIANT |
| Error: `message` (string) MUST be present | COMPLIANT |
| Error: `data` optional | COMPLIANT |
| Error: reserved codes defined | COMPLIANT — constants in `JsonRpcError.Companion` |
| Batch support | NOT IMPLEMENTED — noted below |
| Params: array or object | COMPLIANT — passes through `JsonElement` unchanged |

### Intentional deviations / notes

- **No batch support**: The transport processes one message at a time. Batch arrays are not recognized. This is common in LSP-focused implementations and acceptable for ksrpc's use case.
- **No `jsonrpc` version validation on receive**: Incoming messages are not rejected if `jsonrpc != "2.0"`. Could be added but would be a behavior change affecting interop with non-strict peers.
- **`id` type not restricted**: The spec allows string, number, or null. ksrpc accepts any `JsonPrimitive` (including boolean). Overly permissive but harmless.

## Test plan

- [x] Existing `JsonRpcNotifyRequestShapeTest` passes (validates notification id is null)
- [x] All `JsonRpc*` test classes pass
- [x] `compileKotlinJvm` succeeds with no new warnings

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)