### PR TITLE
Fix native linker duplicate symbol for HTTP error constants

### DIFF
--- a/ksrpc-ktor/server/api/ksrpc-ktor-server.api
+++ b/ksrpc-ktor/server/api/ksrpc-ktor-server.api
@@ -1,7 +1,4 @@
 public final class com/monkopedia/ksrpc/ktor/HttpStreamKt {
-	public static final field KSRPC_ERROR_CODE_HEADER Ljava/lang/String;
-	public static final field KSRPC_ERROR_MESSAGE_HEADER Ljava/lang/String;
-	public static final fun getDEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS ()Ljava/util/Map;
 	public static final fun serveHttp (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lcom/monkopedia/ksrpc/channels/SerializedChannel;Lcom/monkopedia/ksrpc/KsrpcEnvironment;Ljava/util/Map;)V
 	public static final fun serveHttp (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lcom/monkopedia/ksrpc/channels/SerializedService;Lcom/monkopedia/ksrpc/KsrpcEnvironment;Ljava/util/Map;)V
 	public static synthetic fun serveHttp$default (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lcom/monkopedia/ksrpc/channels/SerializedChannel;Lcom/monkopedia/ksrpc/KsrpcEnvironment;Ljava/util/Map;ILjava/lang/Object;)V

--- a/ksrpc-ktor/server/api/ksrpc-ktor-server.klib.api
+++ b/ksrpc-ktor/server/api/ksrpc-ktor-server.klib.api
@@ -1,19 +1,11 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, linuxX64, macosArm64, macosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
 // - Show declarations: true
 
 // Library unique name: <com.monkopedia.ksrpc:ksrpc-ktor-server>
-final const val com.monkopedia.ksrpc.ktor/KSRPC_ERROR_CODE_HEADER // com.monkopedia.ksrpc.ktor/KSRPC_ERROR_CODE_HEADER|{}KSRPC_ERROR_CODE_HEADER[0]
-    final fun <get-KSRPC_ERROR_CODE_HEADER>(): kotlin/String // com.monkopedia.ksrpc.ktor/KSRPC_ERROR_CODE_HEADER.<get-KSRPC_ERROR_CODE_HEADER>|<get-KSRPC_ERROR_CODE_HEADER>(){}[0]
-final const val com.monkopedia.ksrpc.ktor/KSRPC_ERROR_MESSAGE_HEADER // com.monkopedia.ksrpc.ktor/KSRPC_ERROR_MESSAGE_HEADER|{}KSRPC_ERROR_MESSAGE_HEADER[0]
-    final fun <get-KSRPC_ERROR_MESSAGE_HEADER>(): kotlin/String // com.monkopedia.ksrpc.ktor/KSRPC_ERROR_MESSAGE_HEADER.<get-KSRPC_ERROR_MESSAGE_HEADER>|<get-KSRPC_ERROR_MESSAGE_HEADER>(){}[0]
-
-final val com.monkopedia.ksrpc.ktor/DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS // com.monkopedia.ksrpc.ktor/DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS|{}DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS[0]
-    final fun <get-DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS>(): kotlin.collections/Map<kotlin/Int, kotlin/Int> // com.monkopedia.ksrpc.ktor/DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS.<get-DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS>|<get-DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS>(){}[0]
-
 final fun (io.ktor.server.routing/Routing).com.monkopedia.ksrpc.ktor/serveHttp(kotlin/String, com.monkopedia.ksrpc.channels/SerializedChannel<kotlin/String>, com.monkopedia.ksrpc/KsrpcEnvironment<kotlin/String>, kotlin.collections/Map<kotlin/Int, kotlin/Int> = ...) // com.monkopedia.ksrpc.ktor/serveHttp|serveHttp@io.ktor.server.routing.Routing(kotlin.String;com.monkopedia.ksrpc.channels.SerializedChannel<kotlin.String>;com.monkopedia.ksrpc.KsrpcEnvironment<kotlin.String>;kotlin.collections.Map<kotlin.Int,kotlin.Int>){}[0]
 final fun (io.ktor.server.routing/Routing).com.monkopedia.ksrpc.ktor/serveHttp(kotlin/String, com.monkopedia.ksrpc.channels/SerializedService<kotlin/String>, com.monkopedia.ksrpc/KsrpcEnvironment<kotlin/String>, kotlin.collections/Map<kotlin/Int, kotlin/Int> = ...) // com.monkopedia.ksrpc.ktor/serveHttp|serveHttp@io.ktor.server.routing.Routing(kotlin.String;com.monkopedia.ksrpc.channels.SerializedService<kotlin.String>;com.monkopedia.ksrpc.KsrpcEnvironment<kotlin.String>;kotlin.collections.Map<kotlin.Int,kotlin.Int>){}[0]
 final inline fun <#A: reified com.monkopedia.ksrpc/RpcService> (io.ktor.server.routing/Routing).com.monkopedia.ksrpc.ktor/serveHttp(kotlin/String, #A, com.monkopedia.ksrpc/KsrpcEnvironment<kotlin/String>, kotlin.collections/Map<kotlin/Int, kotlin/Int> = ...) // com.monkopedia.ksrpc.ktor/serveHttp|serveHttp@io.ktor.server.routing.Routing(kotlin.String;0:0;com.monkopedia.ksrpc.KsrpcEnvironment<kotlin.String>;kotlin.collections.Map<kotlin.Int,kotlin.Int>){0§<com.monkopedia.ksrpc.RpcService>}[0]

--- a/ksrpc-ktor/server/build.gradle.kts
+++ b/ksrpc-ktor/server/build.gradle.kts
@@ -21,7 +21,8 @@ plugins {
 
 ksrpcModule(
     supportJs = false,
-    supportMingw = false
+    supportMingw = false,
+    supportLinuxArm64 = false
 )
 
 kotlin {
@@ -32,6 +33,10 @@ kotlin {
         // Exposed as `api` so consumers of the HTTP transport don't need to
         // declare it.
         api(project(":ksrpc-binary-ktor"))
+        // Shared HTTP constants (error headers, default status mapping) live in
+        // the client module to avoid duplicate symbols in K/N linking when both
+        // client and server appear on the same classpath.
+        api(project(":ksrpc-ktor-client"))
         api(libs.ktor.server)
     }
 }

--- a/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
+++ b/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
@@ -51,38 +51,9 @@ import kotlinx.coroutines.withContext
 private const val KSRPC_BINARY = "binary"
 private const val KSRPC_CHANNEL = "channel"
 
-/**
- * Header carrying the original ksrpc error code when the wire status maps to the default
- * 500 fallback (i.e. the code is not present in the configured `errorCodeToHttpStatus` map).
- * The client side uses this to recover the exact code for `@KsError`-bound payload routing
- * on the receive path. Match this constant on both ends — see also the duplicate definition
- * in `ksrpc-ktor-client`'s `HttpSerializedChannel.kt`.
- */
-const val KSRPC_ERROR_CODE_HEADER: String = "X-Ksrpc-Error-Code"
-
-/**
- * Header carrying the human-readable error message that pairs with the ksrpc error code on
- * the wire. The body slot carries the typed `errorData` payload; the message moves to a
- * header so it survives transports that strip/escape the body, and so the client can
- * recover it cleanly even when the body decode fails.
- */
-const val KSRPC_ERROR_MESSAGE_HEADER: String = "X-Ksrpc-Error-Message"
-
-/**
- * Default mapping from ksrpc error codes to HTTP status codes used by the HTTP transport.
- *   - [KsrpcException.ENDPOINT_NOT_FOUND_CODE] (`-32601`) -> 404
- *   - [KsrpcException.INTERNAL_ERROR_CODE] (`-32603`) -> 500
- *
- * Codes not present in the configured map default to status 500, with the original code
- * carried in [KSRPC_ERROR_CODE_HEADER]. The error response body always carries the
- * wire-format-encoded error payload (or empty when no payload is attached).
- *
- * Pass the same map on both ends so the round-trip preserves user-defined codes.
- */
-val DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS: Map<Int, Int> = mapOf(
-    KsrpcException.ENDPOINT_NOT_FOUND_CODE to 404,
-    KsrpcException.INTERNAL_ERROR_CODE to 500
-)
+// KSRPC_ERROR_CODE_HEADER, KSRPC_ERROR_MESSAGE_HEADER, and
+// DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS are defined in ksrpc-ktor-client's
+// HttpErrorMapping.kt and re-exported here via the api dependency.
 
 inline fun <reified T : RpcService> Routing.serveHttp(
     basePath: String,


### PR DESCRIPTION
## Summary
- Remove duplicate definitions of `KSRPC_ERROR_CODE_HEADER`, `KSRPC_ERROR_MESSAGE_HEADER`, and `DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS` from `ksrpc-ktor-server`
- Add `api(project(":ksrpc-ktor-client"))` dependency to the server module so it picks up the shared constants from the client's `HttpErrorMapping.kt`
- Add `supportLinuxArm64 = false` to the server module to match the client's target set

## Test plan
- [x] `./gradlew :ksrpc-ktor-server:compileKotlinLinuxX64` passes
- [x] `./gradlew :ksrpc-ktor-server:apiCheck` passes
- [x] `./gradlew :ksrpc-test:jvmTest` passes
- [x] `./gradlew :ksrpc-test:linkDebugTestLinuxX64` no longer fails with `IrPropertySymbolImpl is already bound` for `DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS`

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)