### PR TITLE
Bump version to 1.0.0-RC5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.0.0-RC5 (2026-05-19)
+
+Pre-1.0 polish from real-world consumer feedback (konstructor, kplusplus,
+lsp-kotlin, hauler) gathered during RC4 integration testing. No API changes;
+also serves as a publish smoke-test for the release-signing rework in #192
+before tagging 1.0.0 final.
+
+### Fixes
+
+- **#185 / PR #186**: Kotlin version-check gradle plugin now fires on the
+  version-catalog `alias(libs.plugins.ksrpc)` apply path too, not just
+  `id("...")`. Was silently skipped when ksrpc applied before Kotlin in
+  the plugins block. Reported by kplusplus.
+- **#187 / PR #188**: Receive-loop exceptions after `close()` log at debug
+  instead of warn. Read-side counterpart to the close-during-write fix in
+  PR #172 (#169). Reported by konstructor (production teardown noise).
+
+### Developer experience
+
+- **#189 / PR #190**: New `publishAllToMavenLocal` aggregator task that
+  reaches into the compiler included build, so contributors testing against
+  a development build of ksrpc no longer need to run publishToMavenLocal
+  twice. Reported by kplusplus.
+- **#191 / PR #192**: Release signing is now gated on the
+  `RELEASE_SIGNING_ENABLED` gradle property (vanniktech's convention).
+  Contributors can run `publishToMavenLocal` without the maintainer's GPG
+  key. The maintainer's `signing.gnupg.keyName` moved out of the repo's
+  `gradle.properties`; it now lives in `~/.gradle/gradle.properties` and
+  is passed into the publish CI as a `-P` flag. Reported by kplusplus.
+
 ## 1.0.0-RC4 (2026-05-17)
 
 Re-release of RC3 with no library code changes. RC3's main packages

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.0-RC4
+version=1.0.0-RC5
 org.gradle.jvmargs=-Xmx4096m
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.enableKlibsCrossCompilation=false


### PR DESCRIPTION
## Summary

- \`gradle.properties\`: 1.0.0-RC4 → 1.0.0-RC5
- \`CHANGELOG.md\`: RC5 entry summarizing the four pre-1.0 polish PRs

## Why

Final pre-1.0 RC. Bundles four polish fixes surfaced during RC4 consumer integration testing:

| PR | Issue | Change |
|---|---|---|
| #186 | #185 | Kotlin version-check fires on the alias() apply path |
| #188 | #187 | Receive-loop post-close exception logs at debug |
| #190 | #189 | \`publishAllToMavenLocal\` aggregator for the compiler includeBuild |
| #192 | #191 | Release signing gated on \`RELEASE_SIGNING_ENABLED\` |

No API changes vs RC4. Also acts as a publish smoke-test for #192's signing rework before we commit to a 1.0.0 final tag — that's the actual reason for cutting RC5 rather than going straight to 1.0.0.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: tag v1.0.0-RC5, create release → publish workflow runs and signs cleanly
- [ ] All artifacts present on Maven Central
- [ ] Consumer agents (konstructor, kplusplus, lsp-kotlin, hauler) bump and report no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)