### PR TITLE
Split CI into 3 parallel jobs (lint / jvm-tests / compiler-tests)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -13,24 +13,41 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      - name: Install libcurl
-        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
-
       - name: Check code style
         run: ./gradlew ktlintCheck -x ktlintKotlinScriptCheck --continue
-
       - name: Check license headers
         run: ./gradlew licenseCheckForKotlin --continue
-
       - name: Check API compatibility
         run: ./gradlew apiCheck
 
+  jvm-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Install libcurl
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - name: Run JVM tests
         run: ./gradlew jvmTest --continue
 
+  compiler-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Run compiler plugin tests
         run: cd compiler && ./gradlew test


### PR DESCRIPTION
## Summary

Splits the single sequential `check` job in `.github/workflows/ci.yaml` into three jobs that run in parallel:

- **lint** — ktlintCheck, licenseCheckForKotlin, apiCheck
- **jvm-tests** — jvmTest
- **compiler-tests** — compiler subbuild `test`

## Why

PR #177 surfaced that CI was hanging at 6 hours on every PR. With the license fix from #177, CI actually completes — but it still runs ~25 min serially in one job. Splitting it drops end-to-end wall clock to roughly the slowest job (~10-12 min).

Closes #178.

## Stacked on #177

This branch is stacked on `bump-vannik-0.36` because:

1. The license fix in #177 is required for this workflow to actually finish — the `lint` job runs `licenseCheckForKotlin` which would otherwise hang for 6 hours on its own.
2. Per repo convention we stack related PRs rather than rebase each onto main.

Merge order: #177 first, then this. After #177 merges I'll retarget this PR's base to `main`.

## Test plan

- [ ] CI completes in <15 min
- [ ] All three jobs report green independently
- [ ] No regression in the set of checks run vs. the previous single-job workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)