### PR TITLE
Add CI workflow and update BCV API dumps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Install libcurl
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
+      - name: Check API compatibility
+        run: ./gradlew apiCheck
+
+      - name: Run JVM tests
+        run: ./gradlew jvmTest --continue
+
+      - name: Run compiler plugin tests
+        run: cd compiler && ./gradlew test

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -286,6 +286,15 @@ public final class com/monkopedia/ksrpc/ServiceNameKt {
 	public static final fun serviceNameFor (Lkotlin/reflect/KClass;)Ljava/lang/String;
 }
 
+public final class com/monkopedia/ksrpc/ServiceTier : java/lang/Enum {
+	public static final field BIDI Lcom/monkopedia/ksrpc/ServiceTier;
+	public static final field HOST Lcom/monkopedia/ksrpc/ServiceTier;
+	public static final field SIMPLE Lcom/monkopedia/ksrpc/ServiceTier;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/monkopedia/ksrpc/ServiceTier;
+	public static fun values ()[Lcom/monkopedia/ksrpc/ServiceTier;
+}
+
 public abstract interface class com/monkopedia/ksrpc/SuspendCloseableObservable : com/monkopedia/ksrpc/SuspendCloseable {
 	public abstract fun onClose (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -415,6 +424,8 @@ public abstract interface class com/monkopedia/ksrpc/channels/ChannelHost : com/
 
 public final class com/monkopedia/ksrpc/channels/ChannelHost$DefaultImpls {
 	public static fun getContext (Lcom/monkopedia/ksrpc/channels/ChannelHost;)Lkotlin/coroutines/CoroutineContext;
+	public static fun getSupportedTier (Lcom/monkopedia/ksrpc/channels/ChannelHost;)Lcom/monkopedia/ksrpc/ServiceTier;
+	public static fun getTransportName (Lcom/monkopedia/ksrpc/channels/ChannelHost;)Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/channels/ChannelId {
@@ -434,6 +445,8 @@ public abstract interface class com/monkopedia/ksrpc/channels/Connection : com/m
 public final class com/monkopedia/ksrpc/channels/Connection$DefaultImpls {
 	public static fun defaultChannel (Lcom/monkopedia/ksrpc/channels/Connection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getContext (Lcom/monkopedia/ksrpc/channels/Connection;)Lkotlin/coroutines/CoroutineContext;
+	public static fun getSupportedTier (Lcom/monkopedia/ksrpc/channels/Connection;)Lcom/monkopedia/ksrpc/ServiceTier;
+	public static fun getTransportName (Lcom/monkopedia/ksrpc/channels/Connection;)Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/channels/ConnectionKt {
@@ -508,8 +521,20 @@ public abstract interface class com/monkopedia/ksrpc/channels/SingleChannelClien
 public abstract interface class com/monkopedia/ksrpc/channels/SingleChannelConnection : com/monkopedia/ksrpc/channels/SingleChannelClient, com/monkopedia/ksrpc/channels/SingleChannelHost {
 }
 
+public final class com/monkopedia/ksrpc/channels/SingleChannelConnection$DefaultImpls {
+	public static fun getSupportedTier (Lcom/monkopedia/ksrpc/channels/SingleChannelConnection;)Lcom/monkopedia/ksrpc/ServiceTier;
+	public static fun getTransportName (Lcom/monkopedia/ksrpc/channels/SingleChannelConnection;)Ljava/lang/String;
+}
+
 public abstract interface class com/monkopedia/ksrpc/channels/SingleChannelHost : com/monkopedia/ksrpc/KsrpcEnvironment$Element {
+	public fun getSupportedTier ()Lcom/monkopedia/ksrpc/ServiceTier;
+	public fun getTransportName ()Ljava/lang/String;
 	public abstract fun registerDefault (Lcom/monkopedia/ksrpc/channels/SerializedService;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/monkopedia/ksrpc/channels/SingleChannelHost$DefaultImpls {
+	public static fun getSupportedTier (Lcom/monkopedia/ksrpc/channels/SingleChannelHost;)Lcom/monkopedia/ksrpc/ServiceTier;
+	public static fun getTransportName (Lcom/monkopedia/ksrpc/channels/SingleChannelHost;)Ljava/lang/String;
 }
 
 public final class com/monkopedia/ksrpc/channels/WireContextMap$Key : kotlin/coroutines/CoroutineContext$Key {

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -13,6 +13,18 @@ open annotation class com.monkopedia.ksrpc/RpcObjectKey : kotlin/Annotation { //
         final fun <get-rpcObject>(): kotlin.reflect/KClass<*> // com.monkopedia.ksrpc/RpcObjectKey.rpcObject.<get-rpcObject>|<get-rpcObject>(){}[0]
 }
 
+final enum class com.monkopedia.ksrpc/ServiceTier : kotlin/Enum<com.monkopedia.ksrpc/ServiceTier> { // com.monkopedia.ksrpc/ServiceTier|null[0]
+    enum entry BIDI // com.monkopedia.ksrpc/ServiceTier.BIDI|null[0]
+    enum entry HOST // com.monkopedia.ksrpc/ServiceTier.HOST|null[0]
+    enum entry SIMPLE // com.monkopedia.ksrpc/ServiceTier.SIMPLE|null[0]
+
+    final val entries // com.monkopedia.ksrpc/ServiceTier.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.monkopedia.ksrpc/ServiceTier> // com.monkopedia.ksrpc/ServiceTier.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.monkopedia.ksrpc/ServiceTier // com.monkopedia.ksrpc/ServiceTier.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.monkopedia.ksrpc/ServiceTier> // com.monkopedia.ksrpc/ServiceTier.values|values#static(){}[0]
+}
+
 abstract fun interface com.monkopedia.ksrpc/ErrorListener { // com.monkopedia.ksrpc/ErrorListener|null[0]
     abstract fun onError(kotlin/Throwable) // com.monkopedia.ksrpc/ErrorListener.onError|onError(kotlin.Throwable){}[0]
 }
@@ -67,6 +79,11 @@ abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.channels/SingleChannel
 abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.channels/SingleChannelConnection : com.monkopedia.ksrpc.channels/SingleChannelClient<#A>, com.monkopedia.ksrpc.channels/SingleChannelHost<#A> // com.monkopedia.ksrpc.channels/SingleChannelConnection|null[0]
 
 abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.channels/SingleChannelHost : com.monkopedia.ksrpc/KsrpcEnvironment.Element<#A> { // com.monkopedia.ksrpc.channels/SingleChannelHost|null[0]
+    open val supportedTier // com.monkopedia.ksrpc.channels/SingleChannelHost.supportedTier|{}supportedTier[0]
+        open fun <get-supportedTier>(): com.monkopedia.ksrpc/ServiceTier // com.monkopedia.ksrpc.channels/SingleChannelHost.supportedTier.<get-supportedTier>|<get-supportedTier>(){}[0]
+    open val transportName // com.monkopedia.ksrpc.channels/SingleChannelHost.transportName|{}transportName[0]
+        open fun <get-transportName>(): kotlin/String // com.monkopedia.ksrpc.channels/SingleChannelHost.transportName.<get-transportName>|<get-transportName>(){}[0]
+
     abstract suspend fun registerDefault(com.monkopedia.ksrpc.channels/SerializedService<#A>) // com.monkopedia.ksrpc.channels/SingleChannelHost.registerDefault|registerDefault(com.monkopedia.ksrpc.channels.SerializedService<1:0>){}[0]
 }
 


### PR DESCRIPTION
## Summary
- Update BCV API dumps for ServiceTier, supportedTier, transportName (missing from #150)
- Add CI workflow that runs on PRs and pushes to main:
  - `apiCheck` — catches missing API dump updates
  - `jvmTest` — full JVM test suite
  - compiler plugin tests

Prevents future API dump misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)