### PR TITLE
Fix #189: publishAllToMavenLocal aggregator for the compiler includeBuild

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,3 +144,15 @@ dependencies {
     dokka(project(":ksrpc-sockets"))
     dokka(project(":ksrpc-service-worker"))
 }
+
+// Convenience aggregator so `./gradlew publishAllToMavenLocal` reaches into the compiler
+// included build (settings.gradle.kts:55) — root `publishToMavenLocal` doesn't recurse, so
+// the compiler-plugin / gradle-plugin / plugin-marker artifacts otherwise need a separate
+// `cd compiler/ && ./gradlew publishToMavenLocal` step. Surfaced by kplusplus during the
+// 1.0.0-RC4 #185 retest.
+tasks.register("publishAllToMavenLocal") {
+    group = "publishing"
+    description = "Publishes all ksrpc artifacts (root + compiler included build) to mavenLocal."
+    dependsOn("publishToMavenLocal")
+    dependsOn(gradle.includedBuild("compiler").task(":publishToMavenLocal"))
+}


### PR DESCRIPTION
## Summary

Adds a \`publishAllToMavenLocal\` task at root that depends on both root \`publishToMavenLocal\` and the compiler included build's \`publishToMavenLocal\`, so contributors can populate mavenLocal with one command.

Closes #189.

## Why

The compiler is included via \`includeBuild(\"compiler\")\` in \`settings.gradle.kts\`, which means root \`publishToMavenLocal\` doesn't recurse. Surfaced by kplusplus during the #185 retest — they had to run publishToMavenLocal twice (root + \`cd compiler/\`) before they could exercise their alias() repro against a development build of ksrpc.

## Test plan

- [x] \`./gradlew help --task publishAllToMavenLocal\` resolves and shows the registered description
- [ ] CI green
- [ ] Manual: contributor runs \`./gradlew publishAllToMavenLocal\`, all ksrpc artifacts plus compiler-plugin + gradle-plugin + plugin-marker land in \`~/.m2/repository\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)