### PR TITLE
RC3 prep: Kotlin version check + doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 ### New features
 
-- **`@KsrpcGenerated` marker annotation**: compiler plugin now annotates all synthetic classes (`Stub`, `Companion`, `Obj`, `ServiceExecutor`, synthesized subtype companions). Consumers using BCV can add `nonPublicMarkers += "com.monkopedia.ksrpc.annotation.KsrpcGenerated"` to filter generated classes from their API dumps automatically (#168)
+- **`@KsrpcGenerated` marker annotation** (#168): compiler plugin annotates all synthetic classes (`Stub`, `Companion`, `Obj`, `ServiceExecutor`, synthesized subtype companions). Consumers using BCV can add `nonPublicMarkers += "com.monkopedia.ksrpc.annotation.KsrpcGenerated"` to filter generated classes from API dumps automatically.
+- **Kotlin version check**: Gradle plugin fails fast with a clear message when applied with a Kotlin version older than the one ksrpc was compiled against. The minimum is derived from `gradle/libs.versions.toml` so it stays in sync as we upgrade.
 
 ### Bug fixes
 
-- **JSON-RPC missing params** (#170): 0-arg `@KsMethod` calls now accept omitted `params` field (spec-allowed, used by lsp4j)
+- **JSON-RPC missing params** (#170): 0-arg `@KsMethod` calls now accept omitted `params` field (spec-allowed, used by lsp4j and other JSON-RPC clients)
 - **Subprocess IOException** (#169): `copyToAndFlush` no longer escapes benign IOException to stderr when subprocess closes its stdin
+
+### Documentation
+
+- Migration guide explicitly states the Kotlin version requirement
+- Migration guide notes that call-site code (`ksrpcEnvironment`, `asConnection`, `toStub`, etc.) needs no changes
 
 ## 1.0.0-RC2 (2026-05-03)
 

--- a/compiler/gradle/build.gradle.kts
+++ b/compiler/gradle/build.gradle.kts
@@ -59,6 +59,14 @@ buildConfig {
     buildConfigField("String", "KOTLIN_PLUGIN_GROUP", "\"${project.group}\"")
     buildConfigField("String", "KOTLIN_PLUGIN_NAME", "\"${project.name}\"")
     buildConfigField("String", "KOTLIN_PLUGIN_VERSION", "\"${project.version}\"")
+    // Minimum supported Kotlin version. Derived from the Kotlin plugin version we
+    // ourselves compile against — the compiler plugin uses FIR APIs that change
+    // between Kotlin versions, so consumers must run at least this version.
+    buildConfigField(
+        "String",
+        "MIN_KOTLIN_VERSION",
+        "\"${libs.versions.kotlin.asProvider().get()}\""
+    )
 }
 
 tasks.withType<KotlinCompile> {

--- a/compiler/gradle/src/main/java/KsrpcGradlePlugin.kt
+++ b/compiler/gradle/src/main/java/KsrpcGradlePlugin.kt
@@ -17,11 +17,11 @@ package com.monkopedia.ksrpc.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
-import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
 class KsrpcGradlePlugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project): Unit = with(target) {
@@ -31,23 +31,31 @@ class KsrpcGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
     private fun checkKotlinVersion(project: Project) {
         // Pull the Kotlin plugin version off the buildscript classpath. The compiler
-        // plugin uses FIR APIs (FirNamedFunction) that only exist in 2.3.20+; running
-        // against an older Kotlin throws NoClassDefFoundError mid-compilation with no
-        // useful context. Fail fast with a clear message instead.
-        val kotlinVersion = project.getKotlinPluginVersion() ?: return
-        val (major, minor, patch) = kotlinVersion.split(".", "-").take(3)
-            .mapNotNull { it.toIntOrNull() }
-            .let {
-                if (it.size < 3) listOf(0, 0, 0) else it
-            }
-        val ok = major > 2 || (major == 2 && minor > 3) ||
-            (major == 2 && minor == 3 && patch >= 20)
-        if (!ok) {
+        // plugin uses FIR APIs that change between Kotlin versions; running against an
+        // older Kotlin than the one we compile against throws NoClassDefFoundError
+        // mid-compilation with no useful context. Fail fast with a clear message instead.
+        // The minimum supported version is injected from gradle/libs.versions.toml at
+        // build time, so it stays in sync as we upgrade Kotlin.
+        val kotlinVersion = project.plugins.findPlugin(KotlinBasePlugin::class.java)?.pluginVersion
+            ?: return
+        if (compareVersions(kotlinVersion, BuildConfig.MIN_KOTLIN_VERSION) < 0) {
             error(
-                "ksrpc compiler plugin requires Kotlin 2.3.20 or later " +
-                    "(found $kotlinVersion). Upgrade your kotlin plugin version."
+                "ksrpc compiler plugin requires Kotlin ${BuildConfig.MIN_KOTLIN_VERSION} " +
+                    "or later (found $kotlinVersion). Upgrade your kotlin plugin version."
             )
         }
+    }
+
+    /** Lexicographic comparison of dot-separated numeric versions (ignoring suffixes). */
+    private fun compareVersions(a: String, b: String): Int {
+        val aParts = a.split(".", "-").mapNotNull { it.toIntOrNull() }
+        val bParts = b.split(".", "-").mapNotNull { it.toIntOrNull() }
+        for (i in 0 until maxOf(aParts.size, bParts.size)) {
+            val x = aParts.getOrNull(i) ?: 0
+            val y = bParts.getOrNull(i) ?: 0
+            if (x != y) return x.compareTo(y)
+        }
+        return 0
     }
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true

--- a/compiler/gradle/src/main/java/KsrpcGradlePlugin.kt
+++ b/compiler/gradle/src/main/java/KsrpcGradlePlugin.kt
@@ -21,10 +21,33 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
 class KsrpcGradlePlugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project): Unit = with(target) {
         extensions.create("ksrpc", KsrpcGradleExtension::class.java)
+        checkKotlinVersion(target)
+    }
+
+    private fun checkKotlinVersion(project: Project) {
+        // Pull the Kotlin plugin version off the buildscript classpath. The compiler
+        // plugin uses FIR APIs (FirNamedFunction) that only exist in 2.3.20+; running
+        // against an older Kotlin throws NoClassDefFoundError mid-compilation with no
+        // useful context. Fail fast with a clear message instead.
+        val kotlinVersion = project.getKotlinPluginVersion() ?: return
+        val (major, minor, patch) = kotlinVersion.split(".", "-").take(3)
+            .mapNotNull { it.toIntOrNull() }
+            .let {
+                if (it.size < 3) listOf(0, 0, 0) else it
+            }
+        val ok = major > 2 || (major == 2 && minor > 3) ||
+            (major == 2 && minor == 3 && patch >= 20)
+        if (!ok) {
+            error(
+                "ksrpc compiler plugin requires Kotlin 2.3.20 or later " +
+                    "(found $kotlinVersion). Upgrade your kotlin plugin version."
+            )
+        }
     }
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true

--- a/dokka/guides/migration-1.0.md
+++ b/dokka/guides/migration-1.0.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-ksrpc 1.0 requires **Kotlin 2.3.20 or later**. The compiler plugin uses FIR APIs introduced in 2.3.20; older Kotlin versions will fail at compile time. The Gradle plugin checks this and fails fast with a clear message.
+ksrpc 1.0 requires a recent Kotlin version. The compiler plugin uses FIR APIs that change between Kotlin versions, so consumers must run at least the same Kotlin version that ksrpc was compiled against. The Gradle plugin checks this on apply and fails fast with a clear message naming the required version.
 
 ## Call-site code: no changes needed
 

--- a/dokka/guides/migration-1.0.md
+++ b/dokka/guides/migration-1.0.md
@@ -2,6 +2,14 @@
 
 # Migration Guide: 0.11.x to 1.0
 
+## Requirements
+
+ksrpc 1.0 requires **Kotlin 2.3.20 or later**. The compiler plugin uses FIR APIs introduced in 2.3.20; older Kotlin versions will fail at compile time. The Gradle plugin checks this and fails fast with a clear message.
+
+## Call-site code: no changes needed
+
+The transport entry points are unchanged. Existing calls to `ksrpcEnvironment { }`, `asConnection(env)`, `serveHttp(...)`, `toStub<T>()`, `registerDefault(...)`, etc. work exactly as before — the breaking changes are in the service interface declarations only.
+
 ## Service tier hierarchy (breaking)
 
 Services must now declare their capability tier explicitly:


### PR DESCRIPTION
Addresses second-agent integration feedback: hidden Kotlin 2.3.20 floor causing NoClassDefFoundError stack traces, missing call-site migration note. Adds Gradle plugin version check, migration guide updates, CHANGELOG entry.