### PR TITLE
Fix #169: swallow benign IOException on subprocess stdin close

### DIFF
--- a/ksrpc-sockets/src/jvmMain/kotlin/InputOutputStreams.kt
+++ b/ksrpc-sockets/src/jvmMain/kotlin/InputOutputStreams.kt
@@ -26,6 +26,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
 import io.ktor.utils.io.pool.ByteArrayPool
 import io.ktor.utils.io.readAvailable
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import kotlin.coroutines.coroutineContext
@@ -80,9 +81,16 @@ private suspend fun ByteReadChannel.copyToAndFlush(
                 val rc = readAvailable(buffer, 0, minOf(limit - copied, bufferSize).toInt())
                 if (rc == -1 && isClosedForRead) break
                 if (rc > 0) {
-                    out.write(buffer, 0, rc)
-                    out.flush()
-                    copied += rc
+                    try {
+                        out.write(buffer, 0, rc)
+                        out.flush()
+                        copied += rc
+                    } catch (t: IOException) {
+                        // Destination stream is gone (e.g. subprocess exited and closed
+                        // its stdin). Stop trying to write; the connection scope will
+                        // observe the close via other means.
+                        break
+                    }
                 }
             } catch (t: Throwable) {
                 if (!isClosedForRead) {

--- a/ksrpc-test/src/jvmTest/kotlin/CopyToAndFlushOutputCloseJvmTest.kt
+++ b/ksrpc-test/src/jvmTest/kotlin/CopyToAndFlushOutputCloseJvmTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.channels.RpcCallId
+import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.sockets.asConnection
+import java.io.IOException
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.serializer
+
+/**
+ * Regression test for issue #169: when the OutputStream backing a
+ * `Pair<InputStream, OutputStream>.asConnection` is closed before the read side
+ * observes the close (the typical pattern when a subprocess exits), the
+ * `copyToAndFlush` coroutine used to leak the resulting `IOException` to the
+ * thread's uncaught-exception handler.
+ */
+class CopyToAndFlushOutputCloseJvmTest {
+
+    /**
+     * OutputStream that throws [IOException] from `write` and `flush` once
+     * [fail] has been triggered, mimicking
+     * `java.lang.ProcessBuilder$NullOutputStream` after the subprocess exits.
+     */
+    private class ClosableFailingOutputStream : OutputStream() {
+        @Volatile
+        private var failing = false
+
+        fun fail() {
+            failing = true
+        }
+
+        override fun write(b: Int) {
+            if (failing) throw IOException("Stream closed")
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            if (failing) throw IOException("Stream closed")
+        }
+
+        override fun flush() {
+            if (failing) throw IOException("Stream closed")
+        }
+
+        override fun close() {
+            failing = true
+        }
+    }
+
+    @Test
+    fun outputStreamCloseDoesNotLeakIoExceptionToParentScope() = runBlockingUnit {
+        val env = ksrpcEnvironment { }
+        // Use a piped pair so the InputStream stays open: this mirrors the
+        // subprocess case where the process's stdout is still readable but
+        // its stdin (our OutputStream) has been closed mid-write.
+        val pipeFeed = PipedOutputStream()
+        val input = PipedInputStream(pipeFeed, 64 * 1024)
+        val output = ClosableFailingOutputStream()
+        val capturedException = AtomicReference<Throwable?>(null)
+        val handler = CoroutineExceptionHandler { _: CoroutineContext, t: Throwable ->
+            capturedException.set(t)
+        }
+
+        var connection: Connection<String>? = null
+        try {
+            connection = withContext(handler) {
+                (input to output).asConnection(env)
+            }
+            connection.registerDefault(EchoSerializedService(env))
+
+            // Trigger writes through the OutputStream by issuing an RPC call,
+            // but mark the output as failed first so the writer hits IOException
+            // mid-flight while the read side is still open (mirroring a
+            // subprocess that exited before draining its stdin).
+            withContext(handler) {
+                val request = env.serialization.createCallData(
+                    String.serializer(),
+                    "hello"
+                )
+                output.fail()
+                runCatching {
+                    connection!!.defaultChannel().call("echo", request, callId = null)
+                }
+                // Give the copy coroutine time to observe the failed write
+                // and either swallow it (fixed) or rethrow (buggy).
+                delay(300)
+            }
+        } finally {
+            runCatching { pipeFeed.close() }
+            runCatching { connection?.close() }
+        }
+
+        assertNull(
+            capturedException.get(),
+            "copyToAndFlush leaked exception to parent scope: ${capturedException.get()}"
+        )
+    }
+
+    private class EchoSerializedService(override val env: KsrpcEnvironment<String>) :
+        SerializedService<String> {
+        override suspend fun call(
+            endpoint: String,
+            input: CallData<String>,
+            callId: RpcCallId?
+        ): CallData<String> = input
+
+        override suspend fun close() = Unit
+
+        override suspend fun onClose(onClose: suspend () -> Unit) = Unit
+    }
+}


### PR DESCRIPTION
Closes #169. Narrow catch around the write/flush in copyToAndFlush — when the destination stream is closed (e.g. subprocess exited), stop trying instead of escaping the exception to stderr. Read-side close handling unchanged.