### PR TITLE
Fix lint violations and add CI lint checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,12 @@ jobs:
       - name: Install libcurl
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
+      - name: Check code style
+        run: ./gradlew ktlintCheck -x ktlintKotlinScriptCheck --continue
+
+      - name: Check license headers
+        run: ./gradlew licenseCheckForKotlin --continue
+
       - name: Check API compatibility
         run: ./gradlew apiCheck
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,14 +66,20 @@ subprojects {
         "licenseCheckForKotlin",
         com.hierynomus.gradle.license.tasks.LicenseCheck::class
     ) {
-        source = fileTree(project.projectDir) { include("**/*.kt") }
+        source = fileTree(project.projectDir) {
+            include("**/*.kt")
+            exclude("build/**")
+        }
     }
     tasks["license"].dependsOn("licenseCheckForKotlin")
     tasks.register(
         "licenseFormatForKotlin",
         com.hierynomus.gradle.license.tasks.LicenseFormat::class
     ) {
-        source = fileTree(project.projectDir) { include("**/*.kt") }
+        source = fileTree(project.projectDir) {
+            include("**/*.kt")
+            exclude("build/**")
+        }
     }
     tasks["licenseFormat"].dependsOn("licenseFormatForKotlin")
 

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
@@ -74,8 +74,4 @@ annotation class KsMethodMetadata
 @KsMethodMetadata
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
-annotation class KsTimeout(
-    val millis: Long = 0,
-    val seconds: Long = 0,
-    val minutes: Long = 0
-)
+annotation class KsTimeout(val millis: Long = 0, val seconds: Long = 0, val minutes: Long = 0)

