### PR TITLE
Fix #197: bound CopyToAndFlushOutputCloseJvmTest.call with withTimeoutOrNull

### DIFF
--- a/ksrpc-test/src/jvmTest/kotlin/CopyToAndFlushOutputCloseJvmTest.kt
+++ b/ksrpc-test/src/jvmTest/kotlin/CopyToAndFlushOutputCloseJvmTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.assertNull
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.builtins.serializer
 
 /**
@@ -103,11 +104,20 @@ class CopyToAndFlushOutputCloseJvmTest {
                     "hello"
                 )
                 output.fail()
-                runCatching {
-                    connection!!.defaultChannel().call("echo", request, callId = null)
+                // The call will never return: after #169/PR #172 the writer silently
+                // swallows the IOException, so the request bytes never reach the peer
+                // and no response packet comes back. Bound the wait — what we care
+                // about is whether copyToAndFlush leaked the exception to the parent
+                // scope, not whether the call completes. 1s is plenty for the writer
+                // to observe the failed write.
+                withTimeoutOrNull(1000) {
+                    runCatching {
+                        connection!!.defaultChannel().call("echo", request, callId = null)
+                    }
                 }
-                // Give the copy coroutine time to observe the failed write
-                // and either swallow it (fixed) or rethrow (buggy).
+                // Belt-and-suspenders pause so the copy coroutine has a chance to
+                // observe the failed write and either swallow it (fixed) or rethrow
+                // (buggy) before we read capturedException.
                 delay(300)
             }
         } finally {


### PR DESCRIPTION
## Summary

\`CopyToAndFlushOutputCloseJvmTest\` was hanging forever because its \`connection.call(\"echo\", ...)\` awaits a response packet that can never come — after the #169 fix, copyToAndFlush silently swallows the failing-output IOException, the bytes never reach the peer, and \`awaitRequestCancellable\` sits indefinitely.

Bound the doomed call with \`withTimeoutOrNull(1000)\`. The assertion (no leaked exception to the parent CoroutineExceptionHandler) doesn't depend on the call returning — it only needs enough time for copyToAndFlush to observe the failed write.

Closes #197.

## Why this is urgent

Exposed by PR #194's CI split: \`jni-tests\` was running for ~3 hours before being cancelled. The test has been a hang-forever from day one (added in PR #172 alongside the #169 fix) and silently dormant because CI was wedged at license-check during that window.

## Verification

- [x] Without fix: \`./gradlew :ksrpc-test:jvmTest --tests CopyToAndFlushOutputCloseJvmTest\` hangs indefinitely (verified locally and via jstack pointing at \`CountDownLatch.await\` from runBlockingUnit)
- [x] With fix: completes in ~28s locally
- [ ] CI green
- [ ] After merge: PR #194 (CI speedup) can run without jni-tests wedging

## Follow-up

The architectural concern — that \`call()\` hangs forever when a writer silently fails — should be tracked as a post-1.0 issue. Mentioned in #197. Filing later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)