### PR TITLE
Fix #191: gate release signing on RELEASE_SIGNING_ENABLED

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,16 +23,16 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: Publish compiler plugins
-        run: cd compiler && ./gradlew publish -PmavenCentralUsername=${{ secrets.OSSRH_USERNAME }} -PmavenCentralPassword=${{ secrets.OSSRH_TOKEN }} -Psigning.gnupg.passphrase='${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}'
+        run: cd compiler && ./gradlew publish -PmavenCentralUsername=${{ secrets.OSSRH_USERNAME }} -PmavenCentralPassword=${{ secrets.OSSRH_TOKEN }} -Psigning.gnupg.passphrase='${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}' -Psigning.gnupg.keyName=5B83421E2338B907 -PRELEASE_SIGNING_ENABLED=true
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
 
       - name: Publish to Gradle Plugin Portal
-        run: cd compiler && ./gradlew :ksrpc-gradle-plugin:publishPlugins -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} -Psigning.gnupg.passphrase='${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}'
+        run: cd compiler && ./gradlew :ksrpc-gradle-plugin:publishPlugins -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} -Psigning.gnupg.passphrase='${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}' -Psigning.gnupg.keyName=5B83421E2338B907 -PRELEASE_SIGNING_ENABLED=true
 
       - name: Publish all packages
-        run: ./gradlew publish -PmavenCentralUsername=${{ secrets.OSSRH_USERNAME }} -PmavenCentralPassword=${{ secrets.OSSRH_TOKEN }} -Psigning.gnupg.passphrase='${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}'
+        run: ./gradlew publish -PmavenCentralUsername=${{ secrets.OSSRH_USERNAME }} -PmavenCentralPassword=${{ secrets.OSSRH_TOKEN }} -Psigning.gnupg.passphrase='${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}' -Psigning.gnupg.keyName=5B83421E2338B907 -PRELEASE_SIGNING_ENABLED=true
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/compiler/gradle/build.gradle.kts
+++ b/compiler/gradle/build.gradle.kts
@@ -27,6 +27,10 @@ plugins {
 
 group = "com.monkopedia.ksrpc"
 
+// Release signing is gated so contributors can run publishToMavenLocal without the
+// maintainer's GPG key. Enable in release CI via -PRELEASE_SIGNING_ENABLED=true.
+val signingEnabled = (findProperty("RELEASE_SIGNING_ENABLED") as String?)?.toBoolean() == true
+
 dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("gradle-plugin-api"))
@@ -100,10 +104,14 @@ mavenPublishing {
         }
     }
     publishToMavenCentral()
-    signAllPublications()
+    // signAllPublications() is auto-called by vanniktech when the Gradle property
+    // RELEASE_SIGNING_ENABLED=true is set; we don't call it explicitly to avoid a
+    // double-set on the (now finalized) underlying Property in 0.36.0.
 }
 
