### PR TITLE
Fix #157: native compiler plugin compilation

### DIFF
--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -89,6 +89,7 @@ tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
         freeCompilerArgs.add("-Xjvm-default=all")
+        freeCompilerArgs.add("-Xcontext-parameters")
     }
 }
 


### PR DESCRIPTION
## Summary
Add `-Xcontext-parameters` to the native compiler plugin module's compiler options. The FIR checkers use context parameters syntax which requires this flag — the main plugin had it but the native copy didn't.

One-line fix. Fixes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)