### PR TITLE
Wire @sample tags to surface ksrpc-samples (Part A of #205)

### DIFF
--- a/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
+++ b/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
@@ -223,9 +223,13 @@ fun Project.ksrpcModule(
         dokkaSourceSets.configureEach { sourceSet ->
             sourceSet.includes.from(rootProject.file("dokka/moduledoc.md"))
             if (sourceSet.name == "commonMain") {
+                // Attach both sample roots to commonMain so that common declarations
+                // (e.g. transport entry points such as serveHttp / asConnection) can
+                // reference platform-specific (JVM-only) samples that demonstrate them.
+                // JVM-only samples must compile against JVM APIs, so they live in the
+                // jvmMain sample root; attaching that root only to commonMain avoids the
+                // "same sample root shared by related source sets" validity error.
                 sourceSet.samples.from(rootProject.file("ksrpc-samples/src/commonMain/kotlin"))
-            }
-            if (sourceSet.name == "jvmMain") {
                 sourceSet.samples.from(rootProject.file("ksrpc-samples/src/jvmMain/kotlin"))
             }
             sourceSet.skipEmptyPackages.set(true)

--- a/ksrpc-api/src/commonMain/kotlin/RpcService.kt
+++ b/ksrpc-api/src/commonMain/kotlin/RpcService.kt
@@ -35,6 +35,8 @@ interface RpcService : SuspendCloseable {
  *
  * HTTP transports can host [RpcHostService] instances (sub-service outputs are
  * multiplexed over the same connection), but cannot host [RpcBidiService].
+ *
+ * @sample com.monkopedia.ksrpc.samples.subServiceOutput
  */
 interface RpcHostService : RpcService
 
@@ -48,5 +50,7 @@ interface RpcHostService : RpcService
  *
  * Only bidirectional transports (WebSocket, raw sockets, JNI) can host
  * [RpcBidiService] instances.
+ *
+ * @sample com.monkopedia.ksrpc.samples.subServiceInput
  */
 interface RpcBidiService : RpcHostService

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsContext.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsContext.kt
@@ -49,6 +49,10 @@ import kotlin.reflect.KClass
  * Code emission for stub-side put-into-context and handler-side
  * read-from-coroutine-context, plus per-transport wire formats, is handled by
  * follow-up work and is intentionally not part of this annotation's contract.
+ *
+ * @sample com.monkopedia.ksrpc.samples.contextBindingDefinition
+ * @sample com.monkopedia.ksrpc.samples.contextAnnotationUsage
+ * @sample com.monkopedia.ksrpc.samples.contextPropagationUsage
  */
 @Target(AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.BINARY)

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsError.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsError.kt
@@ -65,6 +65,9 @@ import kotlin.reflect.KClass
  * by the compiler plugin directly because the binding requires a real
  * serializer reference and a dedicated lookup table, not an opaque
  * metadata bag.
+ *
+ * @sample com.monkopedia.ksrpc.samples.errorAnnotationUsage
+ * @sample com.monkopedia.ksrpc.samples.throwingTypedErrors
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
@@ -20,6 +20,9 @@ package com.monkopedia.ksrpc.annotation
  *
  * interfaces tagged with this are expected to extend [com.monkopedia.ksrpc.RpcService], and will
  * have a companion generated for them that implements [com.monkopedia.ksrpc.RpcObject] for itself.
+ *
+ * @sample com.monkopedia.ksrpc.samples.basicServiceDeclaration
+ * @sample com.monkopedia.ksrpc.samples.implementAndSerialize
  */
 annotation class KsService
 
@@ -28,6 +31,10 @@ annotation class KsService
  *
  * The [name] must be unique within a [KsService] but need not be unique
  * globally.
+ *
+ * @sample com.monkopedia.ksrpc.samples.basicServiceDeclaration
+ * @sample com.monkopedia.ksrpc.samples.serializableTypes
+ * @sample com.monkopedia.ksrpc.samples.unitInputOutput
  */
 annotation class KsMethod(val name: String)
 

--- a/ksrpc-core/src/commonMain/kotlin/KsrpcEnvironment.kt
+++ b/ksrpc-core/src/commonMain/kotlin/KsrpcEnvironment.kt
@@ -85,6 +85,16 @@ fun <T> ksrpcEnvironment(
     builder: KsrpcEnvironmentBuilder<T>.() -> Unit
 ): KsrpcEnvironment<T> = KsrpcEnvironmentBuilder<T>(serializer).also(builder)
 
+/**
+ * Creates a string-based [KsrpcEnvironment] using the given [stringFormat] (JSON by default).
+ *
+ * The [builder] lambda configures optional settings such as the
+ * [KsrpcEnvironmentBuilder.errorListener]. Pass a custom [kotlinx.serialization.StringFormat]
+ * to control how payloads are encoded on the wire.
+ *
+ * @sample com.monkopedia.ksrpc.samples.environmentBasicSetup
+ * @sample com.monkopedia.ksrpc.samples.environmentWithErrorListener
+ */
 fun ksrpcEnvironment(
     stringFormat: StringFormat = Json,
     builder: KsrpcEnvironmentBuilder<String>.() -> Unit

--- a/ksrpc-core/src/commonMain/kotlin/RpcObject.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcObject.kt
@@ -19,6 +19,8 @@ import com.monkopedia.ksrpc.channels.SerializedService
 
 /**
  * Interface for generated companions of [RpcService].
+ *
+ * @sample com.monkopedia.ksrpc.samples.basicServiceDeclaration
  */
 interface RpcObject<T : RpcService> {
     val serviceName: String

--- a/ksrpc-core/src/commonMain/kotlin/RpcServiceUtils.kt
+++ b/ksrpc-core/src/commonMain/kotlin/RpcServiceUtils.kt
@@ -20,6 +20,9 @@ import com.monkopedia.ksrpc.internal.HostSerializedServiceImpl
 
 /**
  * Helper to get [RpcObject] for a given [RpcService]
+ *
+ * @sample com.monkopedia.ksrpc.samples.basicServiceDeclaration
+ * @sample com.monkopedia.ksrpc.samples.serializableTypes
  */
 expect inline fun <reified T : RpcService> rpcObject(): RpcObject<T>
 
@@ -43,6 +46,9 @@ fun <T : RpcService, S> T.serialized(
 
 /**
  * Convert a [SerializedService] to a [T] for use as a client.
+ *
+ * @sample com.monkopedia.ksrpc.samples.implementAndSerialize
+ * @sample com.monkopedia.ksrpc.samples.subServiceOutput
  */
 inline fun <reified T : RpcService, S> SerializedService<S>.toStub(): T =
     rpcObject<T>().createStub(this)

--- a/ksrpc-core/src/commonMain/kotlin/channels/Connection.kt
+++ b/ksrpc-core/src/commonMain/kotlin/channels/Connection.kt
@@ -27,6 +27,8 @@ import kotlin.jvm.JvmName
  * A bidirectional channel that can both host and call services/sub-services.
  *
  * (Meaning @KsServices can be used for both input and output of any @KsMethod)
+ *
+ * @sample com.monkopedia.ksrpc.samples.bidirectionalSetup
  */
 interface Connection<T> :
     ChannelHost<T>,
@@ -52,6 +54,8 @@ data class ChannelId(val id: String)
  *
  * This is equivalent to calling [registerDefault] for [T] instance and using
  * [defaultChannel] and [toStub] to create [R].
+ *
+ * @sample com.monkopedia.ksrpc.samples.connectHelper
  */
 @OptIn(ExperimentalContracts::class)
 suspend inline fun <

--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowService.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/KsFlowService.kt
@@ -42,6 +42,9 @@ import kotlinx.coroutines.flow.FlowCollector
  *
  * [KsFlowService] does NOT auto-close on collection completion — it stays
  * alive until [close] is called explicitly or its parent connection closes.
+ *
+ * @sample com.monkopedia.ksrpc.samples.flowMethodDeclaration
+ * @sample com.monkopedia.ksrpc.samples.collectingFlowFromService
  */
 @KsService
 interface KsFlowService<T> :

--- a/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsIntrospectable.kt
+++ b/ksrpc-introspection/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsIntrospectable.kt
@@ -19,6 +19,9 @@ package com.monkopedia.ksrpc.annotation
  * Annotation tagging an interface for processing by the compiler plugin.
  *
  * This should be placed on interfaces which extend [IntrospectableRpcService].
+ *
+ * @sample com.monkopedia.ksrpc.samples.introspectableService
+ * @sample com.monkopedia.ksrpc.samples.queryingEndpointInfo
  */
 @Retention(AnnotationRetention.BINARY)
 annotation class KsIntrospectable

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcChannels.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcChannels.kt
@@ -28,6 +28,16 @@ import io.ktor.utils.io.ByteWriteChannel
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CoroutineScope
 
+/**
+ * Create a [SingleChannelConnection] that communicates over this pair of byte channels using
+ * JSON-RPC 2.0 framing.
+ *
+ * For hosting JSON-RPC over a process' stdin/stdout (e.g. LSP-style protocols on the JVM), see
+ * `stdInJsonRpcConnection` (JVM only), demonstrated in the second sample below.
+ *
+ * @sample com.monkopedia.ksrpc.samples.jsonRpcConnection
+ * @sample com.monkopedia.ksrpc.samples.jsonRpcStdIn
+ */
 suspend fun Pair<ByteReadChannel, ByteWriteChannel>.asJsonRpcConnection(
     env: KsrpcEnvironment<String>,
     includeContentHeaders: Boolean = true,

--- a/ksrpc-ktor/client/src/commonMain/kotlin/HttpChannels.kt
+++ b/ksrpc-ktor/client/src/commonMain/kotlin/HttpChannels.kt
@@ -28,6 +28,8 @@ import io.ktor.client.HttpClient
  * use the WebSocket or JSON-RPC transports instead.
  *
  * This is functionally equivalent to baseUrl.toKsrpcUri().connect(env).
+ *
+ * @sample com.monkopedia.ksrpc.samples.httpClientConnect
  */
 fun HttpClient.asHttpChannelClient(
     baseUrl: String,

--- a/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
+++ b/ksrpc-ktor/server/src/commonMain/kotlin/HttpStream.kt
@@ -55,6 +55,11 @@ private const val KSRPC_CHANNEL = "channel"
 // DEFAULT_KSRPC_ERROR_CODE_TO_HTTP_STATUS are defined in ksrpc-ktor-client's
 // HttpErrorMapping.kt and re-exported here via the api dependency.
 
+/**
+ * Hosts the given [service] over HTTP on the supplied [basePath] within a Ktor [Routing] block.
+ *
+ * @sample com.monkopedia.ksrpc.samples.httpServerSetup
+ */
 inline fun <reified T : RpcService> Routing.serveHttp(
     basePath: String,
     service: T,

--- a/ksrpc-ktor/websocket/client/src/commonMain/kotlin/WebsocketClientChannels.kt
+++ b/ksrpc-ktor/websocket/client/src/commonMain/kotlin/WebsocketClientChannels.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.CoroutineScope
  * Turn an [HttpClient] into a websocket based [Connection] for a specified baseUrl.
  *
  * This is functionally equivalent to baseUrl.toKsrpcUri().connect(env).
+ *
+ * @sample com.monkopedia.ksrpc.samples.websocketClientConnect
  */
 suspend fun HttpClient.asWebsocketConnection(
     baseUrl: String,

--- a/ksrpc-ktor/websocket/server/src/commonMain/kotlin/WebsocketServe.kt
+++ b/ksrpc-ktor/websocket/server/src/commonMain/kotlin/WebsocketServe.kt
@@ -28,6 +28,12 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.websocket.webSocket
 import kotlinx.coroutines.coroutineScope
 
+/**
+ * Hosts the given [service] over a WebSocket on the supplied [basePath] within a Ktor [Routing]
+ * block. The server application must have the WebSockets plugin installed.
+ *
+ * @sample com.monkopedia.ksrpc.samples.websocketServerSetup
+ */
 inline fun <reified T : RpcService> Routing.serveWebsocket(
     basePath: String,
     service: T,

--- a/ksrpc-sockets/src/commonMain/kotlin/ReadWriteChannels.kt
+++ b/ksrpc-sockets/src/commonMain/kotlin/ReadWriteChannels.kt
@@ -29,6 +29,8 @@ internal const val MESSAGE = "Message"
 
 /**
  * Create a [Connection] for the given input/output channel.
+ *
+ * @sample com.monkopedia.ksrpc.samples.socketServerSetup
  */
 suspend fun Pair<ByteReadChannel, ByteWriteChannel>.asConnection(
     env: KsrpcEnvironment<String>

--- a/ksrpc-sockets/src/commonMain/kotlin/StdInOutStream.kt
+++ b/ksrpc-sockets/src/commonMain/kotlin/StdInOutStream.kt
@@ -20,6 +20,8 @@ import com.monkopedia.ksrpc.channels.Connection
 
 /**
  * Create a [Connection] that communicates over the std in/out streams of this process.
+ *
+ * @sample com.monkopedia.ksrpc.samples.stdInOutHosting
  */
 expect suspend inline fun withStdInOut(
     ksrpcEnvironment: KsrpcEnvironment<String>,


### PR DESCRIPTION
## Summary

Part (A) of #205. The `ksrpc-samples` module contains 12 compilable sample functions, but they were orphaned: essentially no public-API KDoc referenced them with `@sample`. This PR wires `@sample` tags across the priority public APIs so the samples surface in the generated docs.

`@sample` tags added (each pointing at a genuinely-matching sample):

- `@KsService`, `@KsMethod` -> `basicServiceDeclaration`, `implementAndSerialize`, `serializableTypes`, `unitInputOutput`
- `@KsError` -> `errorAnnotationUsage`, `throwingTypedErrors`
- `@KsContext` -> `contextBindingDefinition`, `contextAnnotationUsage`, `contextPropagationUsage`
- `@KsIntrospectable` -> `introspectableService`, `queryingEndpointInfo`
- `ksrpcEnvironment` -> `environmentBasicSetup`, `environmentWithErrorListener`
- `rpcObject` / `RpcObject` -> `basicServiceDeclaration`, `serializableTypes`
- `toStub` -> `implementAndSerialize`, `subServiceOutput`
- `Connection` / `connect` -> `bidirectionalSetup`, `connectHelper`
- `RpcHostService` / `RpcBidiService` -> `subServiceOutput`, `subServiceInput`
- `KsFlowService` (Flow streaming entry) -> `flowMethodDeclaration`, `collectingFlowFromService`
- `serveHttp` / `asHttpChannelClient` -> `httpServerSetup`, `httpClientConnect`
- `serveWebsocket` / `asWebsocketConnection` -> `websocketServerSetup`, `websocketClientConnect`
- `asJsonRpcConnection` -> `jsonRpcConnection`, `jsonRpcStdIn`
- socket `asConnection` / `withStdInOut` -> `socketServerSetup`, `stdInOutHosting`

No new sample functions were needed; all 12 existing samples mapped to priority APIs.

### Dokka sample-root wiring

JVM-only samples (HTTP/WebSocket/socket/JSON-RPC/bidirectional) are referenced from `commonMain` transport declarations, but compile only against the `jvmMain` sample root. To make those `@sample` refs resolve, the `jvmMain` sample root is now also attached to the `commonMain` Dokka source set (in `GenerateKsrpcProject.kt`). Attaching it to *both* `commonMain` and `jvmMain` simultaneously trips Dokka's "shared sample root across related source sets" validity check, so it is attached to `commonMain` only; the lone JVM-only declaration that referenced a JVM sample (`stdInJsonRpcConnection`) had its `jsonRpcStdIn` `@sample` relocated onto the common `asJsonRpcConnection` (with a prose pointer) to keep it surfaced and resolvable.

This is Part (A) only. Native sample config (Part B) and the JNI guide (Part C) are out of scope and untouched.

## Test plan

- [x] `./gradlew :ksrpc-samples:compileKotlinJvm` — samples still compile
- [x] `./gradlew dokkaGeneratePublicationHtml` — generates successfully with **zero** unresolved-`@sample` warnings (verified by grepping build output for "Unable to resolve a @sample")
- [x] `./gradlew apiCheck` — public API surface unchanged (KDoc-only changes)

(All Gradle commands run with `JAVA_HOME=/usr/lib/jvm/java-21-openjdk`.)