-signing {
-    useGpgCmd()
-    sign(publishing.publications)
+if (signingEnabled) {
+    signing {
+        useGpgCmd()
+        sign(publishing.publications)
+    }
 }

--- a/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
+++ b/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
@@ -252,6 +252,10 @@ fun Project.ksrpcModule(
     }
     val publishing = extensions.getByType<MavenPublishBaseExtension>()
     val pub = extensions.getByType<PublishingExtension>()
+    // Release signing is gated so contributors can run publishToMavenLocal without the
+    // maintainer's GPG key. Enable in release CI via -PRELEASE_SIGNING_ENABLED=true.
+    val signingEnabled =
+        (findProperty("RELEASE_SIGNING_ENABLED") as String?)?.toBoolean() == true
     publishing.apply {
         pom {
             it.name.set(this@ksrpcModule.name)
@@ -277,19 +281,23 @@ fun Project.ksrpcModule(
             }
         }
         publishToMavenCentral(automaticRelease = true)
-        signAllPublications()
+        // signAllPublications() is auto-called by vanniktech when the Gradle property
+        // RELEASE_SIGNING_ENABLED=true is set; we don't call it explicitly to avoid a
+        // double-set on the (now finalized) underlying Property in 0.36.0.
     }
 
-    extensions.getByType<SigningExtension>().apply {
-        useGpgCmd()
-        sign(pub.publications)
-    }
-    project.afterEvaluate {
-        tasks.withType(org.gradle.plugins.signing.Sign::class) { signingTask ->
-            tasks.withType(
-                org.gradle.api.publish.maven.tasks.AbstractPublishToMaven::class
-            ) { publishTask ->
-                publishTask.dependsOn(signingTask)
+    if (signingEnabled) {
+        extensions.getByType<SigningExtension>().apply {
+            useGpgCmd()
+            sign(pub.publications)
+        }
+        project.afterEvaluate {
+            tasks.withType(org.gradle.plugins.signing.Sign::class) { signingTask ->
+                tasks.withType(
+                    org.gradle.api.publish.maven.tasks.AbstractPublishToMaven::class
+                ) { publishTask ->
+                    publishTask.dependsOn(signingTask)
+                }
             }
         }
     }

--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -26,6 +26,10 @@ plugins {
 
 group = "com.monkopedia.ksrpc"
 
+// Release signing is gated so contributors can run publishToMavenLocal without the
+// maintainer's GPG key. Enable in release CI via -PRELEASE_SIGNING_ENABLED=true.
+val signingEnabled = (findProperty("RELEASE_SIGNING_ENABLED") as String?)?.toBoolean() == true
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -82,7 +86,9 @@ mavenPublishing {
         }
     }
     publishToMavenCentral(automaticRelease = true)
-    signAllPublications()
+    // signAllPublications() is auto-called by vanniktech when the Gradle property
+    // RELEASE_SIGNING_ENABLED=true is set; we don't call it explicitly to avoid a
+    // double-set on the (now finalized) underlying Property in 0.36.0.
 }
 
 tasks.withType<KotlinCompile> {
@@ -93,7 +99,9 @@ tasks.withType<KotlinCompile> {
     }
 }
 
-signing {
-    useGpgCmd()
-    sign(publishing.publications)
+if (signingEnabled) {
+    signing {
+        useGpgCmd()
+        sign(publishing.publications)
+    }
 }

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -26,6 +26,10 @@ plugins {
 
 group = "com.monkopedia.ksrpc"
 
+// Release signing is gated so contributors can run publishToMavenLocal without the
+// maintainer's GPG key. Enable in release CI via -PRELEASE_SIGNING_ENABLED=true.
+val signingEnabled = (findProperty("RELEASE_SIGNING_ENABLED") as String?)?.toBoolean() == true
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -124,7 +128,9 @@ mavenPublishing {
         }
     }
     publishToMavenCentral(automaticRelease = true)
-    signAllPublications()
+    // signAllPublications() is auto-called by vanniktech when the Gradle property
+    // RELEASE_SIGNING_ENABLED=true is set; we don't call it explicitly to avoid a
+    // double-set on the (now finalized) underlying Property in 0.36.0.
 }
 
 tasks.withType<KotlinCompile> {
@@ -138,9 +144,11 @@ tasks.withType<KotlinCompile> {
     }
 }
 
-signing {
-    useGpgCmd()
-    sign(publishing.publications)
+if (signingEnabled) {
+    signing {
+        useGpgCmd()
+        sign(publishing.publications)
+    }
 }
 
 afterEvaluate {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 version=1.0.0-RC4
-signing.gnupg.keyName=5B83421E2338B907
 org.gradle.jvmargs=-Xmx4096m
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.enableKlibsCrossCompilation=false


### PR DESCRIPTION
## Summary

Adopts vanniktech's \`RELEASE_SIGNING_ENABLED\` Gradle property convention so contributors can run \`publishToMavenLocal\` without the maintainer's GPG key.

- Remove \`signing.gnupg.keyName=5B83421E2338B907\` from the repo's \`gradle.properties\` (belongs in the maintainer's \`~/.gradle/gradle.properties\`).
- Drop the four explicit \`signAllPublications()\` calls — vanniktech 0.36.0 auto-calls it when the property is set, and explicit calls now fail with a finalized-Property error in that same scenario.
- Gate the four \`signing { useGpgCmd; sign(publishing.publications) }\` blocks behind \`RELEASE_SIGNING_ENABLED\`. Without the flag, no sign extension config means no sign tasks, and \`publishToMavenLocal\` works without a key.
- Update \`.github/workflows/publish.yaml\` to pass \`-PRELEASE_SIGNING_ENABLED=true\` and \`-Psigning.gnupg.keyName=5B83421E2338B907\` on the three publish steps.

Closes #191.

## Why

Reported by kplusplus during #185 retest: \`publishToMavenLocal\` failed with \`gpg: skipped \"5B83421E2338B907\": No secret key\` and required an init-script workaround.

## Verification

- [x] \`./gradlew help\` configures clean without the flag (no signing tasks generated)
- [x] \`./gradlew :ksrpc-api:tasks --all -PRELEASE_SIGNING_ENABLED=true -Psigning.gnupg.keyName=...\` configures clean and lists \`signJvmPublication\`, \`signKotlinMultiplatformPublication\` under Verification tasks
- [ ] CI green
- [ ] Maintainer note: add \`signing.gnupg.keyName=5B83421E2338B907\` to \`~/.gradle/gradle.properties\` for local release work (no longer in the repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)