### PR TITLE
Fix #200: wake pending calls when JVM pipe write side fails

### DIFF
--- a/ksrpc-sockets/src/jvmMain/kotlin/InputOutputStreams.kt
+++ b/ksrpc-sockets/src/jvmMain/kotlin/InputOutputStreams.kt
@@ -30,6 +30,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -45,30 +46,45 @@ suspend fun Pair<InputStream, OutputStream>.asConnection(
     val (input, output) = this
     val channel = ByteChannel(autoFlush = true)
     val connectionScope = CoroutineScope(coroutineContext + SupervisorJob())
+    // The connection isn't built until after this coroutine launches, so hand it to the
+    // copy coroutine via a deferred — it needs it to force-close on write-side failure (#200).
+    val connectionReady = CompletableDeferred<Connection<String>>()
     connectionScope.launch(Dispatchers.IO) {
-        channel.copyToAndFlush(output)
-    }
-    return (input.toByteReadChannel(Dispatchers.IO) to channel)
-        .asConnection(connectionScope, env)
-        .also {
-            it.onClose {
-                swallow { connectionScope.cancel() }
-                swallow { input.close() }
-                swallow { output.close() }
-            }
+        val cleanEof = channel.copyToAndFlush(output)
+        if (!cleanEof) {
+            // The write side died (e.g. subprocess closed its stdin) while the read side may
+            // still be open. Without this, the receive loop keeps waiting on the live read
+            // side, MultiChannel.close() never fires, and any pending call() awaits a response
+            // that can never come — hanging forever (#200). Closing the connection runs the
+            // normal teardown, which completes pending receivers exceptionally so callers fail
+            // fast instead of hanging.
+            swallow { connectionReady.await().close() }
         }
+    }
+    val connection = (input.toByteReadChannel(Dispatchers.IO) to channel)
+        .asConnection(connectionScope, env)
+    connection.onClose {
+        swallow { connectionScope.cancel() }
+        swallow { input.close() }
+        swallow { output.close() }
+    }
+    connectionReady.complete(connection)
+    return connection
 }
 
 /**
- * Copies up to [limit] bytes from [this] byte channel to [out] stream suspending on read channel
- * and blocking on output
+ * Copies bytes from [this] byte channel to [out] stream, suspending on read and blocking on
+ * the output write.
  *
- * @return number of bytes copied
+ * @return `true` if the copy ended because the read side reached a clean EOF; `false` if it
+ *   ended because the destination stream failed (e.g. the subprocess closed its stdin). The
+ *   caller uses a `false` return to force-close the connection so pending calls don't hang on
+ *   a write side that silently went away (#200).
  */
 private suspend fun ByteReadChannel.copyToAndFlush(
     out: OutputStream,
     limit: Long = Long.MAX_VALUE
-): Long {
+): Boolean {
     require(limit >= 0) { "Limit shouldn't be negative: $limit" }
 
     val buffer = ByteArrayPool.borrow()
@@ -87,9 +103,10 @@ private suspend fun ByteReadChannel.copyToAndFlush(
                         copied += rc
                     } catch (t: IOException) {
                         // Destination stream is gone (e.g. subprocess exited and closed
-                        // its stdin). Stop trying to write; the connection scope will
-                        // observe the close via other means.
-                        break
+                        // its stdin). Signal the failure to the caller so it can tear the
+                        // connection down — see #200.
+                        swallow { out.close() }
+                        return false
                     }
                 }
             } catch (t: Throwable) {
@@ -100,7 +117,7 @@ private suspend fun ByteReadChannel.copyToAndFlush(
         }
         swallow { out.close() }
 
-        return copied
+        return true
     } finally {
         ByteArrayPool.recycle(buffer)
     }

