### PR TITLE
Bump vanniktech maven-publish 0.35.0 -> 0.36.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,22 +100,6 @@ subprojects {
         version.set("1.8.0")
         android.set(true)
     }
-    afterEvaluate {
-        tasks.findByName("licenseCheckForKotlin")?.let {
-            tasks.all {
-                if ((this.name.startsWith("ktlint") && this.name.endsWith("Check")) ||
-                    (this.name.startsWith("transform") && this.name.endsWith("Metadata")) ||
-                    (this.name.startsWith("compile") && this.name.contains("Kotlin")) ||
-                    this.name.startsWith("link") ||
-                    this.name == "copyLib" ||
-                    this.name.endsWith("Test") ||
-                    this.name.endsWith("Tests")
-                ) {
-                    it.dependsOn(this)
-                }
-            }
-        }
-    }
 }
 
 val dokkaAssets = rootProject.file("dokka/assets").listFiles()?.toList().orEmpty()

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -48,16 +48,20 @@ subprojects {
         "licenseCheckForKotlin",
         com.hierynomus.gradle.license.tasks.LicenseCheck::class
     ) {
-        dependsOn("processResources")
-        source = fileTree(project.projectDir) { include("**/*.kt") }
+        source = fileTree(project.projectDir) {
+            include("**/*.kt")
+            exclude("build/**")
+        }
     }
     tasks["license"].dependsOn("licenseCheckForKotlin")
     tasks.register(
         "licenseFormatForKotlin",
         com.hierynomus.gradle.license.tasks.LicenseFormat::class
     ) {
-        dependsOn("processResources")
-        source = fileTree(project.projectDir) { include("**/*.kt") }
+        source = fileTree(project.projectDir) {
+            include("**/*.kt")
+            exclude("build/**")
+        }
     }
     tasks["licenseFormat"].dependsOn("licenseFormatForKotlin")
 
@@ -76,24 +80,5 @@ subprojects {
     configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
         version.set("1.8.0")
         android.set(true)
-    }
-    afterEvaluate {
-        listOfNotNull(
-            tasks.findByName("licenseCheckForKotlin"),
-            tasks.findByName("licenseFormatForKotlin")
-        ).forEach {
-            tasks.all {
-                if ((this.name.startsWith("ktlint") && this.name.endsWith("Check")) ||
-                    (this.name.startsWith("transform") && this.name.endsWith("Metadata")) ||
-                    (this.name.startsWith("compile") && this.name.contains("Kotlin")) ||
-                    this.name.startsWith("link") ||
-                    this.name == "copyLib" ||
-                    this.name.endsWith("Test") ||
-                    this.name.endsWith("Tests")
-                ) {
-                    it.dependsOn(this)
-                }
-            }
-        }
     }
 }

--- a/compiler/local-plugin/build.gradle.kts
+++ b/compiler/local-plugin/build.gradle.kts
@@ -35,8 +35,8 @@ dependencies {
 java {
     withJavadocJar()
     withSourcesJar()
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 gradlePlugin {
@@ -52,6 +52,6 @@ gradlePlugin {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ hierynomus = "0.16.1"
 ktlint-plugin = "14.0.1"
 buildconfig = "6.0.6"
 bcv = "0.18.1"
-vannik = "0.35.0"
+vannik = "0.36.0"
 kotlinx-benchmark = "0.4.14"
 
 [libraries]


### PR DESCRIPTION
## Summary

- Bumps `vannik = "0.36.0"` in `libs.versions.toml`.
- Bumps `compiler/local-plugin` JVM target 11 → 17 (vannik 0.36.0's new minimum).
- Decouples `licenseCheckForKotlin` from the entire build graph (separate commit) — the existing wiring made CI hang for 6+ hours on every PR.

## Why (vannik bump)

RC3's main packages didn't publish because the `Publish compiler plugins` step's auto-release polling hit a timeout and returned non-zero, which caused GH Actions to skip the subsequent `Publish all packages` step.

This is the exact problem [Jake Wharton reported in vanniktech/gradle-maven-publish-plugin#1206](https://github.com/vanniktech/gradle-maven-publish-plugin/issues/1206): the plugin waited for Sonatype to reach `PUBLISHED` state, which Wharton notes is "50-50 whether something actually hits Central within 15m of being published."

The upstream fix [shipped in 0.36.0](https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.36.0): `validateDeployment` is now an enum and defaults to `VALIDATED` (finishes in minutes) instead of `PUBLISHED` (15-60+ min). We keep `automaticRelease = true` so Sonatype still releases server-side — no manual click needed.

Supersedes #176.

## Why (CI fix)

While waiting for #177's CI I noticed every PR since 2026-05-05 has hit GH Actions' 6-hour job cap and gotten cancelled — including #173, #174, #175. The `afterEvaluate` blocks in `build.gradle.kts` and `compiler/build.gradle.kts` made `licenseCheckForKotlin` depend on every `compile*Kotlin*`, `link*`, and `*Test` task, so the license step was actually doing a full multi-platform build. Removing the deps drops it from 6+ hours to ~10 seconds; the source set already excludes `build/` so no compilation is needed.

## Compatibility

0.36.0 minimums: JDK 17, Gradle 9.0.0, AGP 8.13.0, Kotlin 2.2.0. We use JDK 21, Gradle 9.2.1, AGP 9.0.0-rc01, Kotlin 2.3.20 — all clear. Dokka v1 support was also dropped; we're already on V2.

## Test plan

- [x] `./gradlew :ksrpc-api:tasks` configures cleanly
- [x] `./gradlew :compiler:ksrpc-compiler-plugin:assemble :compiler:ksrpc-compiler-plugin-native:assemble :compiler:ksrpc-gradle-plugin:assemble` builds clean
- [x] `./gradlew licenseCheckForKotlin` runs in ~10s instead of hanging
- [x] `cd compiler && ./gradlew licenseCheckForKotlin` passes (added matching `exclude("build/**")`)
- [ ] CI green (now actually possible)
- [ ] Re-tag v1.0.0-RC3 after merge to verify publish completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)