### PR TITLE
Add JNI and service-worker samples to ksrpc-samples

### DIFF
--- a/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
+++ b/compiler/local-plugin/src/main/kotlin/GenerateKsrpcProject.kt
@@ -222,15 +222,47 @@ fun Project.ksrpcModule(
     extensions.configure<DokkaExtension> {
         dokkaSourceSets.configureEach { sourceSet ->
             sourceSet.includes.from(rootProject.file("dokka/moduledoc.md"))
+            // Dokka resolves a @sample link only within the dokka source set that the
+            // referencing declaration belongs to (it does not search parent source sets).
+            // A given sample root may also be attached to only ONE source set per module
+            // -- attaching the same root to two related source sets (e.g. common + jvm)
+            // fails Dokka's pre-generation validity check ("common sample roots").
+            //
+            // So the attachment is chosen per module by where the @sample-bearing
+            // declarations live:
+            //  * Most modules reference samples only from commonMain declarations, so the
+            //    common/jvm/js sample roots are attached to commonMain (JVM/JS-only
+            //    samples must still compile against their platform APIs, hence the
+            //    separate roots).
+            //  * ksrpc-jni references samples from jvmMain (KsrpcNativeHost.connect) and
+            //    nativeMain (ksrpcHostConnection) declarations, so its jvm/native roots
+            //    attach to those leaf source sets instead.
+            //  * ksrpc-service-worker references a JS sample from a jsMain declaration
+            //    (onServiceWorkerConnection) and from a commonMain `expect`
+            //    (createServiceWorkerWithConnection); attaching the JS root to jsMain
+            //    resolves both (the expect resolves through its JS actual).
+            val isJni = name == "ksrpc-jni"
+            val isServiceWorker = name == "ksrpc-service-worker"
             if (sourceSet.name == "commonMain") {
-                // Attach both sample roots to commonMain so that common declarations
-                // (e.g. transport entry points such as serveHttp / asConnection) can
-                // reference platform-specific (JVM-only) samples that demonstrate them.
-                // JVM-only samples must compile against JVM APIs, so they live in the
-                // jvmMain sample root; attaching that root only to commonMain avoids the
-                // "same sample root shared by related source sets" validity error.
                 sourceSet.samples.from(rootProject.file("ksrpc-samples/src/commonMain/kotlin"))
+                if (!isJni) {
+                    sourceSet.samples.from(rootProject.file("ksrpc-samples/src/jvmMain/kotlin"))
+                }
+                if (!isServiceWorker) {
+                    sourceSet.samples.from(rootProject.file("ksrpc-samples/src/jsMain/kotlin"))
+                }
+            }
+            // Native samples use cinterop types (@CName, CPointer, JNIEnvVar) that only
+            // resolve in a native source set, so the native sample root attaches to the
+            // shared native dokka source set rather than to commonMain.
+            if (sourceSet.name == "nativeMain" && isJni) {
+                sourceSet.samples.from(rootProject.file("ksrpc-samples/src/nativeMain/kotlin"))
+            }
+            if (sourceSet.name == "jvmMain" && isJni) {
                 sourceSet.samples.from(rootProject.file("ksrpc-samples/src/jvmMain/kotlin"))
+            }
+            if (sourceSet.name == "jsMain" && isServiceWorker) {
+                sourceSet.samples.from(rootProject.file("ksrpc-samples/src/jsMain/kotlin"))
             }
             sourceSet.skipEmptyPackages.set(true)
             listOf(

--- a/dokka/guides/transport-jni.md
+++ b/dokka/guides/transport-jni.md
@@ -103,7 +103,14 @@ val result = service.someMethod("hello")
 
 `KsrpcNativeHost.connect` defaults to a `JniSerialization` environment; pass your own `KsrpcEnvironment<JniSerialized>` to customize the JVM-side logger or error listener. The native side builds its own per-connection environment, tuned via the `configure` block passed to `ksrpcHostConnection`.
 
-The working end-to-end reference is the test harness: [`ksrpc-test/src/nativeMain/kotlin/Test.kt`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-test/src/nativeMain/kotlin/Test.kt) (the `initialize` export) and [`ksrpc-test/src/jvmTest/kotlin/JniTest.kt`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-test/src/jvmTest/kotlin/JniTest.kt) (the `KsrpcNativeHost.connect` calls).
+## Packaging the shared library
+
+`NativeUtils.loadLibraryFromJar("/libs/libmy_service.so")` extracts the `.so` from the JVM classpath, so the linked library has to be placed there. The `sharedLib` from step 1 is produced under `build/bin/<target>/<buildType>Shared/lib<module>.so` (e.g. `build/bin/linuxX64/debugShared/libmy_service.so`); a Gradle copy task stages it into the JVM module's resources (under `libs/`) so `loadLibraryFromJar` can find it. Account for the per-OS extension (`.so` / `.dylib` / `.dll`) and the host's target.
+
+The working end-to-end reference is the test harness:
+
+- [`ksrpc-test/build.gradle.kts`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-test/build.gradle.kts) -- the `sharedLib` export and the `copyLib` task that stages the built `.so` into JVM resources per host OS.
+- [`ksrpc-test/src/nativeMain/kotlin/Test.kt`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-test/src/nativeMain/kotlin/Test.kt) (the `initialize` export) and [`ksrpc-test/src/jvmTest/kotlin/JniTest.kt`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-test/src/jvmTest/kotlin/JniTest.kt) (the `KsrpcNativeHost.connect` calls).
 
 ## Transport semantics
 

--- a/dokka/guides/transport-service-worker.md
+++ b/dokka/guides/transport-service-worker.md
@@ -64,6 +64,33 @@ fun main() {
 }
 ```
 
+## Build setup
+
+The worker is a separate browser script that must be built and served on its own, so the code above is only half of what a working setup needs. The worker entry point compiles to a standalone JavaScript bundle, which is served at the path the client passes to `createServiceWorkerWithConnection`.
+
+Build the worker as its own JS executable that depends on `ksrpc-service-worker`, using webpack to produce the bundle:
+
+```kotlin
+kotlin {
+    js {
+        binaries.executable()
+    }
+    sourceSets["jsMain"].dependencies {
+        implementation("com.monkopedia.ksrpc:ksrpc-service-worker:$KSRPC_VERSION")
+        implementation(npm("webpack", "5.101.3"))
+        implementation(npm("webpack-cli", "6.0.1"))
+        implementation(npm("source-map-loader", "5.0.0"))
+    }
+}
+```
+
+`jsBrowserProductionWebpack` / `jsBrowserDistribution` produce the worker bundle under `build/dist/js/productionExecutable`. Serve that `.js` at the origin-relative path the client registers (e.g. `/worker.js`).
+
+The repository's own modules are the working end-to-end reference for this wiring:
+
+- [`ksrpc-service-worker-test`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-service-worker-test/build.gradle.kts) -- the worker built as a standalone JS executable.
+- [`ksrpc-test`](https://github.com/Monkopedia/ksrpc/blob/main/ksrpc-test/build.gradle.kts) -- the `copyWebWorker*` tasks that stage the built worker bundle into resources and serve it for the client to register.
+
 ## Transport semantics
 
 - Returns a full [`Connection`](https://monkopedia.github.io/ksrpc/ksrpc-core/com.monkopedia.ksrpc.channels/-connection/index.html)`<String>` supporting bidirectional communication

--- a/ksrpc-jni/src/jvmMain/kotlin/com/monkopedia/ksrpc/jni/KsrpcNativeHost.kt
+++ b/ksrpc-jni/src/jvmMain/kotlin/com/monkopedia/ksrpc/jni/KsrpcNativeHost.kt
@@ -67,6 +67,8 @@ object KsrpcNativeHost {
      * configures the JVM-side [KsrpcEnvironment] (logger, error listener, ...). The
      * native side builds its own per-connection environment, configured via the
      * `configure` block passed to `ksrpcHostConnection`.
+     *
+     * @sample com.monkopedia.ksrpc.samples.jniHostConnect
      */
     suspend fun connect(
         scope: CoroutineScope,

--- a/ksrpc-jni/src/nativeMain/kotlin/com/monkopedia/ksrpc/jni/KsrpcNativeHost.kt
+++ b/ksrpc-jni/src/nativeMain/kotlin/com/monkopedia/ksrpc/jni/KsrpcNativeHost.kt
@@ -66,6 +66,8 @@ import platform.posix.usleep
  * The [setup] lambda runs once per connection, on the JNI dispatcher, with the
  * freshly-opened [Connection] so it can register the service(s) this connection
  * hosts. Each connection gets its own environment and service instance(s).
+ *
+ * @sample com.monkopedia.ksrpc.samples.initialize
  */
 fun ksrpcHostConnection(
     env: CPointer<JNIEnvVar>,

--- a/ksrpc-samples/build.gradle.kts
+++ b/ksrpc-samples/build.gradle.kts
@@ -5,11 +5,20 @@ plugins {
 }
 
 ksrpcModule(
-    supportNative = false,
-    supportJs = false,
+    supportNative = true,
+    supportLinuxArm64 = false,
+    supportMingw = false,
+    supportJs = true,
     supportWasm = false,
     includePublications = false,
-    applyKsrpcPlugin = true
+    applyKsrpcPlugin = true,
+    nativeConfig = {
+        binaries {
+            sharedLib {
+                this.export(project(":ksrpc-jni"))
+            }
+        }
+    }
 )
 
 kotlin {
@@ -27,6 +36,7 @@ kotlin {
         implementation(project(":ksrpc-sockets"))
         implementation(project(":ksrpc-jsonrpc"))
         implementation(project(":ksrpc-server"))
+        implementation(project(":ksrpc-jni"))
         implementation(libs.ktor.server)
         implementation(libs.ktor.server.netty)
         implementation(libs.ktor.client)
@@ -34,4 +44,58 @@ kotlin {
         implementation(libs.ktor.server.websockets)
         implementation(libs.ktor.client.websockets)
     }
+    sourceSets["nativeMain"].dependencies {
+        api(project(":ksrpc-jni"))
+        implementation(project(":ksrpc-packets"))
+    }
+    sourceSets["jsMain"].dependencies {
+        api(project(":ksrpc-service-worker"))
+        implementation(project(":ksrpc-introspection"))
+    }
+}
+
+val copyLib = tasks.register("copyLib", Copy::class) {
+    val hostOs = System.getProperty("os.name")
+    val arch = System.getProperty("os.arch")
+    when (hostOs) {
+        "Mac OS X" -> {
+            if (arch == "aarch64") {
+                dependsOn(tasks.getByName("linkReleaseSharedMacosArm64"))
+                from(
+                    projectDir.resolve(
+                        "build/bin/macosArm64/releaseShared/libksrpc_samples.dylib"
+                    )
+                )
+                destinationDir = projectDir.resolve("build/generated/lib/resources/libs/")
+            } else {
+                dependsOn(tasks.getByName("linkReleaseSharedMacosX64"))
+                from(
+                    projectDir.resolve(
+                        "build/bin/macosX64/releaseShared/libksrpc_samples.dylib"
+                    )
+                )
+                destinationDir = projectDir.resolve("build/generated/lib/resources/libs/")
+            }
+        }
+
+        "Linux" -> {
+            dependsOn(tasks.getByName("linkDebugSharedLinuxX64"))
+            from(projectDir.resolve("build/bin/linuxX64/debugShared/libksrpc_samples.so"))
+            destinationDir = projectDir.resolve("build/generated/lib/resources/libs/")
+        }
+
+        else -> {
+            // Unsupported host (e.g. Windows) — skip native lib copy.
+            // The task will be a no-op; the JNI sample won't link on this platform.
+            enabled = false
+        }
+    }
+}
+
+afterEvaluate {
+    // Stage the built shared library into resources so the JVM JNI sample has the
+    // `.so` available, and ensure the native host sample is compiled + linked as
+    // part of the module build.
+    tasks.findByName("jvmMainProcessResources")?.dependsOn(copyLib)
+    tasks.findByName("assemble")?.dependsOn(copyLib)
 }

--- a/ksrpc-samples/src/jsMain/kotlin/com/monkopedia/ksrpc/samples/ServiceWorkerHosting.kt
+++ b/ksrpc-samples/src/jsMain/kotlin/com/monkopedia/ksrpc/samples/ServiceWorkerHosting.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalKsrpc::class)
+@file:Suppress("unused", "UNUSED_VARIABLE")
+
+package com.monkopedia.ksrpc.samples
+
+import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
+import com.monkopedia.ksrpc.channels.registerDefault
+import com.monkopedia.ksrpc.ksrpcEnvironment
+import com.monkopedia.ksrpc.serialized
+import com.monkopedia.ksrpc.toStub
+import com.monkopedia.ksrpc.webworker.createServiceWorkerWithConnection
+import com.monkopedia.ksrpc.webworker.onServiceWorkerConnection
+
+/**
+ * Demonstrates hosting a ksrpc service inside a browser service worker.
+ *
+ * This runs in the worker script. `onServiceWorkerConnection` listens for
+ * incoming `"ksrpc-connect"` messages and establishes a `Connection` for each
+ * client, on which the service is registered.
+ */
+fun serviceWorkerHosting() {
+    val env = ksrpcEnvironment { }
+    val service = object : GreetingService {
+        override suspend fun greet(name: String): String = "Hello, $name!"
+    }
+    onServiceWorkerConnection(env) { connection ->
+        connection.registerDefault(service.serialized(env))
+    }
+}
+
+/**
+ * Demonstrates connecting to a service worker from the main thread.
+ *
+ * `createServiceWorkerWithConnection` registers the worker script and returns a
+ * `Connection` whose default channel can be turned into a stub.
+ */
+suspend fun serviceWorkerClient() {
+    val env = ksrpcEnvironment { }
+    val connection = createServiceWorkerWithConnection("/worker.js", env)
+    val service = connection.defaultChannel().toStub<GreetingService, String>()
+}

--- a/ksrpc-samples/src/jvmMain/kotlin/com/monkopedia/ksrpc/samples/JniHostJvm.kt
+++ b/ksrpc-samples/src/jvmMain/kotlin/com/monkopedia/ksrpc/samples/JniHostJvm.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("unused", "UNUSED_VARIABLE")
+
+package com.monkopedia.ksrpc.samples
+
+import com.monkopedia.ksrpc.jni.JniHostInit
+import com.monkopedia.ksrpc.jni.JniSerialized
+import com.monkopedia.ksrpc.jni.KsrpcNativeHost
+import com.monkopedia.ksrpc.jni.NativeUtils
+import com.monkopedia.ksrpc.toStub
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * The JVM-side binding for the native host. The `@CName` export in the native
+ * source set (`Java_com_monkopedia_ksrpc_samples_MyNativeService_initialize`) is
+ * named after this class, so the symbol lands under the sample's package.
+ */
+object MyNativeService {
+    external fun initialize(host: JniHostInit)
+}
+
+/**
+ * Demonstrates connecting to a ksrpc service hosted inside a Kotlin/Native shared
+ * library over the JNI transport.
+ */
+suspend fun jniHostConnect(scope: CoroutineScope) {
+    // Load the Kotlin/Native shared library bundled on the classpath (once per process).
+    NativeUtils.loadLibraryFromJar("/libs/libksrpc_samples.so")
+
+    // connect() invokes MyNativeService::initialize, which drives the native
+    // `ksrpcHostConnection` to build this connection's environment and register
+    // its service before returning a connection ready to use.
+    val connection = KsrpcNativeHost.connect(scope, MyNativeService::initialize)
+
+    // Use the connection.
+    val service = connection.defaultChannel().toStub<GreetingService, JniSerialized>()
+    val greeting = service.greet("world")
+}

--- a/ksrpc-samples/src/nativeMain/kotlin/com/monkopedia/ksrpc/samples/JniHostNative.kt
+++ b/ksrpc-samples/src/nativeMain/kotlin/com/monkopedia/ksrpc/samples/JniHostNative.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+@file:Suppress("unused")
+
+package com.monkopedia.ksrpc.samples
+
+import com.monkopedia.jni.JNIEnvVar
+import com.monkopedia.jni.jobject
+import com.monkopedia.ksrpc.channels.registerDefault
+import com.monkopedia.ksrpc.jni.ksrpcHostConnection
+import com.monkopedia.ksrpc.serialized
+import kotlin.experimental.ExperimentalNativeApi
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+
+/**
+ * Native host side of the JNI transport sample.
+ *
+ * This is the `@CName` export that backs `MyNativeService.initialize` on the JVM
+ * side. Its symbol is derived from the declaring JVM class, so it lives under the
+ * sample's package. It forwards the `JniHostInit`
+ * (delivered as the raw `host` jobject) to `ksrpcHostConnection`, which builds the
+ * per-connection environment and runs the `setup` lambda that registers the
+ * service this connection hosts.
+ */
+@CName("Java_com_monkopedia_ksrpc_samples_MyNativeService_initialize")
+fun initialize(env: CPointer<JNIEnvVar>, clazz: jobject, host: jobject) =
+    ksrpcHostConnection(env, host) { conn ->
+        val service = object : GreetingService {
+            override suspend fun greet(name: String): String = "Hello, $name!"
+        }
+        conn.registerDefault(service.serialized(conn.env))
+    }

--- a/ksrpc-service-worker/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsJs.kt
+++ b/ksrpc-service-worker/src/jsMain/kotlin/com/monkopedia/ksrpc/webworker/ServiceWorkerConnectionsJs.kt
@@ -36,6 +36,11 @@ import org.w3c.dom.MessageChannel
 import org.w3c.dom.MessageEvent
 import org.w3c.dom.MessagePort
 
+/**
+ * Creates a connection to a service worker registered at [workerScriptPath].
+ *
+ * @sample com.monkopedia.ksrpc.samples.serviceWorkerClient
+ */
 @ExperimentalKsrpc
 actual fun createServiceWorkerWithConnection(
     workerScriptPath: String,
@@ -63,6 +68,8 @@ actual fun createServiceWorkerWithConnection(
  *
  * This is an experimental API — the service-worker transport has limited test
  * coverage and its behavior may change without notice.
+ *
+ * @sample com.monkopedia.ksrpc.samples.serviceWorkerHosting
  */
 @ExperimentalKsrpc
 fun onServiceWorkerConnection(


### PR DESCRIPTION
## Summary

`ksrpc-samples` covered HTTP, websocket, JSON-RPC, and sockets but not the **JNI** or **service-worker** transports, because the module had only `commonMain` + `jvmMain` source sets. This adds a Kotlin/Native target (building its own `libksrpc_samples.so` via a `sharedLib` that exports `ksrpc-jni`) and a JS target, so both transports are sampled across their native/JVM and JS sides. It also documents the build wiring these transports need (which a code `@sample` cannot capture).

## Changes

- **`ksrpc-samples/build.gradle.kts`**: `supportNative = true` (linuxArm64/mingw off), `supportJs = true`; `nativeConfig` adds a `sharedLib` exporting `ksrpc-jni`; nativeMain/jsMain deps; a `copyLib` task stages the built `.so`.
- **`JniHostNative.kt`**: the native `@CName("Java_com_monkopedia_ksrpc_samples_MyNativeService_initialize")` host export forwarding to `ksrpcHostConnection`.
- **`JniHostJvm.kt`**: the `MyNativeService` binding object and `jniHostConnect(scope)` using `KsrpcNativeHost.connect(scope, MyNativeService::initialize)`.
- **`ServiceWorkerHosting.kt`**: `serviceWorkerHosting()` (worker, `onServiceWorkerConnection`) and `serviceWorkerClient()` (`createServiceWorkerWithConnection`).
- **`@sample` tags** on `ksrpcHostConnection`, `KsrpcNativeHost.connect`, `onServiceWorkerConnection`, and `createServiceWorkerWithConnection`.
- **`GenerateKsrpcProject.kt`**: sample roots attach per source set. Dokka resolves a `@sample` only within the declaring source set and forbids one sample root on two related source sets, so `ksrpc-jni`'s jvm/native roots attach to `jvmMain`/`nativeMain` and `ksrpc-service-worker`'s js root to `jsMain`; other modules keep `commonMain` attachment (unchanged behavior).
- **Guide build-setup docs** (a `@sample` is Kotlin-only and can't show build scripts):
  - `transport-service-worker.md`: a "Build setup" section (worker as a JS executable + webpack, where the bundle lands, serving it at the client's registration path) + links to `ksrpc-service-worker-test` / `ksrpc-test`.
  - `transport-jni.md`: a "Packaging the shared library" section (staging the linked `.so` onto the JVM classpath for `loadLibraryFromJar`) + link to `ksrpc-test`'s `copyLib`.

The samples reuse the existing `GreetingService` from `commonMain`.

## Verification (`JAVA_HOME=/usr/lib/jvm/java-17-openjdk`)
- `:ksrpc-samples:compileKotlinJvm`, `:ksrpc-samples:linkDebugSharedLinuxX64` (builds `libksrpc_samples.so`), `:ksrpc-samples:compileKotlinJs` — pass.
- `:dokkaGeneratePublicationHtml` — no `@sample` or new link warnings from these changes (including the guide edits).
- `:ksrpc-samples:ktlintCheck`, `:ksrpc-samples:licenseCheckForKotlin` — pass.

## Notes
- `copyLib` stages `libksrpc_samples.so` but it is not added as a jvmMain `resources.srcDir`, so the JNI sample is not *executed* — these are documentation samples (compile/link only).
- Pre-existing (from #209, already on `main`) Dokka link warnings for cross-source-set `[...]` references are unrelated to this PR and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)