### PR TITLE
Fix #185: Kotlin version check silently skipped on alias() apply path

### DIFF
--- a/compiler/gradle/src/main/java/KsrpcGradlePlugin.kt
+++ b/compiler/gradle/src/main/java/KsrpcGradlePlugin.kt
@@ -30,19 +30,25 @@ class KsrpcGradlePlugin : KotlinCompilerPluginSupportPlugin {
     }
 
     private fun checkKotlinVersion(project: Project) {
-        // Pull the Kotlin plugin version off the buildscript classpath. The compiler
-        // plugin uses FIR APIs that change between Kotlin versions; running against an
-        // older Kotlin than the one we compile against throws NoClassDefFoundError
+        // The compiler plugin uses FIR APIs that change between Kotlin versions; running
+        // against an older Kotlin than the one we compile against throws NoClassDefFoundError
         // mid-compilation with no useful context. Fail fast with a clear message instead.
         // The minimum supported version is injected from gradle/libs.versions.toml at
         // build time, so it stays in sync as we upgrade Kotlin.
-        val kotlinVersion = project.plugins.findPlugin(KotlinBasePlugin::class.java)?.pluginVersion
-            ?: return
-        if (compareVersions(kotlinVersion, BuildConfig.MIN_KOTLIN_VERSION) < 0) {
-            error(
-                "ksrpc compiler plugin requires Kotlin ${BuildConfig.MIN_KOTLIN_VERSION} " +
-                    "or later (found $kotlinVersion). Upgrade your kotlin plugin version."
-            )
+        //
+        // withType(...) fires for both already-registered plugins and any that show up
+        // later in the plugins block, so the check works regardless of whether the user
+        // applies ksrpc before or after Kotlin (and regardless of whether they use the
+        // `id(...)` apply path or the version-catalog `alias(libs.plugins.ksrpc)` path —
+        // see ksrpc#185).
+        project.plugins.withType(KotlinBasePlugin::class.java) { kotlinPlugin ->
+            val kotlinVersion = kotlinPlugin.pluginVersion
+            if (compareVersions(kotlinVersion, BuildConfig.MIN_KOTLIN_VERSION) < 0) {
+                error(
+                    "ksrpc compiler plugin requires Kotlin ${BuildConfig.MIN_KOTLIN_VERSION} " +
+                        "or later (found $kotlinVersion). Upgrade your kotlin plugin version."
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Switches `KsrpcGradlePlugin.checkKotlinVersion` from a one-shot `findPlugin(KotlinBasePlugin)` lookup at our `apply()` time to `plugins.withType(KotlinBasePlugin) { ... }`, which fires whenever a Kotlin plugin is registered — regardless of relative apply order or whether ksrpc was applied via `id(...)` or `alias(libs.plugins.ksrpc)`.

Closes #185.

## Why

Reported by kplusplus during RC4 integration testing. With Kotlin set to a version below the floor and ksrpc applied via the version-catalog alias path, the check from #174 silently no-op'd via `?: return` because `KotlinBasePlugin` wasn't registered on the project yet at our `apply()` time. Users got the original bare `NoClassDefFoundError: org/jetbrains/kotlin/fir/declarations/FirNamedFunction` from `KsMethodFunctionChecker.check` mid-compilation — the exact symptom #174 was supposed to prevent.

## Verification

- [x] `:compiler:ksrpc-gradle-plugin:assemble` clean
- [ ] kplusplus to retest with `kotlin = "2.3.0"` against `alias(libs.plugins.ksrpc)` and confirm the friendly error fires (will ping after merge)
- [ ] CI green

## Out of scope

A proper TestKit regression test would need adding test infrastructure to `compiler/gradle/` (currently no `src/test/`). Worth doing but not blocking the fix. Tracked separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)