### PR TITLE
Split CI into 3 parallel jobs (lint / jvm-tests / compiler-tests)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -13,24 +13,41 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      - name: Install libcurl
-        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
-
       - name: Check code style
         run: ./gradlew ktlintCheck -x ktlintKotlinScriptCheck --continue
-
       - name: Check license headers
         run: ./gradlew licenseCheckForKotlin --continue
-
       - name: Check API compatibility
         run: ./gradlew apiCheck
 
+  jvm-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Install libcurl
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - name: Run JVM tests
         run: ./gradlew jvmTest --continue
 
+  compiler-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Run compiler plugin tests
         run: cd compiler && ./gradlew test


### PR DESCRIPTION
## Summary

Splits the single sequential `check` job into three parallel jobs:

- **lint** — ktlintCheck, licenseCheckForKotlin, apiCheck (~5 min)
- **jvm-tests** — jvmTest (currently ~25 min; see follow-up)
- **compiler-tests** — compiler subbuild `test` (~5 min)

End-to-end wall clock is bound by jvm-tests for now. The lint and compiler-tests jobs no longer block on serial execution.

Closes #178.

(Was #179 / `ci-parallelize`, auto-closed by GitHub when its base branch was deleted by #177's merge. Re-opened against main with no content changes; rebase dropped the now-upstream license + vannik commits.)

## Follow-up

`jvm-tests` taking 25+ min is the new long pole. Will file an issue for splitting it — likely candidates include extracting the JNI module to its own test job (native lib build happens in jvmTest setup).

## Test plan

- [x] Lint job verified green on previous run of this branch (4m39s)
- [x] compiler-tests job verified green on stacked PR #180 (4m36s)
- [ ] CI on this rebased version

🤖 Generated with [Claude Code](https://claude.com/claude-code)