### PR TITLE
Support @KsService interface inheritance + emit serviceTier on companions

### DIFF
--- a/compiler/plugin/src/main/java/CompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/CompanionGeneration.kt
@@ -39,6 +39,7 @@ import org.jetbrains.kotlin.ir.builders.irWhen
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
@@ -46,6 +47,7 @@ import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.classFqName
@@ -115,6 +117,16 @@ class CompanionGeneration(
                     +irReturn(irListOfStrings(env, endpoints))
                 }
             }
+        // Emit serviceTier property body.
+        val tier = computeServiceTier(cls.irClass)
+        declaration.declarations
+            .filterIsInstance<IrProperty>()
+            .firstOrNull { it.name == FqConstants.SERVICE_TIER }
+            ?.let { property ->
+                property.getter?.body = context.irBuilder(property.getter!!).irSynthBody {
+                    +irReturn(irGetEnumValue(env, tier))
+                }
+            }
         // For generic service companions, eagerly emit the `arity` getter body — the
         // property overrides RpcObjectFactory.arity and must return a fixed integer.
         if (k.isGeneric) {
@@ -169,6 +181,12 @@ class CompanionGeneration(
                 val arity = cls.irClass.typeParameters.size
                 return context.irBuilder(function).irSynthBody {
                     +irReturn(irInt(arity))
+                }
+            }
+            if (propertyName == FqConstants.SERVICE_TIER) {
+                val tier = computeServiceTier(cls.irClass)
+                return context.irBuilder(function).irSynthBody {
+                    +irReturn(irGetEnumValue(env, tier))
                 }
             }
         }

--- a/compiler/plugin/src/main/java/FirCompanionDeclarationGenerator.kt
+++ b/compiler/plugin/src/main/java/FirCompanionDeclarationGenerator.kt
@@ -30,6 +30,7 @@ import com.monkopedia.ksrpc.plugin.FqConstants.RPC_OBJECT
 import com.monkopedia.ksrpc.plugin.FqConstants.RPC_OBJECT_FACTORY
 import com.monkopedia.ksrpc.plugin.FqConstants.SERIALIZED_SERVICE
 import com.monkopedia.ksrpc.plugin.FqConstants.SERVICE_NAME
+import com.monkopedia.ksrpc.plugin.FqConstants.SERVICE_TIER
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality.FINAL
@@ -177,6 +178,7 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
         return when (callableId.callableName) {
             SERVICE_NAME -> createServiceName(callableId, context.owner, ownerKey)
             ENDPOINTS -> createEndpoints(callableId, context.owner, ownerKey)
+            SERVICE_TIER -> createServiceTier(callableId, context.owner, ownerKey)
             else -> emptyList()
         }
     }
@@ -337,6 +339,28 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
         return listOf(property.symbol)
     }
 
+    private fun createServiceTier(
+        callableId: CallableId,
+        owner: FirClassSymbol<*>,
+        ownerKey: Key
+    ): List<FirPropertySymbol> {
+        val tierType = FqConstants.SERVICE_TIER_CLASS.createConeType(session)
+        val property = createMemberProperty(
+            owner,
+            ownerKey,
+            callableId.callableName,
+            tierType,
+            isVal = true,
+            hasBackingField = false
+        ) {
+            modality = FINAL
+            status {
+                isOverride = true
+            }
+        }
+        return listOf(property.symbol)
+    }
+
     override fun getCallableNamesForClass(
         classSymbol: FirClassSymbol<*>,
         context: MemberGenerationContext
@@ -352,7 +376,7 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
         val origin = classSymbol.origin as? FirDeclarationOrigin.Plugin
         val key = origin?.key as? Key
         return when {
-            key == null -> setOf(FIND_ENDPOINT, CREATE_STUB, SERVICE_NAME, ENDPOINTS)
+            key == null -> setOf(FIND_ENDPOINT, CREATE_STUB, SERVICE_NAME, ENDPOINTS, SERVICE_TIER)
 
             key.isGeneric -> if (factorySupported) {
                 setOf(INVOKE, CREATE, ARITY, SpecialNames.INIT)
@@ -360,7 +384,10 @@ class FirCompanionDeclarationGenerator(session: FirSession) :
                 setOf(INVOKE, SpecialNames.INIT)
             }
 
-            else -> setOf(FIND_ENDPOINT, CREATE_STUB, SERVICE_NAME, ENDPOINTS, SpecialNames.INIT)
+            else -> setOf(
+                FIND_ENDPOINT, CREATE_STUB, SERVICE_NAME, ENDPOINTS, SERVICE_TIER,
+                SpecialNames.INIT
+            )
         }
     }
 

--- a/compiler/plugin/src/main/java/FirKsrpcObjGenerator.kt
+++ b/compiler/plugin/src/main/java/FirKsrpcObjGenerator.kt
@@ -25,6 +25,7 @@ import com.monkopedia.ksrpc.plugin.FqConstants.RPC_METHOD
 import com.monkopedia.ksrpc.plugin.FqConstants.RPC_OBJECT
 import com.monkopedia.ksrpc.plugin.FqConstants.SERIALIZED_SERVICE
 import com.monkopedia.ksrpc.plugin.FqConstants.SERVICE_NAME
+import com.monkopedia.ksrpc.plugin.FqConstants.SERVICE_TIER
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
@@ -136,6 +137,7 @@ class FirKsrpcObjGenerator(session: FirSession) : FirDeclarationGenerationExtens
         return when (callableId.callableName) {
             SERVICE_NAME -> createServiceName(callableId, owner, ownerKey)
             ENDPOINTS -> createEndpoints(callableId, owner, ownerKey)
+            SERVICE_TIER -> createServiceTier(callableId, owner, ownerKey)
             else -> emptyList()
         }
     }
@@ -234,6 +236,28 @@ class FirKsrpcObjGenerator(session: FirSession) : FirDeclarationGenerationExtens
         return listOf(property.symbol)
     }
 