--- a/ksrpc-test/src/jvmTest/kotlin/CallHangsOnWriteFailureJvmTest.kt
+++ b/ksrpc-test/src/jvmTest/kotlin/CallHangsOnWriteFailureJvmTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.channels.RpcCallId
+import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.sockets.asConnection
+import java.io.IOException
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.builtins.serializer
+
+/**
+ * Regression test for issue #200: when the write side of a
+ * `Pair<InputStream, OutputStream>.asConnection` fails (e.g. a subprocess closed
+ * its stdin) while the read side stays open, an in-flight `call()` used to await a
+ * response that could never arrive and hang forever. The fix force-closes the
+ * connection on write-side failure so the pending call wakes with an exception
+ * instead of hanging.
+ */
+class CallHangsOnWriteFailureJvmTest {
+
+    /** OutputStream that throws once [fail] is triggered (mimics a dead subprocess stdin). */
+    private class ClosableFailingOutputStream : OutputStream() {
+        @Volatile
+        private var failing = false
+
+        fun fail() {
+            failing = true
+        }
+
+        override fun write(b: Int) {
+            if (failing) throw IOException("Stream closed")
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            if (failing) throw IOException("Stream closed")
+        }
+
+        override fun flush() {
+            if (failing) throw IOException("Stream closed")
+        }
+
+        override fun close() {
+            failing = true
+        }
+    }
+
+    @Test
+    fun callWakesWhenWriteSideFails() = runBlockingUnit {
+        val env = ksrpcEnvironment { }
+        // Piped input stays open (no EOF) — this is the asymmetric case where only the
+        // write side dies, which is the one that used to hang (#200). If the read side
+        // also closed, the receive loop would EOF and tear down the connection anyway.
+        val pipeFeed = PipedOutputStream()
+        val input = PipedInputStream(pipeFeed, 64 * 1024)
+        val output = ClosableFailingOutputStream()
+
+        val connection = (input to output).asConnection(env)
+        connection.registerDefault(EchoSerializedService(env))
+
+        val request = env.serialization.createCallData(String.serializer(), "hello")
+        output.fail()
+
+        // The call must terminate (throw) rather than hang. Bound it so a regression
+        // surfaces as a test failure (assertNotNull below) instead of wedging the suite.
+        val outcome = withTimeoutOrNull(5_000) {
+            runCatching {
+                connection.defaultChannel().call("echo", request, callId = null)
+            }
+        }
+
+        assertNotNull(
+            outcome,
+            "call() did not terminate within 5s after the write side failed — it hung (#200)"
+        )
+
+        runCatching { pipeFeed.close() }
+        runCatching { connection.close() }
+    }
+
+    private class EchoSerializedService(override val env: KsrpcEnvironment<String>) :
+        SerializedService<String> {
+        override suspend fun call(
+            endpoint: String,
+            input: CallData<String>,
+            callId: RpcCallId?
+        ): CallData<String> = input
+
+        override suspend fun close() = Unit
+
+        override suspend fun onClose(onClose: suspend () -> Unit) = Unit
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #200 for the JVM `Pair<InputStream, OutputStream>.asConnection` transport — the case konstructor hit in production (subprocess script execution where the lock-holder hung on a never-returning `call()`).

**Root cause:** after the #169 fix, `copyToAndFlush` silently swallows the IOException when the destination stream dies. If the read side stays open (asymmetric failure), the receive loop keeps waiting, the connection's `MultiChannel.close()` never fires, and any pending `call()` awaits a response that can't come — hanging forever.

**Fix:** `copyToAndFlush` now returns `true` on clean read-side EOF, `false` on write-side failure. On `false`, the copy coroutine force-closes the connection, which runs normal teardown — and `MultiChannel.close()` already completes pending receivers exceptionally. So callers fail fast instead of hanging. The recovery machinery existed; it just wasn't being triggered on a write-only failure.

## Test

`CallHangsOnWriteFailureJvmTest` reproduces the asymmetric failure (write dies via a failing OutputStream, read side held open via PipedInputStream) and asserts a pending `call()` terminates within 5s. **Verified it's a genuine guard:** with the fix reverted, the test fails (times out); with the fix, it passes (~36s build+run). Bounded by `withTimeoutOrNull` so a future regression surfaces as a failure, not a wedged suite.

## Scope

- **JVM pipe transport (this PR):** fixed + tested. The demonstrated production case.
- **Kotlin/Native posix transport:** has an analogous gap via a different mechanism (`channel.cancel` on posix write failure). Not demonstrated in production (lsp-kotlin, the native stdio user, didn't hit it), needs K/N-specific test setup. Tracked as #201 for 1.0.x.

## CI note

I will verify all CI jobs actually *complete* (not just step-pass) before considering this merge-ready — including the jni-tests job that exercises ksrpc-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)