### PR TITLE
Fix Dokka samples configuration for publish

### DIFF
--- a/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
+++ b/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
@@ -222,8 +222,10 @@ fun Project.ksrpcModule(
     extensions.configure<DokkaExtension> {
         dokkaSourceSets.configureEach { sourceSet ->
             sourceSet.includes.from(rootProject.file("dokka/moduledoc.md"))
-            sourceSet.samples.from(rootProject.file("ksrpc-samples/src/commonMain/kotlin"))
-            if (sourceSet.name.contains("jvm", ignoreCase = true)) {
+            if (sourceSet.name == "commonMain") {
+                sourceSet.samples.from(rootProject.file("ksrpc-samples/src/commonMain/kotlin"))
+            }
+            if (sourceSet.name == "jvmMain") {
                 sourceSet.samples.from(rootProject.file("ksrpc-samples/src/jvmMain/kotlin"))
             }
             sourceSet.skipEmptyPackages.set(true)


### PR DESCRIPTION
Publish workflow failed because samples.from() was added to all source sets. Dokka rejects shared roots. Scoped to commonMain/jvmMain only.