### PR TITLE
Fix duplicate @RpcObjectKey on plain-Kotlin @KsService subtypes

### DIFF
--- a/compiler/plugin/src/main/java/CompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/CompanionGeneration.kt
@@ -80,10 +80,19 @@ class CompanionGeneration(
         // companion is the `RpcObject`; for generic services it's the `RpcObjectFactory`.
         // `rpcObject<T>()` inspects the returned instance and, when it's a factory,
         // resolves typeArgs from `typeOf<T>()` and calls `create(...)`.
-        env.rpcObjectKey?.let {
+        env.rpcObjectKey?.let { rpcObjectKeySymbol ->
+            val rpcObjectKeyFqName = rpcObjectKeySymbol.owner.kotlinFqName
             val objectReference = createClassReference(context, declaration)
             cls.irClassAndImpls.forEach { irClass ->
-                irClass.annotations += createRpcObjectAnnotation(irClass, it, objectReference)
+                // Skip classes that already have @RpcObjectKey (e.g. plain-Kotlin subtypes
+                // whose synthesized companion already added the annotation via
+                // SubtypeCompanionGeneration — see issue #160).
+                val alreadyAnnotated = irClass.annotations.any {
+                    it.type.classFqName == rpcObjectKeyFqName
+                }
+                if (!alreadyAnnotated) {
+                    irClass.annotations += createRpcObjectAnnotation(irClass, rpcObjectKeySymbol, objectReference)
+                }
             }
         }
         declaration.declarations

--- a/compiler/plugin/src/main/java/ServiceClass.kt
+++ b/compiler/plugin/src/main/java/ServiceClass.kt
@@ -26,9 +26,11 @@ import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin.GeneratedByPlugin
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.util.companionObject
 import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
 import org.jetbrains.kotlin.ir.util.getAllSuperclasses
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
@@ -140,6 +142,16 @@ private class SubclassVisitor(
         val declFqName = declaration.fqNameForIrSerialization.asString()
         // Skip if this class is itself a @KsService (it has its own entry)
         if (declFqName in classes) {
+            return super.visitClass(declaration)
+        }
+        // Skip if the class already has a synthesized companion from
+        // FirSubtypeCompanionGenerator — that companion handles @RpcObjectKey
+        // itself and adding the class to irClassAndImpls would cause a duplicate
+        // annotation (see issue #160).
+        val companionOrigin = declaration.companionObject()?.origin
+        if (companionOrigin is GeneratedByPlugin &&
+            companionOrigin.pluginKey is FirSubtypeCompanionGenerator.Key
+        ) {
             return super.visitClass(declaration)
         }
         val ksServiceSupers = declaration.getAllSuperclasses().mapNotNull {


### PR DESCRIPTION
## Summary
- Plain-Kotlin subtypes of `@KsService` interfaces (e.g. `interface TypedFoo : GenericService<String>`) were getting `@RpcObjectKey` applied twice: once by `SubtypeCompanionGeneration` (correct) and once by `CompanionGeneration` via `irClassAndImpls` (redundant)
- On native targets this caused a fatal linker error: "duplicate value for RpcObjectKey, previous was Companion"
- Fix: `SubclassVisitor` now skips classes whose companion was generated by `FirSubtypeCompanionGenerator`, and `CompanionGeneration` defensively skips classes that already carry the annotation

Fixes #160

## Test plan
- [x] `./gradlew :ksrpc-test:linkDebugTestLinuxX64` passes (previously failed with duplicate annotation error)
- [x] `./gradlew :ksrpc-test:jvmTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)