+    private fun createServiceTier(
+        callableId: CallableId,
+        owner: FirRegularClassSymbol,
+        ownerKey: Key
+    ): List<FirPropertySymbol> {
+        val tierType = FqConstants.SERVICE_TIER_CLASS.createConeType(session)
+        val property = createMemberProperty(
+            owner,
+            ownerKey,
+            callableId.callableName,
+            tierType,
+            isVal = true,
+            hasBackingField = false
+        ) {
+            modality = Modality.FINAL
+            status {
+                isOverride = true
+            }
+        }
+        return listOf(property.symbol)
+    }
+
     override fun getCallableNamesForClass(
         classSymbol: FirClassSymbol<*>,
         context: MemberGenerationContext
@@ -248,6 +272,7 @@ class FirKsrpcObjGenerator(session: FirSession) : FirDeclarationGenerationExtens
                 FIND_ENDPOINT,
                 SERVICE_NAME,
                 ENDPOINTS,
+                SERVICE_TIER,
                 SpecialNames.INIT
             )
         } else {

--- a/compiler/plugin/src/main/java/FqConstants.kt
+++ b/compiler/plugin/src/main/java/FqConstants.kt
@@ -106,6 +106,7 @@ object FqConstants {
     val FIND_ENDPOINT = Name.identifier("findEndpoint")
     val SERVICE_NAME = Name.identifier("serviceName")
     val ENDPOINTS = Name.identifier("endpoints")
+    val SERVICE_TIER = Name.identifier("serviceTier")
     val OBJ = Name.identifier("Obj")
 
     val RPC_OBJECT = ClassId(FQPKG, Name.identifier("RpcObject"))

--- a/compiler/plugin/src/main/java/FqConstants.kt
+++ b/compiler/plugin/src/main/java/FqConstants.kt
@@ -109,6 +109,7 @@ object FqConstants {
     val SERVICE_TIER = Name.identifier("serviceTier")
     val OBJ = Name.identifier("Obj")
 
+    val SERVICE_TIER_CLASS = ClassId(FQPKG, Name.identifier("ServiceTier"))
     val RPC_OBJECT = ClassId(FQPKG, Name.identifier("RpcObject"))
     val RPC_OBJECT_FACTORY = ClassId(FQPKG, Name.identifier("RpcObjectFactory"))
     val RESOLVE_SERIALIZER_OR_THROW: CallableId =

--- a/compiler/plugin/src/main/java/IrUtils.kt
+++ b/compiler/plugin/src/main/java/IrUtils.kt
@@ -64,8 +64,10 @@ import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
 import org.jetbrains.kotlin.ir.util.defaultType as irClassDefaultType
 import org.jetbrains.kotlin.ir.util.erasedUpperBound
+import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.getAllSuperclasses
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -75,6 +77,25 @@ fun IrBuilderWithScope.buildStringFormat(vararg args: IrExpression): IrStringCon
     irConcat().apply {
         arguments += args
     }
+
+/**
+ * Emit an `IrGetEnumValue` expression for the given [entryName] on the `ServiceTier` enum.
+ */
+internal fun IrBuilderWithScope.irGetEnumValue(
+    env: KsrpcGenerationEnvironment,
+    entryName: String
+): IrExpression {
+    val enumClass = env.serviceTierClass.owner
+    val entry = enumClass.declarations
+        .filterIsInstance<org.jetbrains.kotlin.ir.declarations.IrEnumEntry>()
+        .first { it.name.asString() == entryName }
+    return org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl(
+        SYNTHETIC_OFFSET,
+        SYNTHETIC_OFFSET,
+        env.serviceTierClass.defaultType,
+        entry.symbol
+    )
+}
 
 inline fun DeclarationIrBuilder.irSynthBody(builder: IrBlockBodyBuilder.() -> Unit) = irBlockBody {
     startOffset = SYNTHETIC_OFFSET
@@ -122,6 +143,20 @@ fun IrClass.isSubclassOfFqName(fqName: String): Boolean =
         superTypes.any {
             it.erasedUpperBound.isSubclassOfFqName(fqName)
         }
+
+/**
+ * Determine the service tier from an `@KsService` interface's supertypes.
+ * Returns "SIMPLE", "HOST", or "BIDI".
+ */
+internal fun computeServiceTier(irClass: IrClass): String = when {
+    irClass.getAllSuperclasses().any {
+        it.fqNameForIrSerialization == FqConstants.FQRPC_BIDI_SERVICE
+    } -> "BIDI"
+    irClass.getAllSuperclasses().any {
+        it.fqNameForIrSerialization == FqConstants.FQRPC_HOST_SERVICE
+    } -> "HOST"
+    else -> "SIMPLE"
+}
 
 fun IrSimpleFunction.overridesFunctionIn(fqName: FqName): Boolean =
     parentClassOrNull?.fqNameWhenAvailable == fqName ||

--- a/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
+++ b/compiler/plugin/src/main/java/KsrpcGenerationEnvironment.kt
@@ -92,6 +92,7 @@ class KsrpcGenerationEnvironment(
     val introspectionConstructor: IrConstructorSymbol by lazy {
         introspectionImpl.constructors.first()
     }
+    val serviceTierClass = referenceClass(FqConstants.SERVICE_TIER_CLASS)
     val subserviceTransformer = referenceClass(FqConstants.SUBSERVICE_TRANSFORMER)
     val rpcObjectKey = maybeReferenceClass(FqConstants.RPC_OBJECT_KEY)
     val suspendCloseable = referenceClass(FqConstants.SUSPEND_CLOSEABLE)

--- a/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
+++ b/compiler/plugin/src/main/java/KsrpcIrGenerationExtension.kt
@@ -209,30 +209,33 @@ class KsrpcIrGenerationExtension(private val report: MessageCollector) : IrGener
         val hasRpcServiceSuper = allSuperFqNames.contains(FQRPC_SERVICE)
         val hasIntrospectableSuper =
             allSuperFqNames.contains(INTROSPECTABLE_RPC_SERVICE.asSingleFqName())
-        // Reject `@KsService` applied to a subtype of another `@KsService` interface.
-        // The parent's @KsService annotation already drives codegen, and `rpcObject<Sub>()`
-        // walks supertypes to find the parent's `RpcObject`/`RpcObjectFactory` companion
-        // automatically. Allowing @KsService on the subtype would produce a duplicate
-        // companion that has no working stub/obj of its own and previously crashed
-        // CompanionGeneration with "Invalid synthetic declaration for ..." (issue #45).
-        val ksServiceSuper = irClass.superTypes
+        // Check for diamond @KsService inheritance (two UNRELATED @KsService ancestors).
+        // Linear chains (A extends B, both @KsService) are now allowed.
+        val ksServiceSupers = irClass.superTypes
             .mapNotNull { it.classOrNull?.owner }
-            .firstOrNull { superClass ->
+            .filter { superClass ->
                 superClass.annotations.any { it.type.classFqName == KS_SERVICE }
             }
-        if (ksServiceSuper != null) {
-            report.reportUserError(
-                "@KsService cannot be applied to ${irClass.kotlinFqName.asString()} because " +
-                    "its supertype ${ksServiceSuper.kotlinFqName.asString()} is already " +
-                    "@KsService. Remove @KsService from " +
-                    "${irClass.kotlinFqName.asString()}; rpcObject<" +
-                    "${irClass.name.asString()}>() will find the parent's companion " +
-                    "automatically.",
-                element = irClass
-            )
-            isValid = false
+        if (ksServiceSupers.size > 1) {
+            // Leaf-filter: keep only those not transitively extended by another in the list
+            val leafSupers = ksServiceSupers.filter { candidate ->
+                ksServiceSupers.none { other ->
+                    other != candidate &&
+                        other.getAllSuperclasses().any {
+                            it.fqNameForIrSerialization == candidate.fqNameForIrSerialization
+                        }
+                }
+            }
+            if (leafSupers.size > 1) {
+                report.reportUserError(
+                    "${irClass.kotlinFqName.asString()} has " +
+                        "multiple @KsService super types, which is not supported.",
+                    element = irClass
+                )
+                isValid = false
+            }
         }
-        if (!hasRpcServiceSuper && !hasIntrospectableSuper && ksServiceSuper == null) {
+        if (!hasRpcServiceSuper && !hasIntrospectableSuper && ksServiceSupers.isEmpty()) {
             report.reportUserError(
                 "${irClass.kotlinFqName.asString()} does not extend ${FQRPC_SERVICE.asString()}",
                 element = irClass

--- a/compiler/plugin/src/main/java/ObjGeneration.kt
+++ b/compiler/plugin/src/main/java/ObjGeneration.kt
@@ -132,6 +132,15 @@ class ObjGeneration(
                     +irReturn(irListOfStrings(env, endpointsList))
                 }
             }
+        // Emit serviceTier property body.
+        val tier = computeServiceTier(cls.irClass)
+        declaration.declarations.filterIsInstance<IrProperty>()
+            .firstOrNull { it.name == FqConstants.SERVICE_TIER }
+            ?.let { property ->
+                property.getter?.body = context.irBuilder(property.getter!!).irSynthBody {
+                    +irReturn(irGetEnumValue(env, tier))
+                }
+            }
         return emptyList()
     }
 
@@ -173,6 +182,12 @@ class ObjGeneration(
                 }
                 return context.irBuilder(function).irSynthBody {
                     +irReturn(irListOfStrings(env, endpoints))
+                }
+            }
+            if (propertyName == FqConstants.SERVICE_TIER) {
+                val tier = computeServiceTier(cls.irClass)
+                return context.irBuilder(function).irSynthBody {
+                    +irReturn(irGetEnumValue(env, tier))
                 }
             }
         }

--- a/compiler/plugin/src/main/java/ServiceClass.kt
+++ b/compiler/plugin/src/main/java/ServiceClass.kt
@@ -137,17 +137,32 @@ private class SubclassVisitor(
     private val classes: Map<String, ServiceClass>
 ) : IrElementTransformerVoid() {
     override fun visitClass(declaration: IrClass): IrStatement {
-        declaration.getAllSuperclasses().mapNotNull {
+        val declFqName = declaration.fqNameForIrSerialization.asString()
+        // Skip if this class is itself a @KsService (it has its own entry)
+        if (declFqName in classes) {
+            return super.visitClass(declaration)
+        }
+        val ksServiceSupers = declaration.getAllSuperclasses().mapNotNull {
             classes[it.fqNameForIrSerialization.asString()]
-        }.also {
-            if (it.size > 1) {
-                messageCollector.reportUserError(
-                    "${declaration.fqNameForIrSerialization.asString()} has " +
-                        "multiple @KsService super types, which is not supported.",
-                    element = declaration
-                )
+        }
+        // Leaf-filter: keep only those not transitively extended by another in the list
+        val leafSupers = ksServiceSupers.filter { candidate ->
+            ksServiceSupers.none { other ->
+                other != candidate &&
+                    other.irClass.getAllSuperclasses().any {
+                        it.fqNameForIrSerialization.asString() ==
+                            candidate.irClass.fqNameForIrSerialization.asString()
+                    }
             }
-        }.singleOrNull()?.irClassAndImpls?.add(declaration)
+        }
+        if (leafSupers.size > 1) {
+            messageCollector.reportUserError(
+                "${declaration.fqNameForIrSerialization.asString()} has " +
+                    "multiple @KsService super types, which is not supported.",
+                element = declaration
+            )
+        }
+        leafSupers.singleOrNull()?.irClassAndImpls?.add(declaration)
         return super.visitClass(declaration)
     }
 }
@@ -234,14 +249,70 @@ data class ServiceClass(
     }
 
     companion object {
+        private val serviceAnnotationFqName =
+            FqName("com.monkopedia.ksrpc.annotation.KsService")
+
         fun findServices(
             messageCollector: MessageCollector,
             moduleFragment: IrModuleFragment
         ): MutableMap<String, ServiceClass> {
             val visitor = Visitor(messageCollector)
             visitor.visitElement(moduleFragment)
+            // Import inherited methods from parent @KsService classes
+            importInheritedMethods(visitor.classes)
             SubclassVisitor(messageCollector, visitor.classes).visitElement(moduleFragment)
             return visitor.classes
+        }
+
+        /**
+         * For each ServiceClass, walk its @KsService supertypes (found in [classes])
+         * and import their ServiceMethod entries. Skip methods already present in the
+         * child (by endpoint name extracted from the @KsMethod annotation value).
+         */
+        private fun importInheritedMethods(classes: MutableMap<String, ServiceClass>) {
+            for ((_, serviceClass) in classes) {
+                val existingEndpoints = serviceClass.methods.map { method ->
+                    extractEndpointName(method)
+                }.toMutableSet()
+                // Walk supertypes to find parent @KsService classes
+                val visited = mutableSetOf<String>()
+                val queue = ArrayDeque<IrClass>()
+                for (superType in serviceClass.irClass.superTypes) {
+                    val superClass = superType.classOrNull?.owner ?: continue
+                    val fqName = superClass.fqNameForIrSerialization.asString()
+                    if (visited.add(fqName)) queue.add(superClass)
+                }
+                while (queue.isNotEmpty()) {
+                    val current = queue.removeFirst()
+                    val currentFqName = current.fqNameForIrSerialization.asString()
+                    val parentService = classes[currentFqName]
+                    if (parentService != null) {
+                        for (method in parentService.methods) {
+                            val endpoint = extractEndpointName(method)
+                            if (endpoint !in existingEndpoints) {
+                                existingEndpoints.add(endpoint)
+                                serviceClass.methods.add(method)
+                            }
+                        }
+                    }
+                    // Continue walking up
+                    for (superType in current.superTypes) {
+                        val superClass = superType.classOrNull?.owner ?: continue
+                        val fqName = superClass.fqNameForIrSerialization.asString()
+                        if (visited.add(fqName)) queue.add(superClass)
+                    }
+                }
+            }
+        }
+
+        /**
+         * Extract the endpoint name from a ServiceMethod's @KsMethod annotation.
+         * The first argument of @KsMethod is the endpoint string.
+         */
+        private fun extractEndpointName(method: ServiceMethod): String {
+            val annotation = method.ksMethodAnnotation
+            return annotation.arguments[0].constString()
+                ?: method.function.name.asString()
         }
     }
 }

--- a/compiler/plugin/src/main/java/fir/KsServiceClassChecker.kt
+++ b/compiler/plugin/src/main/java/fir/KsServiceClassChecker.kt
@@ -99,16 +99,23 @@ internal object KsServiceClassChecker :
             checkKsServiceClass(declaration, symbol, ksServiceSuperSymbols, context, reporter)
         } else {
             // Non-@KsService classes are only interesting if they implement multiple
-            // @KsService interfaces (legacy SubclassVisitor behaviour).
+            // UNRELATED @KsService interfaces (legacy SubclassVisitor behaviour).
             if (ksServiceSuperSymbols.size > 1) {
-                val source = declaration.source ?: return
-                reporter.reportOn(
-                    source,
-                    KsrpcDiagnostics.MULTIPLE_KSSERVICE_SUPERTYPES,
-                    "${symbol.classId.asFqNameString()} has " +
-                        "multiple @KsService super types, which is not supported.",
-                    context
-                )
+                val leafKsServiceSupers = ksServiceSuperSymbols.filter { candidate ->
+                    ksServiceSuperSymbols.none { other ->
+                        other != candidate && transitivelyExtends(other, candidate, context.session)
+                    }
+                }
+                if (leafKsServiceSupers.size > 1) {
+                    val source = declaration.source ?: return
+                    reporter.reportOn(
+                        source,
+                        KsrpcDiagnostics.MULTIPLE_KSSERVICE_SUPERTYPES,
+                        "${symbol.classId.asFqNameString()} has " +
+                            "multiple @KsService super types, which is not supported.",
+                        context
+                    )
+                }
             }
         }
     }
@@ -145,27 +152,27 @@ internal object KsServiceClassChecker :
         val hasRpcServiceSuper = allSuperFqNames.contains(FQRPC_SERVICE)
         val hasIntrospectableSuper = allSuperFqNames.contains(FQ_INTROSPECTABLE_RPC_SERVICE)
 
-        val ksServiceSuper = ksServiceSuperSymbols.firstOrNull()
-        if (ksServiceSuper != null) {
-            // #1: @KsService on a subtype of another @KsService — reject with the
-            // existing wording so the existing test suite keeps asserting on the
-            // same message.
-            val selfFqName = symbol.classId.asFqNameString()
-            val superFqName = ksServiceSuper.classId.asFqNameString()
-            val selfShortName = symbol.classId.shortClassName.asString()
-            reporter.reportOn(
-                source,
-                KsrpcDiagnostics.KSSERVICE_SUBTYPE_OF_KSSERVICE,
-                "@KsService cannot be applied to $selfFqName because " +
-                    "its supertype $superFqName is already " +
-                    "@KsService. Remove @KsService from " +
-                    "$selfFqName; rpcObject<" +
-                    "$selfShortName>() will find the parent's companion " +
-                    "automatically.",
-                context
-            )
+        // #1: Check for diamond inheritance (two UNRELATED @KsService ancestors).
+        // A linear chain (A extends B extends C, all @KsService) is allowed.
+        // Filter to "leaf" services: those not transitively extended by another
+        // @KsService in the list.
+        if (ksServiceSuperSymbols.size > 1) {
+            val leafKsServiceSupers = ksServiceSuperSymbols.filter { candidate ->
+                ksServiceSuperSymbols.none { other ->
+                    other != candidate && transitivelyExtends(other, candidate, session)
+                }
+            }
+            if (leafKsServiceSupers.size > 1) {
+                reporter.reportOn(
+                    source,
+                    KsrpcDiagnostics.MULTIPLE_KSSERVICE_SUPERTYPES,
+                    "${symbol.classId.asFqNameString()} has " +
+                        "multiple @KsService super types, which is not supported.",
+                    context
+                )
+            }
         }
-        if (!hasRpcServiceSuper && !hasIntrospectableSuper && ksServiceSuper == null) {
+        if (!hasRpcServiceSuper && !hasIntrospectableSuper && ksServiceSuperSymbols.isEmpty()) {
             // #2
             reporter.reportOn(
                 source,
@@ -275,11 +282,10 @@ internal object KsServiceClassChecker :
             } else {
                 val returnServiceSymbol = asKsServiceSymbol(returnType, session)
                 if (returnServiceSymbol != null) {
-                    // Returning a sub-service requires at least HOST
-                    val subTier = tierOfService(returnServiceSymbol, session)
+                    // Returning a sub-service requires at least HOST.
+                    // The sub-service's own tier is NOT propagated — the parent
+                    // only needs to host the sub-service, not replicate its tier.
                     requiredForMethod = maxOf(requiredForMethod, Tier.HOST)
-                    // If the sub-service itself requires BIDI, propagate
-                    requiredForMethod = maxOf(requiredForMethod, subTier)
                 }
             }
 
@@ -343,6 +349,34 @@ internal object KsServiceClassChecker :
             return "returns $name (a ${tier.interfaceName})"
         }
         return "requires a higher service tier"
+    }
+
+    /**
+     * Check whether [child] transitively extends [ancestor] through supertypes.
+     */
+    @OptIn(SymbolInternals::class)
+    private fun transitivelyExtends(
+        child: FirClassSymbol<*>,
+        ancestor: FirClassSymbol<*>,
+        session: FirSession
+    ): Boolean {
+        val targetClassId = ancestor.classId
+        val visited = mutableSetOf<ClassId>()
+        val queue = ArrayDeque<FirClassSymbol<*>>()
+        // Start from child's supertypes
+        for (superRef in child.fir.superTypeRefs) {
+            val sym = superRef.toRegularClassSymbol(session) ?: continue
+            if (visited.add(sym.classId)) queue.add(sym)
+        }
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (current.classId == targetClassId) return true
+            for (superRef in current.fir.superTypeRefs) {
+                val sym = superRef.toRegularClassSymbol(session) ?: continue
+                if (visited.add(sym.classId)) queue.add(sym)
+            }
+        }
+        return false
     }
 
     /**

--- a/compiler/plugin/src/test/java/KsServiceHierarchyTest.kt
+++ b/compiler/plugin/src/test/java/KsServiceHierarchyTest.kt
@@ -197,6 +197,7 @@ import com.monkopedia.ksrpc.annotation.KsService
 import com.monkopedia.ksrpc.RpcService
 import com.monkopedia.ksrpc.RpcBidiService
 import com.monkopedia.ksrpc.ksrpcEnvironment
+import com.monkopedia.ksrpc.serialized
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 

--- a/compiler/plugin/src/test/java/KsServiceHierarchyTest.kt
+++ b/compiler/plugin/src/test/java/KsServiceHierarchyTest.kt
@@ -1,0 +1,410 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package com.monkopedia.ksrpc.plugin
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Test
+
+/**
+ * Compiler plugin tests for @KsService interface inheritance (hierarchy support).
+ *
+ * Currently @KsService on a subtype of another @KsService is rejected. These tests
+ * document the intended behavior once the restriction is lifted. They are expected to
+ * FAIL until the feature is implemented.
+ */
+class KsServiceHierarchyTest {
+
+    @Test
+    fun `KsService extending KsService compiles successfully`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.RpcBidiService
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface CoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+@KsService
+interface ExtendedService : CoreService, RpcBidiService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<String>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected @KsService extending @KsService to compile. messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `linear chain A to B to C compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.RpcHostService
+import com.monkopedia.ksrpc.RpcBidiService
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface BaseService : RpcService {
+    @KsMethod("/base")
+    suspend fun base(): String
+}
+
+@KsService
+interface MiddleService : BaseService, RpcHostService {
+    @KsMethod("/middle")
+    suspend fun middle(): BaseService
+}
+
+@KsService
+interface FullService : MiddleService, RpcBidiService {
+    @KsMethod("/stream")
+    suspend fun stream(): Flow<String>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected linear chain to compile. messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `stub has all inherited methods`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.RpcBidiService
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface CoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+@KsService
+interface ExtendedService : CoreService, RpcBidiService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<String>
+}
+
+// Verify the Stub can be instantiated and has both inherited and own methods
+suspend fun useStub(channel: SerializedService<String>): String {
+    val stub = ExtendedService.Stub(channel)
+    val data = stub.getData("test")
+    return data
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected stub to have inherited methods. messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `endpoints list contains both inherited and own endpoints`() {
+        // This test verifies the companion's rpcObject contains all endpoints.
+        // The actual runtime assertion is in the integration test; here we verify
+        // the code that accesses both endpoints compiles.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.RpcBidiService
+import com.monkopedia.ksrpc.rpcObject
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface CoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+@KsService
+interface ExtendedService : CoreService, RpcBidiService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<String>
+}
+
+fun checkEndpoints() {
+    val obj = rpcObject<ExtendedService>()
+    val endpoints = obj.endpoints
+    require("getData" in endpoints) { "Missing inherited endpoint getData" }
+    require("updates" in endpoints) { "Missing own endpoint updates" }
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected endpoints access to compile. messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `implementation class does not get multiple KsService supertypes error`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.RpcBidiService
+import com.monkopedia.ksrpc.ksrpcEnvironment
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+@KsService
+interface CoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+@KsService
+interface ExtendedService : CoreService, RpcBidiService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<String>
+}
+
+class ExtendedServiceImpl : ExtendedService {
+    override suspend fun getData(id: String): String = "data-${'$'}id"
+    override suspend fun updates(filter: String): Flow<String> = flowOf("u1")
+}
+
+suspend fun roundTrip() {
+    val impl = ExtendedServiceImpl()
+    val channel = impl.serialized<ExtendedService, String>(ksrpcEnvironment { })
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected implementation class to compile without errors. " +
+                "messages: ${result.messages}"
+        )
+        assertTrue(
+            !result.messages.contains("multiple @KsService supertypes"),
+            "Should not get 'multiple @KsService supertypes' error. " +
+                "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `child with bidi methods must extend RpcBidiService`() {
+        // Tier enforcement: if parent is RpcService but child adds Flow methods,
+        // the child must extend RpcBidiService. This test verifies the tier check
+        // still applies to inherited + own methods combined.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface CoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+// This should fail: has Flow method but only extends RpcService (via CoreService)
+@KsService
+interface BadExtendedService : CoreService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<String>
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        // Should fail because Flow requires RpcBidiService
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail when Flow method lacks RpcBidiService tier. " +
+                "messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("RpcBidiService"),
+            "Expected error to suggest RpcBidiService. messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `child with sub-service output must extend at least RpcHostService`() {
+        // Tier enforcement: if child adds a sub-service-returning method, it needs
+        // at least RpcHostService.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+
+@KsService
+interface LeafService : RpcService {
+    @KsMethod("/ping")
+    suspend fun ping(msg: String): String
+}
+
+@KsService
+interface CoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+// This should fail: has sub-service output but only extends RpcService (via CoreService)
+@KsService
+interface BadHostService : CoreService {
+    @KsMethod("/getLeaf")
+    suspend fun getLeaf(): LeafService
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertTrue(
+            result.exitCode != KotlinCompilation.ExitCode.OK,
+            "Expected compilation to fail when sub-service output lacks RpcHostService tier. " +
+                "messages: ${result.messages}"
+        )
+        assertTrue(
+            result.messages.contains("RpcHostService"),
+            "Expected error to suggest RpcHostService. messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `sub-service returning a hierarchy service compiles`() {
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.RpcHostService
+import com.monkopedia.ksrpc.RpcBidiService
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface CoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+@KsService
+interface ExtendedService : CoreService, RpcBidiService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<String>
+}
+
+@KsService
+interface ParentService : RpcHostService {
+    @KsMethod("/getExtended")
+    suspend fun getExtended(): ExtendedService
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected sub-service returning hierarchy service to compile. " +
+                "messages: ${result.messages}"
+        )
+    }
+
+    @Test
+    fun `parent service unaffected by child existing`() {
+        // Verifying that the parent @KsService still compiles and generates correctly
+        // when a child @KsService extends it in the same compilation unit.
+        val source = SourceFile.kotlin(
+            "main.kt",
+            """
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.RpcBidiService
+import com.monkopedia.ksrpc.rpcObject
+import com.monkopedia.ksrpc.channels.SerializedService
+import kotlinx.coroutines.flow.Flow
+
+@KsService
+interface CoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+@KsService
+interface ExtendedService : CoreService, RpcBidiService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<String>
+}
+
+// Verify CoreService still works independently
+suspend fun useCoreStub(channel: SerializedService<String>): String {
+    val stub = CoreService.Stub(channel)
+    return stub.getData("test")
+}
+
+fun checkCoreEndpoints() {
+    val obj = rpcObject<CoreService>()
+    require("getData" in obj.endpoints)
+}
+"""
+        )
+        val result = compile(sourceFile = source)
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected parent service to still work independently. " +
+                "messages: ${result.messages}"
+        )
+    }
+}

--- a/compiler/plugin/src/test/java/KsServiceSubtypeValidationTest.kt
+++ b/compiler/plugin/src/test/java/KsServiceSubtypeValidationTest.kt
@@ -25,16 +25,17 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Test
 
 /**
- * Regression tests for issue #45: applying `@KsService` to a subtype of another
- * `@KsService` interface used to crash CompanionGeneration with
- * "Invalid synthetic declaration for ...". The plugin now rejects this with a clear
- * compile-time diagnostic, while the supported workaround (a plain Kotlin subtype with
- * no `@KsService`) continues to work — see `GenericServiceSubtypeJvmTest`.
+ * Tests for @KsService interface inheritance support.
+ *
+ * @KsService on a subtype of another @KsService is now allowed (interface hierarchy).
+ * Only true diamond inheritance (two UNRELATED @KsService ancestors) is rejected.
+ * The supported workaround (a plain Kotlin subtype with no `@KsService`) also
+ * continues to work — see `GenericServiceSubtypeJvmTest`.
  */
 class KsServiceSubtypeValidationTest {
 
     @Test
-    fun `KsService on subtype of generic KsService is rejected with a clear diagnostic`() {
+    fun `KsService on subtype of generic KsService compiles successfully`() {
         val source = SourceFile.kotlin(
             "main.kt",
             """
@@ -53,27 +54,16 @@ interface TypedGenericEcho : GenericEcho<String>
 """
         )
         val result = compile(listOf(source))
-        assertTrue(
-            result.exitCode != KotlinCompilation.ExitCode.OK,
-            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
-        )
-        assertTrue(
-            result.messages.contains("@KsService cannot be applied to") &&
-                result.messages.contains("TypedGenericEcho") &&
-                result.messages.contains("GenericEcho"),
-            "Expected diagnostic mentioning @KsService, TypedGenericEcho and GenericEcho, " +
-                "got: ${result.messages}"
-        )
-        // Make sure we're not seeing the old crash anymore.
-        assertTrue(
-            !result.messages.contains("Invalid synthetic declaration"),
-            "Plugin should not crash with 'Invalid synthetic declaration' anymore, " +
-                "got: ${result.messages}"
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected @KsService on subtype of generic @KsService to compile. " +
+                "messages: ${result.messages}"
         )
     }
 
     @Test
-    fun `KsService on subtype of non-generic KsService is rejected`() {
+    fun `KsService on subtype of non-generic KsService compiles successfully`() {
         val source = SourceFile.kotlin(
             "main.kt",
             """
@@ -92,16 +82,11 @@ interface ChildService : ParentService
 """
         )
         val result = compile(listOf(source))
-        assertTrue(
-            result.exitCode != KotlinCompilation.ExitCode.OK,
-            "Expected compilation to fail but got: ${result.exitCode}\n${result.messages}"
-        )
-        assertTrue(
-            result.messages.contains("@KsService cannot be applied to") &&
-                result.messages.contains("ChildService") &&
-                result.messages.contains("ParentService"),
-            "Expected diagnostic mentioning @KsService, ChildService and ParentService, " +
-                "got: ${result.messages}"
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Expected @KsService on subtype of non-generic @KsService to compile. " +
+                "messages: ${result.messages}"
         )
     }
 

--- a/compiler/plugin/src/test/java/ServiceTierValidationTest.kt
+++ b/compiler/plugin/src/test/java/ServiceTierValidationTest.kt
@@ -262,7 +262,9 @@ interface FullService : RpcBidiService {
     }
 
     @Test
-    fun `recursive - service returning a RpcBidiService sub-service needs RpcBidiService`() {
+    fun `recursive - service returning a RpcBidiService sub-service only needs RpcHostService`() {
+        // Returning a sub-service only requires HOST tier regardless of the sub-service's
+        // own tier. The sub-service manages its own bidirectional connections.
         val source = SourceFile.kotlin(
             "main.kt",
             """
@@ -292,16 +294,10 @@ interface Outer : RpcHostService {
         )
         val result = compile(sourceFile = source)
         assertEquals(
-            KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            KotlinCompilation.ExitCode.OK,
             result.exitCode,
-            "messages: ${result.messages}"
-        )
-        assertTrue(
-            result.messages.contains("Outer") &&
-                result.messages.contains("bidi") &&
-                result.messages.contains("RpcBidiService"),
-            "Expected diagnostic mentioning Outer, method 'bidi', and RpcBidiService; " +
-                "got: ${result.messages}"
+            "Expected RpcHostService returning BidiSub to compile (sub-service manages " +
+                "its own tier). messages: ${result.messages}"
         )
     }
 }

--- a/ksrpc-core/api/ksrpc-core.api
+++ b/ksrpc-core/api/ksrpc-core.api
@@ -254,6 +254,11 @@ public abstract interface class com/monkopedia/ksrpc/RpcObject {
 	public abstract fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
 	public abstract fun getEndpoints ()Ljava/util/List;
 	public abstract fun getServiceName ()Ljava/lang/String;
+	public fun getServiceTier ()Lcom/monkopedia/ksrpc/ServiceTier;
+}
+
+public final class com/monkopedia/ksrpc/RpcObject$DefaultImpls {
+	public static fun getServiceTier (Lcom/monkopedia/ksrpc/RpcObject;)Lcom/monkopedia/ksrpc/ServiceTier;
 }
 
 public abstract interface class com/monkopedia/ksrpc/RpcObjectFactory {

--- a/ksrpc-core/api/ksrpc-core.klib.api
+++ b/ksrpc-core/api/ksrpc-core.klib.api
@@ -34,6 +34,8 @@ abstract interface <#A: com.monkopedia.ksrpc/RpcService> com.monkopedia.ksrpc/Rp
         abstract fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc/RpcObject.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
     abstract val serviceName // com.monkopedia.ksrpc/RpcObject.serviceName|{}serviceName[0]
         abstract fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc/RpcObject.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+    open val serviceTier // com.monkopedia.ksrpc/RpcObject.serviceTier|{}serviceTier[0]
+        open fun <get-serviceTier>(): com.monkopedia.ksrpc/ServiceTier // com.monkopedia.ksrpc/RpcObject.serviceTier.<get-serviceTier>|<get-serviceTier>(){}[0]
 
     abstract fun <#A1: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A1>): #A // com.monkopedia.ksrpc/RpcObject.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
     abstract fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc/RpcObject.findEndpoint|findEndpoint(kotlin.String){}[0]

--- a/ksrpc-core/src/commonMain/kotlin/RpcObject.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcObject.kt
@@ -23,6 +23,15 @@ import com.monkopedia.ksrpc.channels.SerializedService
 interface RpcObject<T : RpcService> {
     val serviceName: String
     val endpoints: List<String>
+
+    /**
+     * The minimum transport capability tier this service requires, as determined
+     * by the compiler plugin from the service's method signatures. Used by
+     * transport registration checks to reject services that can't work on a
+     * given channel.
+     */
+    val serviceTier: ServiceTier get() = ServiceTier.SIMPLE
+
     fun <S> createStub(channel: SerializedService<S>): T
     fun findEndpoint(endpoint: String): RpcMethod<*, *, *>
 }

--- a/ksrpc-core/src/commonMain/kotlin/ServiceTier.kt
+++ b/ksrpc-core/src/commonMain/kotlin/ServiceTier.kt
@@ -19,6 +19,7 @@ import com.monkopedia.ksrpc.annotation.KsrpcInternal
 
 /**
  * Describes the minimum transport capability a service requires.
+ * The compiler plugin sets this on the generated [RpcObject] companion.
  */
 enum class ServiceTier {
     /** Simple input/output — works on all transports. */
@@ -32,27 +33,9 @@ enum class ServiceTier {
 }
 
 /**
- * Compute the minimum [ServiceTier] required by this [RpcObject]'s methods.
- */
-@KsrpcInternal
-fun <T : RpcService> RpcObject<T>.requiredTier(): ServiceTier {
-    var tier = ServiceTier.SIMPLE
-    for (endpoint in endpoints) {
-        val method = findEndpoint(endpoint)
-        if (method.inputTransform is BaseSubserviceTransformer<*, *>) {
-            return ServiceTier.BIDI // sub-service input → bidi, can't get higher
-        }
-        if (method.outputTransform is BaseSubserviceTransformer<*, *>) {
-            tier = maxOf(tier, ServiceTier.HOST)
-        }
-    }
-    return tier
-}
-
-/**
- * Verify that [rpcObject]'s required tier is at most [maxTier]. Throws
- * [IllegalArgumentException] with a descriptive message naming the offending
- * method if the service exceeds the transport's capability.
+ * Verify that [rpcObject]'s [RpcObject.serviceTier] is at most [maxTier]. Throws
+ * [IllegalArgumentException] with a descriptive message if the service exceeds the
+ * transport's capability.
  */
 @KsrpcInternal
 fun <T : RpcService> requireTier(
@@ -60,41 +43,9 @@ fun <T : RpcService> requireTier(
     maxTier: ServiceTier,
     transportName: String
 ) {
-    val required = rpcObject.requiredTier()
+    val required = rpcObject.serviceTier
     if (required <= maxTier) return
 
-    // Find the first offending method for a helpful error message.
-    for (endpoint in rpcObject.endpoints) {
-        val method = rpcObject.findEndpoint(endpoint)
-        if (required == ServiceTier.BIDI &&
-            method.inputTransform is BaseSubserviceTransformer<*, *>
-        ) {
-            throw IllegalArgumentException(
-                "${rpcObject.serviceName} requires bidirectional transport " +
-                    "(method '$endpoint' accepts a sub-service input), " +
-                    "but $transportName does not support this."
-            )
-        }
-        if (required == ServiceTier.BIDI &&
-            method.outputTransform is BaseSubserviceTransformer<*, *>
-        ) {
-            throw IllegalArgumentException(
-                "${rpcObject.serviceName} requires bidirectional transport " +
-                    "(method '$endpoint' returns a bidirectional sub-service), " +
-                    "but $transportName does not support this."
-            )
-        }
-        if (required == ServiceTier.HOST &&
-            method.outputTransform is BaseSubserviceTransformer<*, *>
-        ) {
-            throw IllegalArgumentException(
-                "${rpcObject.serviceName} requires HOST transport " +
-                    "(method '$endpoint' returns a sub-service), " +
-                    "but $transportName only supports SIMPLE services."
-            )
-        }
-    }
-    // Generic fallback
     throw IllegalArgumentException(
         "${rpcObject.serviceName} requires ${required.name} transport capability, " +
             "but $transportName only supports up to ${maxTier.name}."

--- a/ksrpc-flow/api/ksrpc-flow.api
+++ b/ksrpc-flow/api/ksrpc-flow.api
@@ -13,6 +13,7 @@ public final class com/monkopedia/ksrpc/flow/KsCollectionToken$Companion : com/m
 	public final fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
 	public final fun getEndpoints ()Ljava/util/List;
 	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getServiceTier ()Lcom/monkopedia/ksrpc/ServiceTier;
 }
 
 public final class com/monkopedia/ksrpc/flow/KsCollectionToken$DefaultImpls {
@@ -60,6 +61,7 @@ public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Obj : com/monkopedi
 	public final fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
 	public final fun getEndpoints ()Ljava/util/List;
 	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getServiceTier ()Lcom/monkopedia/ksrpc/ServiceTier;
 }
 
 public final class com/monkopedia/ksrpc/flow/KsFlowCollector$Stub : com/monkopedia/ksrpc/RpcService, com/monkopedia/ksrpc/flow/KsFlowCollector {
@@ -114,6 +116,7 @@ public final class com/monkopedia/ksrpc/flow/KsFlowService$Obj : com/monkopedia/
 	public final fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
 	public final fun getEndpoints ()Ljava/util/List;
 	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getServiceTier ()Lcom/monkopedia/ksrpc/ServiceTier;
 }
 
 public final class com/monkopedia/ksrpc/flow/KsFlowService$Stub : com/monkopedia/ksrpc/RpcService, com/monkopedia/ksrpc/flow/KsFlowService {

--- a/ksrpc-flow/api/ksrpc-flow.klib.api
+++ b/ksrpc-flow/api/ksrpc-flow.klib.api
@@ -18,6 +18,8 @@ abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/KsFlowCollector :
             final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
         final val serviceName // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.serviceName|{}serviceName[0]
             final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+        final val serviceTier // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.serviceTier|{}serviceTier[0]
+            final fun <get-serviceTier>(): com.monkopedia.ksrpc/ServiceTier // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.serviceTier.<get-serviceTier>|<get-serviceTier>(){}[0]
 
         final fun <#A2: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A2>): com.monkopedia.ksrpc.flow/KsFlowCollector<#A1> // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
         final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsFlowCollector.Obj.findEndpoint|findEndpoint(kotlin.String){}[0]
@@ -56,6 +58,8 @@ abstract interface <#A: kotlin/Any?> com.monkopedia.ksrpc.flow/KsFlowService : c
             final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsFlowService.Obj.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
         final val serviceName // com.monkopedia.ksrpc.flow/KsFlowService.Obj.serviceName|{}serviceName[0]
             final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsFlowService.Obj.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+        final val serviceTier // com.monkopedia.ksrpc.flow/KsFlowService.Obj.serviceTier|{}serviceTier[0]
+            final fun <get-serviceTier>(): com.monkopedia.ksrpc/ServiceTier // com.monkopedia.ksrpc.flow/KsFlowService.Obj.serviceTier.<get-serviceTier>|<get-serviceTier>(){}[0]
 
         final fun <#A2: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A2>): com.monkopedia.ksrpc.flow/KsFlowService<#A1> // com.monkopedia.ksrpc.flow/KsFlowService.Obj.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
         final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsFlowService.Obj.findEndpoint|findEndpoint(kotlin.String){}[0]
@@ -100,6 +104,8 @@ abstract interface com.monkopedia.ksrpc.flow/KsCollectionToken : com.monkopedia.
             final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
         final val serviceName // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.serviceName|{}serviceName[0]
             final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+        final val serviceTier // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.serviceTier|{}serviceTier[0]
+            final fun <get-serviceTier>(): com.monkopedia.ksrpc/ServiceTier // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.serviceTier.<get-serviceTier>|<get-serviceTier>(){}[0]
 
         final fun <#A2: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A2>): com.monkopedia.ksrpc.flow/KsCollectionToken // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
         final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc.flow/KsCollectionToken.Companion.findEndpoint|findEndpoint(kotlin.String){}[0]

--- a/ksrpc-introspection/api/ksrpc-introspection.api
+++ b/ksrpc-introspection/api/ksrpc-introspection.api
@@ -26,6 +26,7 @@ public final class com/monkopedia/ksrpc/IntrospectionService$Companion : com/mon
 	public final fun findEndpoint (Ljava/lang/String;)Lcom/monkopedia/ksrpc/RpcMethod;
 	public final fun getEndpoints ()Ljava/util/List;
 	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getServiceTier ()Lcom/monkopedia/ksrpc/ServiceTier;
 }
 
 public final class com/monkopedia/ksrpc/IntrospectionService$DefaultImpls {

--- a/ksrpc-introspection/api/ksrpc-introspection.klib.api
+++ b/ksrpc-introspection/api/ksrpc-introspection.klib.api
@@ -67,6 +67,8 @@ abstract interface com.monkopedia.ksrpc/IntrospectionService : com.monkopedia.ks
             final fun <get-endpoints>(): kotlin.collections/List<kotlin/String> // com.monkopedia.ksrpc/IntrospectionService.Companion.endpoints.<get-endpoints>|<get-endpoints>(){}[0]
         final val serviceName // com.monkopedia.ksrpc/IntrospectionService.Companion.serviceName|{}serviceName[0]
             final fun <get-serviceName>(): kotlin/String // com.monkopedia.ksrpc/IntrospectionService.Companion.serviceName.<get-serviceName>|<get-serviceName>(){}[0]
+        final val serviceTier // com.monkopedia.ksrpc/IntrospectionService.Companion.serviceTier|{}serviceTier[0]
+            final fun <get-serviceTier>(): com.monkopedia.ksrpc/ServiceTier // com.monkopedia.ksrpc/IntrospectionService.Companion.serviceTier.<get-serviceTier>|<get-serviceTier>(){}[0]
 
         final fun <#A2: kotlin/Any?> createStub(com.monkopedia.ksrpc.channels/SerializedService<#A2>): com.monkopedia.ksrpc/IntrospectionService // com.monkopedia.ksrpc/IntrospectionService.Companion.createStub|createStub(com.monkopedia.ksrpc.channels.SerializedService<0:0>){0§<kotlin.Any?>}[0]
         final fun findEndpoint(kotlin/String): com.monkopedia.ksrpc/RpcMethod<*, *, *> // com.monkopedia.ksrpc/IntrospectionService.Companion.findEndpoint|findEndpoint(kotlin.String){}[0]

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcTierCheckTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcTierCheckTest.kt
@@ -44,8 +44,8 @@ class JsonRpcTierCheckTest {
             connection.registerDefault(hostService)
         }
         assertTrue(
-            exception.message!!.contains("sub-service"),
-            "Error message should mention sub-service, got: ${exception.message}"
+            exception.message!!.contains("HOST"),
+            "Error message should mention HOST tier, got: ${exception.message}"
         )
         assertTrue(
             exception.message!!.contains("JSON-RPC"),

--- a/ksrpc-test/src/commonTest/kotlin/KsServiceHierarchyTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsServiceHierarchyTest.kt
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.sockets.asConnection
+import io.ktor.utils.io.close
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+
+// --- Service hierarchy definitions ---
+
+@KsService
+interface HierarchyCoreService : RpcService {
+    @KsMethod("/getData")
+    suspend fun getData(id: String): String
+}
+
+@KsService
+interface HierarchyExtendedService : HierarchyCoreService, RpcBidiService {
+    @KsMethod("/updates")
+    suspend fun updates(filter: String): Flow<String>
+}
+
+@KsService
+interface HierarchyBaseService : RpcService {
+    @KsMethod("/base")
+    suspend fun base(): String
+}
+
+@KsService
+interface HierarchyMiddleService : HierarchyBaseService, RpcHostService {
+    @KsMethod("/middle")
+    suspend fun middle(): HierarchyCoreService
+}
+
+@KsService
+interface HierarchyFullService : HierarchyMiddleService, RpcBidiService {
+    @KsMethod("/stream")
+    suspend fun stream(): Flow<String>
+}
+
+@KsService
+interface HierarchyParentService : RpcHostService {
+    @KsMethod("/getExtended")
+    suspend fun getExtended(): HierarchyExtendedService
+}
+
+// --- Implementations ---
+
+private class HierarchyExtendedServiceImpl : HierarchyExtendedService {
+    override suspend fun getData(id: String): String = "data-$id"
+    override suspend fun updates(filter: String): Flow<String> = flowOf("update-1")
+}
+
+private class HierarchyFullServiceImpl : HierarchyFullService {
+    override suspend fun base(): String = "base-value"
+    override suspend fun middle(): HierarchyCoreService = object : HierarchyCoreService {
+        override suspend fun getData(id: String): String = "middle-data-$id"
+    }
+    override suspend fun stream(): Flow<String> = flowOf("stream-a", "stream-b")
+}
+
+/**
+ * Integration tests for @KsService interface inheritance (hierarchy support).
+ *
+ * These tests verify that a @KsService interface can extend another @KsService interface,
+ * inheriting parent methods while adding its own. Currently this feature is NOT implemented
+ * and these tests are expected to FAIL. They document the intended behavior for the feature.
+ */
+class KsServiceHierarchyTest {
+
+    // --- Test 1: Basic inheritance - child includes parent methods ---
+
+    @Test
+    fun extendedServiceEndpointsContainBothParentAndChild() = runBlockingUnit {
+        val obj = rpcObject<HierarchyExtendedService>()
+        assertTrue(
+            "getData" in obj.endpoints,
+            "Expected 'getData' (inherited) in endpoints: ${obj.endpoints}"
+        )
+        assertTrue(
+            "updates" in obj.endpoints,
+            "Expected 'updates' (own) in endpoints: ${obj.endpoints}"
+        )
+    }
+
+    @Test
+    fun extendedServiceRoundTripGetData() = executePipe(
+        serviceJob = { c ->
+            val impl = HierarchyExtendedServiceImpl()
+            c.registerDefault(impl.serialized<HierarchyExtendedService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<HierarchyExtendedService, String>()
+            assertEquals("data-abc", stub.getData("abc"))
+        }
+    )
+
+    @Test
+    fun extendedServiceRoundTripUpdates() = executePipe(
+        serviceJob = { c ->
+            val impl = HierarchyExtendedServiceImpl()
+            c.registerDefault(impl.serialized<HierarchyExtendedService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<HierarchyExtendedService, String>()
+            val result = stub.updates("filter").toList()
+            assertEquals(listOf("update-1"), result)
+        }
+    )
+
+    // --- Test 2: Parent works independently ---
+
+    @Test
+    fun coreServiceWorksIndependently() = runBlockingUnit {
+        val obj = rpcObject<HierarchyCoreService>()
+        assertTrue(
+            "getData" in obj.endpoints,
+            "Expected 'getData' in core service endpoints: ${obj.endpoints}"
+        )
+    }
+
+    @Test
+    fun coreServiceRoundTripIndependently() = runBlockingUnit {
+        val impl: HierarchyCoreService = object : HierarchyCoreService {
+            override suspend fun getData(id: String): String = "core-$id"
+        }
+        val channel = impl.serialized<HierarchyCoreService, String>(ksrpcEnvironment { })
+        val stub = channel.toStub<HierarchyCoreService, String>()
+        assertEquals("core-xyz", stub.getData("xyz"))
+    }
+
+    // --- Test 3: Implementation class resolves correctly ---
+
+    @Test
+    fun implementationClassSerializesAndCallsViaStub() = executePipe(
+        serviceJob = { c ->
+            val impl = HierarchyExtendedServiceImpl()
+            c.registerDefault(impl.serialized<HierarchyExtendedService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<HierarchyExtendedService, String>()
+            assertEquals("data-test", stub.getData("test"))
+            val updates = stub.updates("f").toList()
+            assertEquals(listOf("update-1"), updates)
+        }
+    )
+
+    // --- Test 4: Linear chain (A -> B -> C) ---
+
+    @Test
+    fun fullServiceEndpointsContainAllThree() = runBlockingUnit {
+        val obj = rpcObject<HierarchyFullService>()
+        assertTrue(
+            "base" in obj.endpoints,
+            "Expected 'base' (from BaseService) in endpoints: ${obj.endpoints}"
+        )
+        assertTrue(
+            "middle" in obj.endpoints,
+            "Expected 'middle' (from MiddleService) in endpoints: ${obj.endpoints}"
+        )
+        assertTrue(
+            "stream" in obj.endpoints,
+            "Expected 'stream' (own) in endpoints: ${obj.endpoints}"
+        )
+    }
+
+    @Test
+    fun fullServiceLinearChainRoundTrip() = executePipe(
+        serviceJob = { c ->
+            val impl = HierarchyFullServiceImpl()
+            c.registerDefault(impl.serialized<HierarchyFullService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<HierarchyFullService, String>()
+            assertEquals("base-value", stub.base())
+            val streams = stub.stream().toList()
+            assertEquals(listOf("stream-a", "stream-b"), streams)
+        }
+    )
+
+    @Test
+    fun fullServiceSubserviceFromMiddle() = executePipe(
+        serviceJob = { c ->
+            val impl = HierarchyFullServiceImpl()
+            c.registerDefault(impl.serialized<HierarchyFullService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<HierarchyFullService, String>()
+            val child = stub.middle()
+            assertEquals("middle-data-hello", child.getData("hello"))
+        }
+    )
+
+    // --- Test 6: Transport compatibility (PIPE) ---
+
+    @Test
+    fun extendedServiceWorksOverPipeTransport() = executePipe(
+        serviceJob = { c ->
+            val impl = HierarchyExtendedServiceImpl()
+            c.registerDefault(impl.serialized<HierarchyExtendedService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<HierarchyExtendedService, String>()
+            // Verify both inherited and own methods work over pipe
+            assertEquals("data-pipe", stub.getData("pipe"))
+            val updates = stub.updates("pipe-filter").toList()
+            assertEquals(listOf("update-1"), updates)
+        }
+    )
+
+    // --- Test 7: Sub-service returning a hierarchy service ---
+
+    @Test
+    fun parentServiceReturnsHierarchySubservice() = executePipe(
+        serviceJob = { c ->
+            val impl = object : HierarchyParentService {
+                override suspend fun getExtended(): HierarchyExtendedService =
+                    HierarchyExtendedServiceImpl()
+            }
+            c.registerDefault(impl.serialized<HierarchyParentService, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<HierarchyParentService, String>()
+            val extended = stub.getExtended()
+            assertEquals("data-sub", extended.getData("sub"))
+            val updates = extended.updates("sub-filter").toList()
+            assertEquals(listOf("update-1"), updates)
+        }
+    )
+
+    // --- Pipe test helper ---
+
+    private fun executePipe(
+        serviceJob: suspend (Connection<String>) -> Unit,
+        clientJob: suspend (Connection<String>) -> Unit
+    ) = runBlockingUnit {
+        val (output, input) = createPipe()
+        val (so, si) = createPipe()
+        val serviceChannel = (si to output).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { }
+            }
+        )
+        val clientChannel = (input to so).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { }
+            }
+        )
+        val bgJob = GlobalScope.launch(Dispatchers.Default) {
+            serviceJob(serviceChannel)
+        }
+        try {
+            clientJob(clientChannel)
+        } finally {
+            try {
+                clientChannel.close()
+            } catch (_: Throwable) {}
+            try {
+                serviceChannel.close()
+            } catch (_: Throwable) {}
+            try {
+                input.cancel(null)
+            } catch (_: Throwable) {}
+            try {
+                si.cancel(null)
+            } catch (_: Throwable) {}
+            output.close(null)
+            so.close(null)
+            bgJob.join()
+        }
+    }
+}
+
+/**
+ * Transport functionality test: verifies ExtendedService works over all transport types.
+ * This is the test for scenario 6 (transport compatibility) using the RpcFunctionalityTest
+ * pattern which exercises SERIALIZE, PIPE, HTTP, and WEBSOCKET transports.
+ */
+class KsServiceHierarchyTransportTest :
+    RpcFunctionalityTest(
+        serializedChannel = {
+            val impl = object : HierarchyExtendedService {
+                override suspend fun getData(id: String): String = "data-$id"
+                override suspend fun updates(filter: String): Flow<String> =
+                    flowOf("update-$filter")
+            }
+            impl.serialized(ksrpcEnvironment { })
+        },
+        verifyOnChannel = { serializedChannel ->
+            val stub = serializedChannel.toStub<HierarchyExtendedService, String>()
+            assertEquals("data-transport", stub.getData("transport"))
+        },
+        // Only PIPE supports bidi (needed for Flow), but getData works on all
+        supportedTypes = listOf(TestType.PIPE)
+    )

--- a/ksrpc-test/src/commonTest/kotlin/KsServiceHierarchyTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsServiceHierarchyTest.kt
@@ -68,6 +68,20 @@ interface HierarchyParentService : RpcHostService {
     suspend fun getExtended(): HierarchyExtendedService
 }
 
+// --- Same-tier inheritance (both RpcService, no tier escalation) ---
+
+@KsService
+interface SameTierBase : RpcService {
+    @KsMethod("/greet")
+    suspend fun greet(name: String): String
+}
+
+@KsService
+interface SameTierChild : SameTierBase {
+    @KsMethod("/farewell")
+    suspend fun farewell(name: String): String
+}
+
 // --- Implementations ---
 
 private class HierarchyExtendedServiceImpl : HierarchyExtendedService {
@@ -131,6 +145,43 @@ class KsServiceHierarchyTest {
             assertEquals(listOf("update-1"), result)
         }
     )
+
+    // --- Test: Same capability tier inheritance ---
+
+    @Test
+    fun sameTierChildHasBothEndpoints() = runBlockingUnit {
+        val obj = rpcObject<SameTierChild>()
+        assertTrue(
+            "greet" in obj.endpoints,
+            "Expected 'greet' (inherited) in endpoints: ${obj.endpoints}"
+        )
+        assertTrue(
+            "farewell" in obj.endpoints,
+            "Expected 'farewell' (own) in endpoints: ${obj.endpoints}"
+        )
+    }
+
+    @Test
+    fun sameTierChildRoundTrip() = runBlockingUnit {
+        val impl = object : SameTierChild {
+            override suspend fun greet(name: String) = "hello $name"
+            override suspend fun farewell(name: String) = "bye $name"
+        }
+        val channel = impl.serialized<SameTierChild, String>(ksrpcEnvironment { })
+        val stub = channel.toStub<SameTierChild, String>()
+        assertEquals("hello world", stub.greet("world"))
+        assertEquals("bye world", stub.farewell("world"))
+    }
+
+    @Test
+    fun sameTierBaseStillWorksAlone() = runBlockingUnit {
+        val impl = object : SameTierBase {
+            override suspend fun greet(name: String) = "hi $name"
+        }
+        val channel = impl.serialized<SameTierBase, String>(ksrpcEnvironment { })
+        val stub = channel.toStub<SameTierBase, String>()
+        assertEquals("hi there", stub.greet("there"))
+    }
 
     // --- Test 2: Parent works independently ---
 

--- a/ksrpc-test/src/commonTest/kotlin/KsServiceHierarchyTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsServiceHierarchyTest.kt
@@ -39,7 +39,9 @@ interface HierarchyCoreService : RpcService {
 }
 
 @KsService
-interface HierarchyExtendedService : HierarchyCoreService, RpcBidiService {
+interface HierarchyExtendedService :
+    HierarchyCoreService,
+    RpcBidiService {
     @KsMethod("/updates")
     suspend fun updates(filter: String): Flow<String>
 }
@@ -51,13 +53,17 @@ interface HierarchyBaseService : RpcService {
 }
 
 @KsService
-interface HierarchyMiddleService : HierarchyBaseService, RpcHostService {
+interface HierarchyMiddleService :
+    HierarchyBaseService,
+    RpcHostService {
     @KsMethod("/middle")
     suspend fun middle(): HierarchyCoreService
 }
 
 @KsService
-interface HierarchyFullService : HierarchyMiddleService, RpcBidiService {
+interface HierarchyFullService :
+    HierarchyMiddleService,
+    RpcBidiService {
     @KsMethod("/stream")
     suspend fun stream(): Flow<String>
 }

--- a/ksrpc-test/src/commonTest/kotlin/KsServiceHierarchyTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsServiceHierarchyTest.kt
@@ -63,7 +63,7 @@ interface HierarchyFullService : HierarchyMiddleService, RpcBidiService {
 }
 
 @KsService
-interface HierarchyParentService : RpcHostService {
+interface HierarchyParentService : RpcBidiService {
     @KsMethod("/getExtended")
     suspend fun getExtended(): HierarchyExtendedService
 }


### PR DESCRIPTION
## Summary

Adds support for `@KsService` interface inheritance — a child `@KsService` can extend a parent `@KsService`, inheriting its methods while adding new ones. Also completes the `serviceTier` codegen: the compiler plugin now emits the tier on generated companions rather than computing it at runtime.

### Service hierarchy support
```kotlin
@KsService
interface CoreService : RpcService {
    @KsMethod("/getData")
    suspend fun getData(id: String): String
}

@KsService
interface ExtendedService : CoreService, RpcBidiService {
    @KsMethod("/updates")
    suspend fun updates(filter: String): Flow<String>
}
```

- `rpcObject<ExtendedService>().endpoints` includes both `/getData` and `/updates`
- Parent and child work independently
- Same-tier inheritance (both RpcService) works
- Linear chains (A → B → C) work
- Diamond inheritance (two unrelated @KsService ancestors) is still rejected

### Compiler plugin changes
- Removed `KSSERVICE_SUBTYPE_OF_KSSERVICE` blanket rejection
- Added inherited method collection from parent @KsService interfaces
- Fixed `SubclassVisitor` to not add @KsService classes to parent's `irClassAndImpls`
- Multiple-supertypes check uses leaf-filtering (only flags true diamonds)
- Emits `serviceTier` property on generated companions from interface supertypes

### serviceTier on RpcObject
- `RpcObject.serviceTier: ServiceTier` property (defaults to SIMPLE)
- Compiler plugin emits override based on service interface's declared supertypes
- `requireTier()` simplified to just read `rpcObject.serviceTier` — no runtime scanning

## Test plan
- [x] Same-tier inheritance: both endpoints present, round-trip works
- [x] Tier-escalating inheritance: RpcService → RpcBidiService
- [x] Linear chain (3 levels): all endpoints present
- [x] Parent works independently
- [x] Implementation class round-trip
- [x] Transport compatibility (PIPE)
- [x] Sub-service returning hierarchy service
- [x] Compiler plugin: hierarchy compiles, stub has all methods
- [x] Compiler plugin: diamond still rejected
- [x] JSON-RPC tier check still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)