### PR TITLE
Bump version to 1.0.0-RC4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.0.0-RC4 (2026-05-17)
+
+Re-release of RC3 with no library code changes. RC3's main packages
+(`ksrpc-core`, `ksrpc-api`, `ksrpc-flow`, etc.) failed to reach Maven Central
+because the vanniktech-maven-publish plugin's auto-release polling timed out
+on the compiler-plugin step, causing GitHub Actions to skip the subsequent
+publish steps. Only `ksrpc-compiler-plugin` and `ksrpc-gradle-plugin` made
+it through.
+
+RC4 publishes everything from a single consistent build with the upstream fix
+in place (vanniktech 0.36.0's new `VALIDATED` default replaces the old
+`PUBLISHED` polling wait). Functionally equivalent to RC3 at the API level.
+
 ## 1.0.0-RC3 (2026-05-05)
 
 ### New features

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.0-RC3
+version=1.0.0-RC4
 signing.gnupg.keyName=5B83421E2338B907
 org.gradle.jvmargs=-Xmx4096m
 kotlin.mpp.enableCInteropCommonization=true


### PR DESCRIPTION
## Summary

- `gradle.properties`: 1.0.0-RC3 → 1.0.0-RC4
- `CHANGELOG.md`: RC4 entry explaining the re-release

## Why

RC3 only partially reached Maven Central:

| Artifact | Status |
|---|---|
| ksrpc-compiler-plugin | published ✓ |
| ksrpc-gradle-plugin | published ✓ |
| ksrpc-core, ksrpc-api, ksrpc-flow, etc. | missing ✗ |

The main packages were skipped because the vanniktech plugin's auto-release polling hit a timeout on the compiler-plugin step, returning non-zero and causing GH Actions to skip the subsequent publish steps. See vanniktech/gradle-maven-publish-plugin#1206 for the upstream issue.

#177 picked up the fix in vanniktech 0.36.0 (default `validateDeployment` changed from `PUBLISHED` to `VALIDATED`, no more 60-min polling).

RC4 publishes everything fresh from a single consistent build. No library code changes vs RC3 (the diff is purely build infrastructure: vannik bump, CI fixes, compiler test deps fix from #177, #181, #182).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, tag v1.0.0-RC4 + create release → publish workflow runs
- [ ] All artifacts present on Maven Central afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)