### PR TITLE
Disable auto-release on publish workflow

### DIFF
--- a/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
+++ b/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
@@ -276,7 +276,7 @@ fun Project.ksrpcModule(
                 it.url.set("http://github.com/Monkopedia/ksrpc/")
             }
         }
-        publishToMavenCentral(automaticRelease = true)
+        publishToMavenCentral()
         signAllPublications()
     }
 

--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -81,7 +81,7 @@ mavenPublishing {
             url.set("http://github.com/Monkopedia/ksrpc/")
         }
     }
-    publishToMavenCentral(automaticRelease = true)
+    publishToMavenCentral()
     signAllPublications()
 }
 

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -152,7 +152,7 @@ mavenPublishing {
             url.set("http://github.com/Monkopedia/ksrpc/")
         }
     }
-    publishToMavenCentral(automaticRelease = true)
+    publishToMavenCentral()
     signAllPublications()
 }
 


### PR DESCRIPTION
Auto-release validation timeout was killing the workflow before subsequent steps could run.