### PR TITLE
Fix #170: accept omitted params for 0-arg @KsMethod on JSON-RPC

### DIFF
--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcSerializedChannel.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcSerializedChannel.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 
 private val RpcMethod<*, *, *>.isNotification: Boolean
     get() = metadata("com.monkopedia.ksrpc.annotation.KsNotification") != null
@@ -59,7 +60,15 @@ class JsonRpcSerializedChannel(
         require(!input.isBinary) {
             "JsonRpc does not support binary data"
         }
-        val message = json.decodeFromString<JsonElement?>(input.readSerialized())
+        // We always have a real input payload here (the stub serialized something —
+        // even a `null` value is the literal string "null"). Decoding `"null"` via
+        // `<JsonElement?>` collapses to a Kotlin `null`, but downstream we use the
+        // `null`-vs-non-null distinction to mean "wire `params` field omitted vs.
+        // present" (see #170). Coerce to `JsonNull` so the request encodes as
+        // `params: null` on the wire — distinguishable from a missing `params`
+        // field — and the typed nullable input deserializer on the receiving side
+        // still accepts the literal "null" value.
+        val message = json.decodeFromString<JsonElement?>(input.readSerialized()) ?: JsonNull
         // Outbound stub path: no server-side id to forward. The wire id (if any) is allocated
         // by the underlying JsonRpcChannel.
         val response = try {

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcWriterBase.kt
@@ -73,6 +73,12 @@ class JsonRpcWriterBase(
          * original can be recovered on the receiving side.
          */
         private const val IN_PARAMS_WRAPPED_VALUE_KEY = "__ksrpc_value"
+
+        /**
+         * Substituted in place of an omitted wire-level `params` field so the
+         * downstream Unit input deserializer accepts the request — see #170.
+         */
+        private val EMPTY_PARAMS: JsonObject = buildJsonObject { }
     }
 
     private var baseChannel = CompletableDeferred<JsonRpcChannel>()
@@ -88,7 +94,30 @@ class JsonRpcWriterBase(
                         if ((p as? JsonObject)?.containsKey("method") == true) {
                             val wireCtx = extractContext(p)
                             val cleaned = stripContext(p)
-                            val request = json.decodeFromJsonElement<JsonRpcRequest>(cleaned)
+                            val rawObj = cleaned as? JsonObject
+                            val decoded = json.decodeFromJsonElement<JsonRpcRequest>(cleaned)
+                            // JSON-RPC 2.0 §4 explicitly allows the `params` member to be
+                            // omitted entirely. Real LSP clients (lsp4j, vscode) routinely
+                            // send 0-arg calls like `shutdown` and notifications like
+                            // `exit` with no `params`. Distinguish "missing on the wire"
+                            // (no `params` key on the raw inbound object) from "explicit
+                            // wire null" (key present with value `null`) — only the
+                            // missing case is normalized to an empty object so the
+                            // downstream input-type deserializer (notably Unit, the
+                            // synthesized input for 0-arg @KsMethod functions per #40)
+                            // accepts it. Wire-level `null` is preserved as a Kotlin
+                            // `null` here because that's what nullable-input stubs send,
+                            // and the typed nullable deserializer accepts the literal
+                            // `"null"` string downstream. See #170.
+                            val request = if (
+                                rawObj != null &&
+                                !rawObj.containsKey("params") &&
+                                decoded.params == null
+                            ) {
+                                decoded.copy(params = EMPTY_PARAMS)
+                            } else {
+                                decoded
+                            }
                             if (isCancellationNotification(request)) {
                                 handleCancellationNotification(request)
                             } else {

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcOmittedParamsTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcOmittedParamsTest.kt
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(KsrpcInternal::class)
+
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcTransformer
+import com.monkopedia.ksrpc.jsonrpc.internal.JsonRpcWriterBase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Coverage for issue #170 — JSON-RPC 2.0 §4 explicitly allows `params` to be omitted
+ * from a Request object. Real LSP clients (lsp4j, vscode) routinely send 0-arg calls
+ * like `shutdown` and notifications like `exit` with no `params` field at all.
+ *
+ * The server-side dispatcher must accept these requests when the resolved method's
+ * input type is `Unit` (the synthesized input for 0-arg `@KsMethod` functions per
+ * #40). Methods that require real params still surface a deserialization error, but
+ * not the cryptic "Expected start of the object '{', but had 'n' instead" produced
+ * when the literal string "null" is fed to an object deserializer.
+ */
+@KsService
+interface ShutdownService : RpcService {
+    @KsMethod("shutdown")
+    suspend fun shutdown(): String
+
+    @KsMethod("exit")
+    suspend fun exit()
+
+    @KsMethod("greet")
+    suspend fun greet(name: String): String
+}
+
+private class ShutdownServiceImpl(
+    val onExit: () -> Unit = {}
+) : ShutdownService {
+    override suspend fun shutdown(): String = "ok"
+    override suspend fun exit() {
+        onExit()
+    }
+    override suspend fun greet(name: String): String = "hello $name"
+}
+
+class JsonRpcOmittedParamsTest {
+
+    @Test
+    fun zeroArgMethodAcceptsRequestWithNoParamsField() = runBlockingUnit {
+        val transformer = ScriptedTransformer()
+        val env = ksrpcEnvironment { }
+        val writer = JsonRpcWriterBase(
+            scope = CoroutineScope(coroutineContext + SupervisorJob()),
+            context = coroutineContext,
+            env = env,
+            comm = transformer
+        )
+        try {
+            val service: ShutdownService = ShutdownServiceImpl()
+            writer.registerDefault(service.serialized<ShutdownService, String>(env))
+
+            // No `params` field at all — what lsp4j sends for shutdown.
+            transformer.inject("""{"jsonrpc":"2.0","id":1,"method":"shutdown"}""")
+
+            val response = withTimeout(2_000) { transformer.nextOutgoing() }
+            val obj = response.jsonObject
+            assertEquals(JsonPrimitive(1), obj["id"])
+            assertNull(obj["error"])
+            assertEquals(JsonPrimitive("ok"), obj["result"])
+        } finally {
+            writer.close()
+        }
+    }
+
+    @Test
+    fun zeroArgMethodStillAcceptsExistingEmptyObjectParams() = runBlockingUnit {
+        // Regression check — ksrpc-on-both-ends always sent `params: {}` and that
+        // path must continue to work after the fix.
+        val transformer = ScriptedTransformer()
+        val env = ksrpcEnvironment { }
+        val writer = JsonRpcWriterBase(
+            scope = CoroutineScope(coroutineContext + SupervisorJob()),
+            context = coroutineContext,
+            env = env,
+            comm = transformer
+        )
+        try {
+            val service: ShutdownService = ShutdownServiceImpl()
+            writer.registerDefault(service.serialized<ShutdownService, String>(env))
+
+            transformer.inject("""{"jsonrpc":"2.0","id":3,"method":"shutdown","params":{}}""")
+
+            val response = withTimeout(2_000) { transformer.nextOutgoing() }
+            val obj = response.jsonObject
+            assertEquals(JsonPrimitive(3), obj["id"])
+            assertNull(obj["error"])
+            assertEquals(JsonPrimitive("ok"), obj["result"])
+        } finally {
+            writer.close()
+        }
+    }
+
+    @Test
+    fun zeroArgNotificationAcceptsRequestWithNoParamsField() = runBlockingUnit {
+        val transformer = ScriptedTransformer()
+        val env = ksrpcEnvironment { }
+        val writer = JsonRpcWriterBase(
+            scope = CoroutineScope(coroutineContext + SupervisorJob()),
+            context = coroutineContext,
+            env = env,
+            comm = transformer
+        )
+        val exitCalled = CompletableDeferred<Unit>()
+        try {
+            val service: ShutdownService = ShutdownServiceImpl(
+                onExit = { exitCalled.complete(Unit) }
+            )
+            writer.registerDefault(service.serialized<ShutdownService, String>(env))
+
+            // Notification: no `id`, no `params` — what lsp4j sends for exit.
+            transformer.inject("""{"jsonrpc":"2.0","method":"exit"}""")
+
+            // The handler must run; the test will fail by timeout if the dispatcher
+            // rejected the request before reaching the service.
+            withTimeout(2_000) { exitCalled.await() }
+
+            // Notifications produce no response — give the writer a moment and assert
+            // nothing came back on the outgoing channel.
+            assertNull(transformer.tryNextOutgoing())
+        } finally {
+            writer.close()
+        }
+    }
+
+    @Test
+    fun methodRequiringParamsStillErrorsWhenParamsOmitted() = runBlockingUnit {
+        // Methods whose input is NOT Unit must still fail when params are missing —
+        // they just fail with a sensible deserialization error rather than the
+        // cryptic 'n' parser error. The handler is NOT invoked.
+        val transformer = ScriptedTransformer()
+        val env = ksrpcEnvironment { }
+        val writer = JsonRpcWriterBase(
+            scope = CoroutineScope(coroutineContext + SupervisorJob()),
+            context = coroutineContext,
+            env = env,
+            comm = transformer
+        )
+        try {
+            val service: ShutdownService = ShutdownServiceImpl()
+            writer.registerDefault(service.serialized<ShutdownService, String>(env))
+
+            transformer.inject("""{"jsonrpc":"2.0","id":4,"method":"greet"}""")
+
+            val response = withTimeout(2_000) { transformer.nextOutgoing() }
+            val obj = response.jsonObject
+            assertEquals(JsonPrimitive(4), obj["id"])
+            val error = obj["error"]
+            assertNotNull(error, "Expected an error response for method requiring params")
+            // The error message should NOT be the legacy 'expected { but had n'
+            // confused-deserializer message — that was the bug.
+            val msg = error.jsonObject["message"]?.jsonPrimitive?.content ?: ""
+            assertTrue(
+                "had 'n'" !in msg,
+                "Error message should not be the legacy null-fed-to-object error: $msg"
+            )
+        } finally {
+            writer.close()
+        }
+    }
+
+    /**
+     * Test [JsonRpcTransformer] that lets the test inject raw inbound JSON-RPC frames
+     * and read back outbound frames. The writer's receive loop pulls each injected
+     * frame in order; outbound responses are buffered for the test to inspect.
+     */
+    private class ScriptedTransformer : JsonRpcTransformer() {
+        private val inbound = Channel<JsonElement>(capacity = Channel.UNLIMITED)
+        private val outbound = Channel<JsonElement>(capacity = Channel.UNLIMITED)
+        private var closed = false
+
+        override val isOpen: Boolean
+            get() = !closed
+
+        fun inject(rawJson: String) {
+            inbound.trySend(Json.parseToJsonElement(rawJson))
+        }
+
+        suspend fun nextOutgoing(): JsonElement = outbound.receive()
+
+        fun tryNextOutgoing(): JsonElement? = outbound.tryReceive().getOrNull()
+
+        override suspend fun send(message: JsonElement) {
+            outbound.send(message)
+        }
+
+        override suspend fun receive(): JsonElement? {
+            if (closed) return null
+            return inbound.receive()
+        }
+
+        override fun close(cause: Throwable?) {
+            closed = true
+            inbound.close(cause)
+            outbound.close(cause)
+        }
+    }
+}

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcOmittedParamsTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcOmittedParamsTest.kt
@@ -61,9 +61,7 @@ interface ShutdownService : RpcService {
     suspend fun greet(name: String): String
 }
 
-private class ShutdownServiceImpl(
-    val onExit: () -> Unit = {}
-) : ShutdownService {
+private class ShutdownServiceImpl(val onExit: () -> Unit = {}) : ShutdownService {
     override suspend fun shutdown(): String = "ok"
     override suspend fun exit() {
         onExit()


### PR DESCRIPTION
## Summary

- Fixes #170 — JSON-RPC 2.0 §4 explicitly allows the `params` member to be omitted from a Request object, but ksrpc rejected such requests with a cryptic `Expected start of the object '{', but had 'n' instead` error. Real LSP clients (lsp4j, vscode) routinely send 0-arg calls like `shutdown` and notifications like `exit` with no `params` field at all, so ksrpc-backed JSON-RPC servers couldn't interoperate with them without an inbound rewrite shim.
- Distinguish "missing `params` on the wire" from "explicit wire null" in `JsonRpcWriterBase` by inspecting the raw inbound `JsonObject` before decode — only the missing case is normalized to an empty object so the downstream Unit-input deserializer (synthesized for 0-arg `@KsMethod` functions per #40) accepts the call.
- Coerce decoded Kotlin null to `JsonNull` in `JsonRpcSerializedChannel` so the outbound stub path always emits `params: null` on the wire when a typed nullable input was actually sent — the receiver can then tell it apart from an omitted field.
- Methods whose input requires real fields still surface a deserialization error when params are omitted, but with a proper "missing required field" message rather than the legacy null-fed-to-object parser error.

## Test plan

- [x] `./gradlew :ksrpc-test:jvmTest` — full suite green
- [x] New `JsonRpcOmittedParamsTest` covers:
  - 0-arg method called with no `params` field — succeeds
  - 0-arg notification called with no `params` field — handler runs, no response sent
  - 0-arg method still works when `params: {}` is sent (regression check for ksrpc-on-both-ends)
  - Method with required params called without params — returns a sensible JSON-RPC error envelope, not the legacy `'n'` parser message
- [x] Existing `JsonRpcTypeTest$InputIntNullableTest` (typed nullable input) still passes — wire-level `params: null` is preserved end-to-end
- [x] Existing `JsonRpcContextConventionTest` cases (RootSiblings / RootField / InParams) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)