### PR TITLE
Add JNI to catalog docs; refresh JNI/service-worker module blurbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ dependencies {
 | Sockets | JVM, POSIX Native | `ksrpc-sockets` |
 | Stdin/out | JVM, POSIX Native | `ksrpc-sockets` |
 | JSON-RPC 2.0 | JVM, POSIX Native | `ksrpc-jsonrpc` |
+| JNI | JVM + Kotlin/Native | `ksrpc-jni` |
 | Service Workers | JS (experimental) | `ksrpc-service-worker` |
 
 ## Features

--- a/dokka/moduledoc.md
+++ b/dokka/moduledoc.md
@@ -196,23 +196,26 @@ server executables.
 
 # Module ksrpc-service-worker
 
-Experimental JS/WasmJS transport that communicates over browser service workers. Use
-`createServiceWorkerWithConnection` to obtain a `Connection<String>` backed by a
-registered service worker script. Requires `@OptIn(ExperimentalKsrpc::class)`.
+Experimental JS/WasmJS transport that communicates over browser service workers. Host a
+service in the worker with `onServiceWorkerConnection`, and connect from the main thread
+with `createServiceWorkerWithConnection` to obtain a `Connection<String>` backed by the
+registered worker script. Requires `@OptIn(ExperimentalKsrpc::class)`.
 
 # Package com.monkopedia.ksrpc.webworker
 
-`createServiceWorkerWithConnection` and platform-specific service worker connection
-implementations for JS and WasmJS targets.
+`onServiceWorkerConnection` (worker host) and `createServiceWorkerWithConnection` (client),
+plus platform-specific service worker connection implementations for JS and WasmJS targets.
 
 # Module ksrpc-jni
 
-JNI bridge for Kotlin/Native to JVM interop. Provides a compact binary serialization
-format (`JniSer`/`JniSerialized`) and a `NativeConnection` that passes ksrpc calls
-across the JNI boundary without JSON round-tripping. Use this module when embedding a
-Kotlin/Native ksrpc service inside a JVM host (or vice versa) via shared libraries.
+JNI bridge for Kotlin/Native to JVM interop. A JVM client connects to a service hosted in a
+Kotlin/Native shared library with `KsrpcNativeHost.connect`, supplying a native binding that
+delegates to `ksrpcHostConnection`; calls cross the JNI boundary using a compact binary
+serialization format (`JniSer`/`JniSerialized`) rather than JSON. Use this module when
+embedding a Kotlin/Native ksrpc service inside a JVM host via shared libraries.
 
 # Package com.monkopedia.ksrpc.jni
 
-`JniSerialization`, `JniSer`, `JniSerialized`, `JniEncoder`/`JniDecoder`, type converters,
-and the `NativeConnection` that dispatches ksrpc calls across JNI.
+`KsrpcNativeHost` / `ksrpcHostConnection` / `JniHostInit` for hosting and connecting;
+`JniSerialization`, `JniSer`, `JniSerialized`, `JniEncoder`/`JniDecoder`, and type converters
+for the wire format; and the `NativeConnection` that dispatches ksrpc calls across JNI.


### PR DESCRIPTION
## Summary

Two catalog-doc gaps left over from the #209 JNI host API (not addressed by the #211 samples work):

- **README "Supported Transports" table** omitted JNI entirely. Added a `JNI | JVM + Kotlin/Native | ksrpc-jni` row.
- **`moduledoc.md` `ksrpc-jni` blurb** predated #209 — it described only `JniSer`/`JniSerialized` and `NativeConnection`. Updated the module and package docs to lead with `KsrpcNativeHost.connect` / `ksrpcHostConnection` / `JniHostInit` (the host API), keeping the serialization types.
- **`moduledoc.md` `ksrpc-service-worker` blurb** mentioned only the client `createServiceWorkerWithConnection`; added the `onServiceWorkerConnection` host side.

Docs-only; descriptive (no promotional phrasing).

## Verification
- `:dokkaGeneratePublicationHtml` — BUILD SUCCESSFUL (moduledoc is an include).

🤖 Generated with [Claude Code](https://claude.com/claude-code)