### PR TITLE
Fix JNI guide to honestly describe the manual host path (Part C of #205)

### DIFF
--- a/dokka/guides/transport-jni.md
+++ b/dokka/guides/transport-jni.md
@@ -19,56 +19,82 @@ implementation("com.monkopedia.ksrpc:ksrpc-jni:$KSRPC_VERSION")
 
 Both sides run in the same OS process, communicating through JNI calls rather than sockets or HTTP.
 
-## JVM side setup
+## JVM side: loading and connecting
 
-On the JVM side, create a `JniConnection` with a `NativeKsrpcEnvironmentFactory` that initializes the native ksrpc environment:
+The JVM-consumer path is the clean, public part of this transport. Load the native shared library, build a `JniConnection` against a native ksrpc environment pointer, and obtain a stub:
 
 ```kotlin
 import com.monkopedia.ksrpc.jni.JniConnection
-import com.monkopedia.ksrpc.jni.NativeKsrpcEnvironmentFactory
+import com.monkopedia.ksrpc.jni.JniSerialization
+import com.monkopedia.ksrpc.jni.JniSerialized
+import com.monkopedia.ksrpc.jni.NativeUtils
 import com.monkopedia.ksrpc.ksrpcEnvironment
 import com.monkopedia.ksrpc.toStub
 
-val env = ksrpcEnvironment { }
-val connection = JniConnection(
-    scope,
-    env,
-    nativeEnvironmentFactory
-)
+// Load the Kotlin/Native shared library bundled on the classpath
+NativeUtils.loadLibraryFromJar("/libs/libmy_service.so")
+
+val env = ksrpcEnvironment(JniSerialization()) { }
+
+// `nativeEnvironment` is a pointer returned from a native export (see below)
+val nativeEnvironment: Long = MyNativeHost().createEnv()
+val connection = JniConnection(scope, env, nativeEnvironment)
 
 // Call a service hosted on the native side
-val service = connection.defaultChannel().toStub<MyService>()
+val service = connection.defaultChannel().toStub<MyService, JniSerialized>()
 val result = service.someMethod("hello")
-
-// Or host a service for the native side to call
-connection.registerDefault(MyJvmServiceImpl())
 ```
 
-The `NativeKsrpcEnvironmentFactory` is a functional interface that creates the native-side ksrpc environment pointer. Its implementation depends on how your native shared library is loaded and initialized.
+`NativeUtils.loadLibraryFromJar`, `JniConnection`, and `JniSerialization` are public API. The native environment pointer (`createEnv` above) and any service registration are produced by the native module's own JNI exports, which you write yourself -- see the next section.
 
-## Native side
+## Native side: hosting a service
 
-On the Kotlin/Native side, the `NativeConnection` is created automatically by the JNI bridge when `JniConnection.createConnection` is called. The native side uses the same `registerDefault` / `defaultChannel` pattern:
+> **Heads up:** there is no turnkey public API for hosting a ksrpc service inside a Kotlin/Native `.so` in 1.0.0. Doing so today means hand-writing the JNI export boilerplate that bridges the JVM `JniConnection` to a `NativeConnection`. A clean, supported host API is planned -- see [issue #204](https://github.com/Monkopedia/ksrpc/issues/204).
 
-```kotlin
-import com.monkopedia.ksrpc.jni.NativeConnection
-import com.monkopedia.ksrpc.channels.registerDefault
-import com.monkopedia.ksrpc.toStub
+To host a native service today, mirror the working reference pattern in the test harness: [`ksrpc-test/src/nativeMain/kotlin/Test.kt`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-test/src/nativeMain/kotlin/Test.kt) together with its JVM-side `external` declarations in [`ksrpc-test/src/jvmTest/kotlin/Test.kt`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-test/src/jvmTest/kotlin/Test.kt).
 
-// Inside a JNI callback or initialization function
-fun initializeService(connection: NativeConnection) {
-    // Host a native service for the JVM to call
-    connection.registerDefault(MyNativeServiceImpl())
+The shape of the manual path is:
 
-    // Or call a service hosted on the JVM side
-    val jvmService = connection.defaultChannel().toStub<JvmService>()
-}
-```
+1. **Build your native module as a shared library**, so the JVM can load it:
+
+   ```kotlin
+   kotlin {
+       // ... your native target ...
+       binaries {
+           sharedLib { }
+       }
+   }
+   ```
+
+2. **Declare JVM-side `external` functions** that the native library will implement -- a `createEnv` that returns the native ksrpc environment pointer, and a `registerService` that wires up your service:
+
+   ```kotlin
+   class MyNativeHost {
+       external fun createEnv(): Long
+       external fun registerService(
+           connection: JniConnection,
+           output: JavaJniContinuation<Int>
+       )
+   }
+   ```
+
+3. **Implement those exports in Kotlin/Native** with `@CName("Java_...")` functions. Each entry point initializes the JNI thread, then uses `NativeConnection` plus `registerDefault` to host the service:
+
+   ```kotlin
+   @CName("Java_com_example_MyNativeHost_registerService")
+   fun registerService(env: CPointer<JNIEnvVar>, clazz: jobject, input: jobject, output: jobject) {
+       // initialize the JNI thread, convert `input` to a NativeConnection,
+       // then on the dispatcher:
+       //   nativeConnection.registerDefault(MyNativeServiceImpl().serialized(nativeConnection.env))
+   }
+   ```
+
+The dispatcher and thread-bootstrap helpers used by the reference harness currently live under the test-scoped `com.monkopedia.jnitest.*` package (`JNIDispatcher`, `initThread`, `threadEnv`). These are **not** a supported consumer API and may move; treat `ksrpc-test`'s native `Test.kt` as the authoritative example of what the manual path requires rather than copying those imports verbatim. Issue #204 tracks promoting this machinery to a stable, public host helper.
 
 ## Transport semantics
 
 - Uses `JniSerialized` as the wire format -- a binary serialization format, not JSON
-- Bidirectional: both JVM and Native sides can host and call services
+- Bidirectional at the protocol level: both JVM and Native sides can host and call services, though hosting on the native side currently requires the manual JNI export boilerplate described above
 - Full [`Connection`](https://monkopedia.github.io/ksrpc/ksrpc-core/com.monkopedia.ksrpc.channels/-connection/index.html) with sub-service support in both directions
 - Zero network overhead -- data passes through JNI method calls in the same process
 - Packet-based protocol using the same `PacketChannelBase` as other bidirectional transports


### PR DESCRIPTION
## Summary

Part (C) of #205. Revises `dokka/guides/transport-jni.md` so the host-side narrative reflects the actual state of the JNI host path in 1.0.0 instead of overclaiming.

- **JVM-consumer path stays accurate**: clarifies the clean public load+connect surface (`NativeUtils.loadLibraryFromJar`, `JniConnection`, `JniSerialization`, `toStub`) and that the native environment pointer comes from a native export the consumer writes.
- **Host-side narrative is now honest**: hosting a ksrpc service inside a Kotlin/Native `.so` currently requires hand-written `@CName Java_..._...` JNI export boilerplate plus `binaries { sharedLib { } }`. Readers are pointed at `ksrpc-test`'s `Test.kt` (native + jvmTest) as the authoritative working reference pattern.
- **No longer presents test-scoped symbols as a supported API**: explicitly flags that `com.monkopedia.jnitest.*` (`JNIDispatcher`, `initThread`, `threadEnv`) are not a consumer surface and may move.
- **Forward-reference**: a clean public host API is planned -- links #204.
- Softened the "bidirectional" semantics bullet to note native-side hosting still needs the manual path.

This is **Part (C) of #205** -- parts A/B remain, so this does NOT close #205.

## Test plan

- [x] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew processDokkaGuides` builds successfully and `$KSRPC_VERSION` substitutes to `1.0.0`.
- [x] Processed output retains the #204 reference and valid markdown links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)