### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 1.0.0 (2026-05-21)
+
+First stable release. API is now considered stable under semantic versioning —
+breaking changes will require a 2.0.0.
+
+Identical in library code to 1.0.0-RC6 plus the #200 fix (PR #202). The full
+1.0.0 surface was built up across the RC series (see entries below):
+
+- Service capability tier hierarchy (`RpcService` → `RpcHostService` →
+  `RpcBidiService`) with compile-time FIR validation
+- `@KsService` interface inheritance, `@KsContext` propagation, `@KsError`
+  typed error mappings, `@KsIntrospectable` runtime metadata
+- `Flow<T>` streaming (`ksrpc-flow`), binary data adapters (ktor / kotlinx-io /
+  okio), generic service support
+- Transports: HTTP, websocket, JSON-RPC 2.0, POSIX sockets, stdin/out,
+  service-worker
+
+Validated against four downstream consumers (konstructor, kplusplus,
+lsp-kotlin, hauler) across RC2/RC4/RC5/RC6.
+
+### Fixes since RC6
+
+- **#200 / PR #202**: `call()` no longer hangs indefinitely when the JVM pipe
+  transport's write side fails silently (e.g. a subprocess closes its stdin)
+  while the read side stays open. The connection is now force-closed on
+  write-side failure so pending calls fail fast instead of awaiting a response
+  that can never arrive. (The Kotlin/Native posix analog is tracked as #201 for
+  a 1.0.x follow-up.)
+
 ## 1.0.0-RC6 (2026-05-20)
 
 One consumer-facing fix plus test/CI hardening. No API changes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.0-RC6
+version=1.0.0
 org.gradle.jvmargs=-Xmx4096m
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.enableKlibsCrossCompilation=false


### PR DESCRIPTION
## Summary

- `gradle.properties`: 1.0.0-RC6 → **1.0.0**
- `CHANGELOG.md`: 1.0.0 final entry

## This is the 1.0.0 final cut

Library code is RC6 + the #200 fix (PR #202, merged). After this merges, tagging `v1.0.0` + creating the release triggers the publish workflow → Maven Central.

**API stability commitment:** from 1.0.0 on, breaking changes require a 2.0.0 (semver). This is the one-way door.

## Readiness (all met)

- ✅ All four downstream consumers validated RC6 (konstructor, kplusplus, lsp-kotlin, hauler)
- ✅ konstructor confirmed the #195 WARN-flood fix resolved in production (0 occurrences over 5 reruns)
- ✅ #200 (call()-hang) fixed, reviewed (tier 3, you approved), CI-green, merged
- ✅ Pre-1.0 punch list complete: signing gate (#191), CI split (#183), test-hang fix (#197), publish-timeout fix (vannik 0.36.0)
- ✅ Backlog clean: remaining open issues (#201 native analog, #153 checklist, #133 Result<T>, #22 ws overload) are all tracked 1.0.x/needs-decision, none blocking

## Note

This is a release version-bump (infra/tier-2). Merging it is the explicit "cut 1.0.0" decision. After merge I'll tag `v1.0.0` and create the GitHub release to trigger publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)