### PR TITLE
Bump version to 1.0.0-RC6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.0.0-RC6 (2026-05-20)
+
+One consumer-facing fix plus test/CI hardening. No API changes.
+
+### Fixes
+
+- **#195 / PR #196**: the packet receive loop now closes the multiChannel and
+  binary channels cleanly when the channel was already closed by the consumer,
+  instead of propagating a `CancellationException("Multi-channel failure")`
+  wrapping the underlying close IOException. PR #188 (RC5) only quieted ksrpc's
+  own log; the exception was still surfacing to consumers who catch and log it
+  (konstructor's `ScriptManager` logged ~169 WARN events per teardown). This
+  closes that propagation at the source. Reported by konstructor.
+
+### Internal (no artifact impact)
+
+- **#197 / PR #198**: bounded a hanging regression test
+  (`CopyToAndFlushOutputCloseJvmTest`) that had been silently wedging CI since
+  it was added.
+- **#183 / PR #194**: split the JNI/Kotlin-Native-backed jvmTest modules into
+  their own CI job with a `~/.konan` cache, cutting CI wall-clock from ~25min
+  to ~5-8min.
+
 ## 1.0.0-RC5 (2026-05-19)
 
 Pre-1.0 polish from real-world consumer feedback (konstructor, kplusplus,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.0-RC5
+version=1.0.0-RC6
 org.gradle.jvmargs=-Xmx4096m
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.enableKlibsCrossCompilation=false


### PR DESCRIPTION
## Summary

- `gradle.properties`: 1.0.0-RC5 → 1.0.0-RC6
- `CHANGELOG.md`: RC6 entry

## Why

Validates the #195 receive-loop close-cleanly fix (PR #196) against a published artifact before tagging 1.0.0 final. konstructor specifically wants to confirm the post-close WARN noise actually drops in their adolin deployment — that needs a published RC carrying #195.

Also carries #197 (test-hang fix) and #183 (CI split), neither of which affects published bits. No API changes vs RC5.

## Test plan

- [ ] CI green
- [ ] After merge: tag v1.0.0-RC6, release → publish workflow signs + propagates
- [ ] konstructor bumps to RC6, confirms the ~169-WARN-per-teardown noise is gone
- [ ] Other consumers (kplusplus, lsp-kotlin, hauler) bump and report no regressions
- [ ] If all clean → tag 1.0.0 final from this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)