### PR TITLE
Fix #195: close multiChannel cleanly on post-close receive-loop exit

### DIFF
--- a/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
@@ -182,16 +182,22 @@ abstract class PacketChannelBase<T>(
             // Once close() has flipped isClosed, the peer is gone by definition — the read
             // path will see a closed channel and surface IOException ("closed for reading"
             // from PacketUtils.readFields, or framework-equivalent). That's normal teardown,
-            // not a failure: downgrade to debug so it doesn't read as a scary WARN in
-            // consumer logs. Mirrors the close-during-write handling in
-            // ksrpc-sockets/InputOutputStreams.copyToAndFlush (#169 / PR #172).
+            // not a failure: downgrade the local log to debug AND close the multiChannel /
+            // binaryChannels cleanly so consumers awaiting on them see a normal close
+            // instead of a CancellationException wrapping the IOException. Mirrors the
+            // close-during-write handling in ksrpc-sockets/InputOutputStreams.copyToAndFlush
+            // (#169 / PR #172). #187's PR #188 only quieted the ksrpc-internal log; the
+            // CancellationException was still propagating to consumers (konstructor's
+            // ScriptManager surfaced it at WARN with the IOException cause attached).
             if (isClosed) {
                 env.logger.debug("MultiChannel", "Receive loop ended after close", t)
+                binaryChannels.values.forEach { it.closeWithError(null) }
+                multiChannel.close()
             } else {
                 env.logger.warn("MultiChannel", "Exception in multichannel", t)
+                binaryChannels.values.forEach { it.closeWithError(t) }
+                multiChannel.close(CancellationException("Multi-channel failure", t))
             }
-            binaryChannels.values.forEach { it.closeWithError(t) }
-            multiChannel.close(CancellationException("Multi-channel failure", t))
         }
     }
 


### PR DESCRIPTION
## Summary

Completes the post-close receive-loop noise fix that PR #188 only partially addressed.

In \`PacketChannelBase.executeReceive\`'s catch block, when \`isClosed\` (consumer initiated the teardown), close the multiChannel and binaryChannels **cleanly without a cause**. Pre-close exceptions still propagate as before — those are real failures consumers need to see.

Closes #195.

## Why

PR #188 downgraded the ksrpc-internal log statement when \`isClosed\`, but the exception still propagated to consumers via \`multiChannel.close(CancellationException(\"Multi-channel failure\", t))\`. That CancellationException carries the IOException as cause and surfaces to anyone awaiting on the multiChannel.

konstructor reported during 1.0.0-RC5 integration that their ScriptManager caught + logged it at WARN with the same volume (~169 events per 2-test run) as the pre-#188 RC4 noise. Just a different exception type.

This closes the loop on what #187 was actually trying to achieve.

## Test plan

- [x] \`./gradlew :ksrpc-packets:jvmTest\` clean
- [ ] \`./gradlew :ksrpc-test:jvmTest\` clean (in flight locally)
- [ ] CI green
- [ ] After merge: konstructor to bump and confirm the WARN count drops on adolin

🤖 Generated with [Claude Code](https://claude.com/claude-code)