--- a/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcMethod.kt
@@ -441,7 +441,9 @@ class RpcMethod<T : RpcService, I, O>(
         if (typed != null) return typed
         return when (error.errorCode) {
             KsrpcException.ENDPOINT_NOT_FOUND_CODE -> RpcEndpointException(error.errorMessage)
+
             KsrpcException.INTERNAL_ERROR_CODE -> RpcException(error.errorMessage)
+
             // Forward-compat: unknown wire code (e.g. newer server's typed error not
             // bound here) — surface a generic KsrpcException carrying the raw
             // wire-format payload so callers can still inspect the data even without
@@ -455,11 +457,10 @@ class RpcMethod<T : RpcService, I, O>(
     }
 
     @KsrpcInternal
-    fun findSubserviceTransformers(): List<BaseSubserviceTransformer<*, *>> =
-        listOfNotNull(
-            inputTransform as? BaseSubserviceTransformer<*, *>,
-            outputTransform as? BaseSubserviceTransformer<*, *>
-        )
+    fun findSubserviceTransformers(): List<BaseSubserviceTransformer<*, *>> = listOfNotNull(
+        inputTransform as? BaseSubserviceTransformer<*, *>,
+        outputTransform as? BaseSubserviceTransformer<*, *>
+    )
 
     /**
      * Client-side: extract context values from the current [CoroutineContext]

--- a/ksrpc-core/src/commonMain/kotlin/ServiceTier.kt
+++ b/ksrpc-core/src/commonMain/kotlin/ServiceTier.kt
@@ -23,8 +23,10 @@ import com.monkopedia.ksrpc.annotation.KsrpcInternal
 enum class ServiceTier {
     /** Simple input/output — works on all transports. */
     SIMPLE,
+
     /** Returns sub-services — needs [com.monkopedia.ksrpc.channels.ChannelHost]. */
     HOST,
+
     /** Accepts sub-service inputs or uses Flow — needs bidirectional [com.monkopedia.ksrpc.channels.Connection]. */
     BIDI
 }
@@ -64,21 +66,27 @@ fun <T : RpcService> requireTier(
     // Find the first offending method for a helpful error message.
     for (endpoint in rpcObject.endpoints) {
         val method = rpcObject.findEndpoint(endpoint)
-        if (required == ServiceTier.BIDI && method.inputTransform is BaseSubserviceTransformer<*, *>) {
+        if (required == ServiceTier.BIDI &&
+            method.inputTransform is BaseSubserviceTransformer<*, *>
+        ) {
             throw IllegalArgumentException(
                 "${rpcObject.serviceName} requires bidirectional transport " +
                     "(method '$endpoint' accepts a sub-service input), " +
                     "but $transportName does not support this."
             )
         }
-        if (required == ServiceTier.BIDI && method.outputTransform is BaseSubserviceTransformer<*, *>) {
+        if (required == ServiceTier.BIDI &&
+            method.outputTransform is BaseSubserviceTransformer<*, *>
+        ) {
             throw IllegalArgumentException(
                 "${rpcObject.serviceName} requires bidirectional transport " +
                     "(method '$endpoint' returns a bidirectional sub-service), " +
                     "but $transportName does not support this."
             )
         }
-        if (required == ServiceTier.HOST && method.outputTransform is BaseSubserviceTransformer<*, *>) {
+        if (required == ServiceTier.HOST &&
+            method.outputTransform is BaseSubserviceTransformer<*, *>
+        ) {
             throw IllegalArgumentException(
                 "${rpcObject.serviceName} requires HOST transport " +
                     "(method '$endpoint' returns a sub-service), " +

--- a/ksrpc-core/src/commonMain/kotlin/channels/RpcBinaryData.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/RpcBinaryData.kt
@@ -88,9 +88,11 @@ class ByteArrayBinaryData(
         if (length > 0) sink(data, offset, length)
     }
 
-    override suspend fun toByteArray(): ByteArray =
-        if (offset == 0 && length == data.size) data
-        else data.copyOfRange(offset, offset + length)
+    override suspend fun toByteArray(): ByteArray = if (offset == 0 && length == data.size) {
+        data
+    } else {
+        data.copyOfRange(offset, offset + length)
+    }
 
     override suspend fun close() {} // nothing to release
 }

--- a/ksrpc-core/src/commonMain/kotlin/channels/WireContextMap.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/WireContextMap.kt
@@ -47,7 +47,4 @@ class WireContextMap(val values: Map<String, String>) : CoroutineContext.Element
  * intermediate `withContext` switches in the in-process channel path.
  */
 @KsrpcInternal
-class WireContextCallId(
-    val delegate: RpcCallId?,
-    val wireContextMap: WireContextMap?
-) : RpcCallId
+class WireContextCallId(val delegate: RpcCallId?, val wireContextMap: WireContextMap?) : RpcCallId

--- a/ksrpc-core/src/jsMain/kotlin/RpcObject.kt
+++ b/ksrpc-core/src/jsMain/kotlin/RpcObject.kt
@@ -28,9 +28,7 @@ import kotlin.reflect.findAssociatedObject
 @AssociatedObjectKey
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
-actual annotation class RpcObjectKey actual constructor(
-    actual val rpcObject: KClass<*>
-)
+actual annotation class RpcObjectKey actual constructor(actual val rpcObject: KClass<*>)
 
 @Suppress("UNCHECKED_CAST")
 @OptIn(ExperimentalAssociatedObjects::class, KsrpcInternal::class)

--- a/ksrpc-core/src/jvmMain/kotlin/RpcObjectKey.kt
+++ b/ksrpc-core/src/jvmMain/kotlin/RpcObjectKey.kt
@@ -19,6 +19,4 @@ import kotlin.reflect.KClass
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
-actual annotation class RpcObjectKey actual constructor(
-    actual val rpcObject: KClass<*>
-)
+actual annotation class RpcObjectKey actual constructor(actual val rpcObject: KClass<*>)

--- a/ksrpc-core/src/nativeMain/kotlin/RpcObject.kt
+++ b/ksrpc-core/src/nativeMain/kotlin/RpcObject.kt
@@ -29,9 +29,7 @@ import kotlin.reflect.findAssociatedObject
 @AssociatedObjectKey
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
-actual annotation class RpcObjectKey actual constructor(
-    actual val rpcObject: KClass<*>
-)
+actual annotation class RpcObjectKey actual constructor(actual val rpcObject: KClass<*>)
 
 @Suppress("UNCHECKED_CAST")
 @OptIn(ExperimentalAssociatedObjects::class, KsrpcInternal::class)

--- a/ksrpc-core/src/wasmJsMain/kotlin/RpcObject.kt
+++ b/ksrpc-core/src/wasmJsMain/kotlin/RpcObject.kt
@@ -28,9 +28,7 @@ import kotlin.reflect.findAssociatedObject
 @AssociatedObjectKey
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
-actual annotation class RpcObjectKey actual constructor(
-    actual val rpcObject: KClass<*>
-)
+actual annotation class RpcObjectKey actual constructor(actual val rpcObject: KClass<*>)
 
 @Suppress("UNCHECKED_CAST")
 @OptIn(ExperimentalAssociatedObjects::class, KsrpcInternal::class)

--- a/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/RpcEndpointInfo.kt
+++ b/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/RpcEndpointInfo.kt
@@ -60,10 +60,8 @@ sealed class RpcDataType {
     object BinaryData : RpcDataType()
 
     @Serializable
-    data class Service(
-        val qualifiedName: String,
-        val typeArgs: List<RpcDataType> = emptyList()
-    ) : RpcDataType()
+    data class Service(val qualifiedName: String, val typeArgs: List<RpcDataType> = emptyList()) :
+        RpcDataType()
 }
 
 /**

--- a/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
+++ b/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
@@ -24,8 +24,6 @@ import com.monkopedia.ksrpc.RpcHostService
 import com.monkopedia.ksrpc.RpcService
 import com.monkopedia.ksrpc.ServiceTier
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
-import com.monkopedia.ksrpc.requireTier
-import com.monkopedia.ksrpc.rpcObject
 import com.monkopedia.ksrpc.binary.ktor.asRpcBinaryData
 import com.monkopedia.ksrpc.channels.CallData
 import com.monkopedia.ksrpc.channels.ChannelClient
@@ -34,6 +32,8 @@ import com.monkopedia.ksrpc.channels.SerializedChannel
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.channels.WireContextMap
 import com.monkopedia.ksrpc.internal.HostSerializedChannelImpl
+import com.monkopedia.ksrpc.requireTier
+import com.monkopedia.ksrpc.rpcObject
 import com.monkopedia.ksrpc.serialized
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.decodeURLPart

--- a/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
@@ -238,8 +238,11 @@ abstract class PacketChannelBase<T>(
                         val take = if (remaining > packetMax) packetMax else remaining
                         // Avoid a copy when the chunk is already exactly the right
                         // slice — common for small payloads that fit in one packet.
-                        val packet = if (cursor == 0 && take == bytes.size) bytes
-                            else bytes.copyOfRange(cursor, cursor + take)
+                        val packet = if (cursor == 0 && take == bytes.size) {
+                            bytes
+                        } else {
+                            bytes.copyOfRange(cursor, cursor + take)
+                        }
                         send(
                             Packet(
                                 input = input,

--- a/ksrpc-samples/src/commonMain/kotlin/com/monkopedia/ksrpc/samples/ContextPropagation.kt
+++ b/ksrpc-samples/src/commonMain/kotlin/com/monkopedia/ksrpc/samples/ContextPropagation.kt
@@ -54,8 +54,7 @@ class AuthorizationToken(val bearer: String) : CoroutineContext.Element {
     companion object Key : KsContextBinding<AuthorizationToken> {
         override val wireKey: String = "authorization"
         override fun toWire(value: AuthorizationToken): String = value.bearer
-        override fun fromWire(encoded: String): AuthorizationToken =
-            AuthorizationToken(encoded)
+        override fun fromWire(encoded: String): AuthorizationToken = AuthorizationToken(encoded)
     }
 }
 

--- a/ksrpc-samples/src/commonMain/kotlin/com/monkopedia/ksrpc/samples/FlowStreaming.kt
+++ b/ksrpc-samples/src/commonMain/kotlin/com/monkopedia/ksrpc/samples/FlowStreaming.kt
@@ -53,12 +53,11 @@ fun flowMethodDeclaration() {
  */
 suspend fun collectingFlowFromService() {
     val service = object : LogService {
-        override suspend fun streamLogs(filter: String): Flow<String> =
-            flow {
-                emit("[$filter] Starting...")
-                emit("[$filter] Processing...")
-                emit("[$filter] Done.")
-            }
+        override suspend fun streamLogs(filter: String): Flow<String> = flow {
+            emit("[$filter] Starting...")
+            emit("[$filter] Processing...")
+            emit("[$filter] Done.")
+        }
     }
 
     val env = ksrpcEnvironment { }

--- a/ksrpc-samples/src/commonMain/kotlin/com/monkopedia/ksrpc/samples/SubServices.kt
+++ b/ksrpc-samples/src/commonMain/kotlin/com/monkopedia/ksrpc/samples/SubServices.kt
@@ -63,11 +63,9 @@ suspend fun subServiceOutput() {
     // is hosted as a sub-service on the same connection, with its own
     // channel id managed by the framework.
     val factory = object : WorkerFactory {
-        override suspend fun createWorker(name: String): ScopedWorker =
-            object : ScopedWorker {
-                override suspend fun execute(command: String): String =
-                    "[$name] executed: $command"
-            }
+        override suspend fun createWorker(name: String): ScopedWorker = object : ScopedWorker {
+            override suspend fun execute(command: String): String = "[$name] executed: $command"
+        }
     }
 
     // Serialize and use through a stub -- sub-services work transparently.

--- a/ksrpc-test/src/commonTest/kotlin/FlowAutoDetectTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/FlowAutoDetectTest.kt
@@ -236,11 +236,10 @@ class FlowAutoDetectTest {
                 override suspend fun upload(items: Flow<Chunk>): Receipt =
                     error("not exercised here")
 
-                override suspend fun raw(u: Unit): KsFlowService<Update> =
-                    flow {
-                        emit(Update("r-1"))
-                        emit(Update("r-2"))
-                    }.asKsFlow()
+                override suspend fun raw(u: Unit): KsFlowService<Update> = flow {
+                    emit(Update("r-1"))
+                    emit(Update("r-2"))
+                }.asKsFlow()
 
                 override suspend fun close() = Unit
             }
@@ -281,10 +280,18 @@ class FlowAutoDetectTest {
         try {
             clientJob(clientChannel)
         } finally {
-            try { clientChannel.close() } catch (_: Throwable) {}
-            try { serviceChannel.close() } catch (_: Throwable) {}
-            try { input.cancel(null) } catch (_: Throwable) {}
-            try { si.cancel(null) } catch (_: Throwable) {}
+            try {
+                clientChannel.close()
+            } catch (_: Throwable) {}
+            try {
+                serviceChannel.close()
+            } catch (_: Throwable) {}
+            try {
+                input.cancel(null)
+            } catch (_: Throwable) {}
+            try {
+                si.cancel(null)
+            } catch (_: Throwable) {}
             output.close(null)
             so.close(null)
             bgJob.join()

--- a/ksrpc-test/src/commonTest/kotlin/FlowIntrospectionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/FlowIntrospectionTest.kt
@@ -43,7 +43,9 @@ class FlowIntrospectionTest {
 
     @KsService
     @KsIntrospectable
-    interface FlowIntrospectionService : IntrospectableRpcService, RpcBidiService {
+    interface FlowIntrospectionService :
+        IntrospectableRpcService,
+        RpcBidiService {
         @KsMethod("/updates")
         suspend fun updates(filter: String): Flow<Update>
     }

--- a/ksrpc-test/src/commonTest/kotlin/GenericServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/GenericServiceTest.kt
@@ -81,8 +81,7 @@ private class WrappedEchoStringImpl : WrappedEcho<String> {
         items.map { it?.let { "ln:$it" } }
     override suspend fun nested(items: List<List<String>>): List<List<String>> =
         items.map { row -> row.map { "nd:$it" } }
-    override suspend fun nullableList(items: List<String>?): List<String>? =
-        items?.map { "nl:$it" }
+    override suspend fun nullableList(items: List<String>?): List<String>? = items?.map { "nl:$it" }
     override suspend fun close() = Unit
 }
 
@@ -274,4 +273,3 @@ class GenericServiceFactoryTest {
         )
     }
 }
-

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcContextConventionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcContextConventionTest.kt
@@ -58,8 +58,12 @@ class JsonRpcContextConventionTest {
             val stub = channel.defaultChannel().toStub<ContextService, String>()
             verify(stub)
         } finally {
-            try { input.cancel(null) } catch (_: Throwable) {}
-            try { si.cancel(null) } catch (_: Throwable) {}
+            try {
+                input.cancel(null)
+            } catch (_: Throwable) {}
+            try {
+                si.cancel(null)
+            } catch (_: Throwable) {}
             output.close(null)
             so.close(null)
         }

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcTierCheckTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcTierCheckTest.kt
@@ -37,8 +37,7 @@ class JsonRpcTierCheckTest {
 
         val hostService = object : TestRootInterface {
             override suspend fun rpc(u: Pair<String, String>): String = "${u.first} ${u.second}"
-            override suspend fun subservice(prefix: String): TestSubInterface =
-                error("unreachable")
+            override suspend fun subservice(prefix: String): TestSubInterface = error("unreachable")
         }
 
         val exception = assertFailsWith<IllegalArgumentException> {

--- a/ksrpc-test/src/commonTest/kotlin/KsErrorRoutingTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsErrorRoutingTest.kt
@@ -104,9 +104,8 @@ class KsErrorRoutingTest {
     @Test
     fun mappedThrowDeliversTypedDataToClient() = runBlockingUnit {
         val service = object : TypedErrorService {
-            override suspend fun init(input: String): String {
+            override suspend fun init(input: String): String =
                 throw InitError(retry = true, reason = "bad input: $input")
-            }
 
             override suspend fun plain(input: String): String = error("unused")
             override suspend fun category(input: String): String = error("unused")
@@ -132,9 +131,8 @@ class KsErrorRoutingTest {
     @Test
     fun secondMappingResolvesIndependently() = runBlockingUnit {
         val service = object : TypedErrorService {
-            override suspend fun init(input: String): String {
+            override suspend fun init(input: String): String =
                 throw VersionError(expected = 7, actual = 3)
-            }
 
             override suspend fun plain(input: String): String = error("unused")
             override suspend fun category(input: String): String = error("unused")
@@ -158,9 +156,8 @@ class KsErrorRoutingTest {
     @Test
     fun unmappedThrowFallsBackToRpcException() = runBlockingUnit {
         val service = object : TypedErrorService {
-            override suspend fun init(input: String): String {
+            override suspend fun init(input: String): String =
                 throw IllegalStateException("not mapped")
-            }
 
             override suspend fun plain(input: String): String = error("unused")
             override suspend fun category(input: String): String = error("unused")
@@ -187,9 +184,8 @@ class KsErrorRoutingTest {
     @Test
     fun ksrpcExceptionWithUnboundDataFallsBack() = runBlockingUnit {
         val service = object : TypedErrorService {
-            override suspend fun init(input: String): String {
+            override suspend fun init(input: String): String =
                 throw KsrpcException(code = 999, message = "untyped")
-            }
 
             override suspend fun plain(input: String): String = error("unused")
             override suspend fun category(input: String): String = error("unused")
@@ -219,9 +215,8 @@ class KsErrorRoutingTest {
         val service = object : TypedErrorService {
             override suspend fun init(input: String): String = error("unused")
             override suspend fun plain(input: String): String = error("unused")
-            override suspend fun category(input: String): String {
+            override suspend fun category(input: String): String =
                 throw RetryableError(tag = "io", backoffMs = 250L)
-            }
         }
         withInProcessChannel(service) { stub ->
             try {
@@ -372,9 +367,8 @@ class KsErrorRoutingPipeTest :
         ),
         serializedChannel = {
             val service = object : TypedErrorService {
-                override suspend fun init(input: String): String {
+                override suspend fun init(input: String): String =
                     throw InitError(retry = false, reason = "from-pipe")
-                }
 
                 override suspend fun plain(input: String): String = "ok"
                 override suspend fun category(input: String): String = "ok"
@@ -408,9 +402,8 @@ class KsErrorRoutingPipeFallbackTest :
         ),
         serializedChannel = {
             val service = object : TypedErrorService {
-                override suspend fun init(input: String): String {
+                override suspend fun init(input: String): String =
                     throw IllegalArgumentException("not bound")
-                }
 
                 override suspend fun plain(input: String): String = "ok"
                 override suspend fun category(input: String): String = "ok"

--- a/ksrpc-test/src/commonTest/kotlin/MethodMetadataPropagationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/MethodMetadataPropagationTest.kt
@@ -34,11 +34,7 @@ import kotlin.test.assertTrue
 @KsMethodMetadata
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
-annotation class KsTestMarker(
-    val tag: String,
-    val priority: Int = 0,
-    val flags: Array<String> = []
-)
+annotation class KsTestMarker(val tag: String, val priority: Int = 0, val flags: Array<String> = [])
 
 /**
  * Second demo sibling annotation — verifies that multiple metadata annotations
@@ -69,10 +65,7 @@ class KsTestPayload
 @KsMethodMetadata
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
-annotation class KsTestRef(
-    val payload: kotlin.reflect.KClass<*>,
-    val color: KsTestColor
-)
+annotation class KsTestRef(val payload: kotlin.reflect.KClass<*>, val color: KsTestColor)
 
 /**
  * A plain, non-metadata sibling annotation. The compiler plugin should ignore

--- a/ksrpc-test/src/commonTest/kotlin/NestedGenericIntrospectionTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/NestedGenericIntrospectionTest.kt
@@ -43,14 +43,18 @@ class NestedGenericIntrospectionTest {
 
     @KsService
     @KsIntrospectable
-    interface StreamService : IntrospectableRpcService, RpcBidiService {
+    interface StreamService :
+        IntrospectableRpcService,
+        RpcBidiService {
         @KsMethod("/stream")
         suspend fun stream(input: String): Flow<Update>
     }
 
     @KsService
     @KsIntrospectable
-    interface NestedService : IntrospectableRpcService, RpcBidiService {
+    interface NestedService :
+        IntrospectableRpcService,
+        RpcBidiService {
         @KsMethod("/child")
         suspend fun child(input: String): StreamService
     }
@@ -72,7 +76,9 @@ class NestedGenericIntrospectionTest {
      */
     @KsService
     @KsIntrospectable
-    interface GenericStreamService<T> : IntrospectableRpcService, RpcBidiService {
+    interface GenericStreamService<T> :
+        IntrospectableRpcService,
+        RpcBidiService {
         @KsMethod("/stream")
         suspend fun stream(input: String): Flow<T>
     }

--- a/ksrpc-test/src/commonTest/kotlin/UnhandledMethodHandlerTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/UnhandledMethodHandlerTest.kt
@@ -139,9 +139,7 @@ class RpcUnhandledMethodHandlerThrowsTest :
                 override suspend fun <T> onUnhandled(
                     method: String,
                     input: CallData<T>
-                ): CallData<T> {
-                    throw IllegalStateException("boom:$method")
-                }
+                ): CallData<T> = throw IllegalStateException("boom:$method")
             }
             impl.serialized(ksrpcEnvironment { })
         },

--- a/ksrpc-test/src/jvmTest/kotlin/HttpTypedErrorRoutingTest.kt
+++ b/ksrpc-test/src/jvmTest/kotlin/HttpTypedErrorRoutingTest.kt
@@ -64,9 +64,8 @@ class HttpTypedErrorRoutingTest {
     @Test
     fun typedErrorRoundTripsOverHttp() = runBlockingUnit {
         val service = object : HttpTypedErrorService {
-            override suspend fun init(input: String): String {
+            override suspend fun init(input: String): String =
                 throw HttpInitError(retry = true, reason = "input was: $input")
-            }
 
             override suspend fun missingOnly(input: String): String = "ok"
         }
@@ -147,9 +146,8 @@ class HttpTypedErrorRoutingTest {
     @Test
     fun customCodeFallsBackToHeader() = runBlockingUnit {
         val service = object : HttpTypedErrorService {
-            override suspend fun init(input: String): String {
+            override suspend fun init(input: String): String =
                 throw KsrpcException(code = 100, message = "user failure")
-            }
 
             override suspend fun missingOnly(input: String): String = "ok"
         }
@@ -191,9 +189,8 @@ class HttpTypedErrorRoutingTest {
     @Test
     fun customErrorMappingIsRespectedRoundTrip() = runBlockingUnit {
         val service = object : HttpTypedErrorService {
-            override suspend fun init(input: String): String {
+            override suspend fun init(input: String): String =
                 throw HttpInitError(retry = true, reason = "session expired")
-            }
 
             override suspend fun missingOnly(input: String): String = "ok"
         }

--- a/ksrpc-test/src/jvmTest/kotlin/JniTypedErrorRoutingTest.kt
+++ b/ksrpc-test/src/jvmTest/kotlin/JniTypedErrorRoutingTest.kt
@@ -116,8 +116,7 @@ class JniTypedErrorRoutingTest {
         assertIs<RpcEndpointException>(decoded)
     }
 
-    private fun jniEnv(): KsrpcEnvironment<JniSerialized> =
-        ksrpcEnvironment(JniSerialization()) { }
+    private fun jniEnv(): KsrpcEnvironment<JniSerialized> = ksrpcEnvironment(JniSerialization()) { }
 
     private fun loadNativeLib() {
         NativeUtils.loadLibraryFromJar("/libs/libksrpc_test.${extension()}")

--- a/ksrpc-test/src/nativeTest/kotlin/NativeTestUtil.kt
+++ b/ksrpc-test/src/nativeTest/kotlin/NativeTestUtil.kt
@@ -49,6 +49,7 @@ import platform.posix.pthread_self
 
 @PublishedApi
 internal val nextPort = atomic(9181)
+
 @PublishedApi
 internal const val MAX_BIND_ATTEMPTS = 32
 val serverDispatcher = newFixedThreadPoolContext(8, "server-threads")


### PR DESCRIPTION
## Summary
- Run `ktlintFormat` and `licenseFormat` to fix all accumulated style/header violations from recent PRs (28 files)
- Exclude `build/` directories from license checks to prevent false positives on generated benchmark files
- Add `ktlintCheck` and `licenseCheckForKotlin` steps to CI workflow so future PRs cannot merge with violations

## Test plan
- [x] `./gradlew ktlintCheck -x ktlintKotlinScriptCheck --continue` passes
- [x] `./gradlew licenseCheckForKotlin --continue` passes
- [ ] CI workflow runs lint checks on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)