### PR TITLE
Fix #187: downgrade post-close receive-loop exception to debug

### DIFF
--- a/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
@@ -179,7 +179,17 @@ abstract class PacketChannelBase<T>(
                 }
             }
         } catch (t: Throwable) {
-            env.logger.warn("MultiChannel", "Exception in multichannel", t)
+            // Once close() has flipped isClosed, the peer is gone by definition — the read
+            // path will see a closed channel and surface IOException ("closed for reading"
+            // from PacketUtils.readFields, or framework-equivalent). That's normal teardown,
+            // not a failure: downgrade to debug so it doesn't read as a scary WARN in
+            // consumer logs. Mirrors the close-during-write handling in
+            // ksrpc-sockets/InputOutputStreams.copyToAndFlush (#169 / PR #172).
+            if (isClosed) {
+                env.logger.debug("MultiChannel", "Receive loop ended after close", t)
+            } else {
+                env.logger.warn("MultiChannel", "Exception in multichannel", t)
+            }
             binaryChannels.values.forEach { it.closeWithError(t) }
             multiChannel.close(CancellationException("Multi-channel failure", t))
         }


### PR DESCRIPTION
## Summary

\`PacketChannelBase.executeReceive\` catches all throwables from the receive loop and warns unconditionally. After \`close()\` has flipped \`isClosed\`, the peer is gone by definition — any read-side exception at that point is expected teardown, not a failure. Downgrade to debug in that case; keep warn for the pre-close path.

Closes #187.

## Why

Reported by konstructor during 1.0.0-RC4 integration validation. Their adolin redeploy logs show a non-fatal \`IOException: ...closed for reading\` from \`PacketUtils.readFields(PacketUtils.kt:43)\` at WARN level during normal shutdown. Tests still pass; just the read-side counterpart to the write-side close handling that landed in PR #172 (issue #169).

## Test plan

- [x] \`./gradlew :ksrpc-packets:compileKotlinJvm\` compiles clean
- [ ] CI green
- [ ] After merge: konstructor to re-run integration tests and confirm the WARN no longer appears in adolin logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)