### PR TITLE
Fix #201: Kotlin/Native posix transport call-hang on write-side failure

### DIFF
--- a/ksrpc-sockets/api/ksrpc-sockets.klib.api
+++ b/ksrpc-sockets/api/ksrpc-sockets.klib.api
@@ -1,6 +1,7 @@
 // Klib ABI Dump
 // Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, wasmJs]
 // Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64]
+// Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64, macosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
@@ -21,10 +22,13 @@ final fun com.monkopedia.ksrpc.sockets/initTermios(kotlin/Int = ..., kotlinx.cin
 final fun com.monkopedia.ksrpc.sockets/posixFileReadChannel(kotlin/Int): io.ktor.utils.io/ByteReadChannel // com.monkopedia.ksrpc.sockets/posixFileReadChannel|posixFileReadChannel(kotlin.Int){}[0]
 
 // Targets: [native]
-final fun com.monkopedia.ksrpc.sockets/posixFileWriteChannel(kotlin/Int): io.ktor.utils.io/ByteWriteChannel // com.monkopedia.ksrpc.sockets/posixFileWriteChannel|posixFileWriteChannel(kotlin.Int){}[0]
+final fun com.monkopedia.ksrpc.sockets/posixFileWriteChannel(kotlin/Int, kotlin/Function0<kotlin/Unit> = ...): io.ktor.utils.io/ByteWriteChannel // com.monkopedia.ksrpc.sockets/posixFileWriteChannel|posixFileWriteChannel(kotlin.Int;kotlin.Function0<kotlin.Unit>){}[0]
 
 // Targets: [native]
 final fun com.monkopedia.ksrpc.sockets/resetTermios(kotlin/Int = ..., kotlinx.cinterop/CPointer<platform.posix/termios>) // com.monkopedia.ksrpc.sockets/resetTermios|resetTermios(kotlin.Int;kotlinx.cinterop.CPointer<platform.posix.termios>){}[0]
 
 // Targets: [native]
 final inline fun com.monkopedia.ksrpc.sockets/withoutIcanon(kotlin/Int = ..., kotlin/Function0<kotlin/Unit>) // com.monkopedia.ksrpc.sockets/withoutIcanon|withoutIcanon(kotlin.Int;kotlin.Function0<kotlin.Unit>){}[0]
+
+// Targets: [apple]
+final fun com.monkopedia.ksrpc.sockets/posixFileWriteChannel(kotlin/Int): io.ktor.utils.io/ByteWriteChannel // com.monkopedia.ksrpc.sockets/posixFileWriteChannel|posixFileWriteChannel(kotlin.Int){}[0]

--- a/ksrpc-sockets/src/nativeMain/kotlin/PosixFileReadChannel.kt
+++ b/ksrpc-sockets/src/nativeMain/kotlin/PosixFileReadChannel.kt
@@ -64,7 +64,9 @@ actual suspend inline fun withStdInOut(
         // Runs on the dedicated writer thread once the posix write has failed. Closing the
         // connection runs the normal teardown, which completes pending receivers exceptionally
         // (MultiChannel.close already does this) so callers fail fast instead of hanging.
-        GlobalScope.launch {
+        // Launch on the environment's scope (not GlobalScope) so the teardown is tied to the
+        // connection's lifecycle.
+        ksrpcEnvironment.defaultScope.launch {
             swallow { connectionReady.await().close() }
         }
     }

--- a/ksrpc-sockets/src/nativeMain/kotlin/PosixFileReadChannel.kt
+++ b/ksrpc-sockets/src/nativeMain/kotlin/PosixFileReadChannel.kt
@@ -35,9 +35,11 @@ import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import platform.posix.EINTR
 import platform.posix.STDIN_FILENO
@@ -54,9 +56,21 @@ actual suspend inline fun withStdInOut(
     withConnection: (Connection<String>) -> Unit
 ) {
     val input = posixFileReadChannel(STDIN_FILENO)
-    val output = posixFileWriteChannel(STDOUT_FILENO)
+    // The connection isn't built until after the write channel, so hand it to the writer's
+    // failure hook via a deferred — it needs the connection to force-close on write-side
+    // failure so a pending call doesn't hang on a still-open read side (#201, analog of #200).
+    val connectionReady = CompletableDeferred<Connection<String>>()
+    val output = posixFileWriteChannel(STDOUT_FILENO) {
+        // Runs on the dedicated writer thread once the posix write has failed. Closing the
+        // connection runs the normal teardown, which completes pending receivers exceptionally
+        // (MultiChannel.close already does this) so callers fail fast instead of hanging.
+        GlobalScope.launch {
+            swallow { connectionReady.await().close() }
+        }
+    }
     withoutIcanon {
         val connection = (input to output).asConnection(ksrpcEnvironment)
+        connectionReady.complete(connection)
         try {
             withConnection(connection)
         } finally {
@@ -82,7 +96,10 @@ fun posixFileReadChannel(fd: Int): ByteReadChannel {
                 while (true) {
                     val readCount = read(fd, buffer, BUFFER_SIZE.toULong())
                     if (readCount < 0) break
-                    if (readCount == 0L) continue
+                    // On a blocking fd, read() == 0 is EOF (the peer closed the write end), not
+                    // "no data yet" — break so the reader thread terminates. `continue` here
+                    // busy-spins forever once EOF is reached, which wedges process exit (#201).
+                    if (readCount == 0L) break
 
                     channel.writeFully(buffer, 0, readCount)
                     channel.flush()
@@ -103,11 +120,21 @@ fun posixFileReadChannel(fd: Int): ByteReadChannel {
  *
  * This is accomplished by creating a dedicated thread that blocks on reads before queueing to
  * a [ByteChannel] for suspended reading, so only use when needed.
+ *
+ * @param onWriteFailure invoked once if the dedicated writer thread aborts because the underlying
+ *   posix `write` failed (e.g. the peer closed the read end of the fd). Cancelling the write
+ *   [ByteChannel] only surfaces to *new* sends; a call that has already sent its request and is
+ *   awaiting a response is parked on the connection, not on the write channel. If the read side
+ *   stays open, that pending call would hang forever (#201, the K/N analog of #200). The caller
+ *   uses this hook to force-close the connection so pending receivers complete exceptionally and
+ *   callers fail fast instead of hanging. It is never invoked on a clean shutdown (the write
+ *   channel being closed for read, e.g. via `connection.close()`).
  */
 @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
-fun posixFileWriteChannel(fd: Int): ByteWriteChannel {
+fun posixFileWriteChannel(fd: Int, onWriteFailure: () -> Unit = {}): ByteWriteChannel {
     val thread = newSingleThreadContext("write-channel-$fd")
     return GlobalScope.reader(thread, autoFlush = true) {
+        var writeFailed = false
         try {
             while (!channel.isClosedForRead) {
                 channel.read { source, start, end ->
@@ -136,8 +163,16 @@ fun posixFileWriteChannel(fd: Int): ByteWriteChannel {
             }
         } catch (cause: Throwable) {
             cause.printStackTrace()
+            writeFailed = true
             channel.cancel(cause)
         } finally {
+            // Cancelling the write channel above only wakes new sends; force-close the connection
+            // so a call already parked awaiting a response wakes too (#201). Run before
+            // thread.close() so the hook is dispatched while this coroutine's thread is still
+            // live. Guarded so a clean shutdown (channel closed for read) is a no-op.
+            if (writeFailed) {
+                swallow { onWriteFailure() }
+            }
             close(fd)
             thread.close()
         }

--- a/ksrpc-test/src/nativeTest/kotlin/CallHangsOnWriteFailureNativeTest.kt
+++ b/ksrpc-test/src/nativeTest/kotlin/CallHangsOnWriteFailureNativeTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.channels.CallData
+import com.monkopedia.ksrpc.channels.Connection
+import com.monkopedia.ksrpc.channels.RpcCallId
+import com.monkopedia.ksrpc.channels.SerializedService
+import com.monkopedia.ksrpc.sockets.asConnection
+import com.monkopedia.ksrpc.sockets.posixFileReadChannel
+import com.monkopedia.ksrpc.sockets.posixFileWriteChannel
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.builtins.serializer
+import platform.posix.close
+import platform.posix.pipe
+
+/**
+ * Regression test for issue #201 (Kotlin/Native posix analog of #200): when the write side of a
+ * posix-backed connection fails (e.g. the peer closed the read end of the fd) while the read side
+ * stays open, an in-flight `call()` used to await a response that could never arrive and hang
+ * forever. The fix force-closes the connection on write-side failure (via the `onWriteFailure`
+ * hook threaded through [posixFileWriteChannel]) so the pending call wakes with an exception
+ * instead of hanging.
+ */
+class CallHangsOnWriteFailureNativeTest {
+
+    @Test
+    fun callWakesWhenWriteSideFails() = runBlockingUnit {
+        memScoped {
+            val env = ksrpcEnvironment { }
+
+            // Read side: a pipe whose write end stays open for the duration of the test, so the
+            // read fd never sees EOF — the receive loop keeps waiting. This is the asymmetric
+            // case that used to hang (#201): only the write side dies.
+            val readPipe = allocArray<IntVar>(2)
+            require(pipe(readPipe) >= 0) { "Failed to create read pipe" }
+            val readFd = readPipe[0]
+            val readPipeWriteEnd = readPipe[1]
+
+            // Write side: a pipe we fully close so the fd is invalid. Posix write then returns
+            // EBADF (not EPIPE, which would raise SIGPIPE and kill the test process), mimicking a
+            // dead peer whose stream went away. The non-EINTR failure trips the onWriteFailure
+            // hook exactly as a real write-side death would.
+            val writePipe = allocArray<IntVar>(2)
+            require(pipe(writePipe) >= 0) { "Failed to create write pipe" }
+            val writeFd = writePipe[1]
+            close(writePipe[0])
+            close(writePipe[1])
+
+            // The connection isn't built until after the write channel, so hand it to the
+            // failure hook via a deferred — exactly the withStdInOut wiring.
+            val connectionReady = CompletableDeferred<Connection<String>>()
+
+            val input = posixFileReadChannel(readFd)
+            val output = posixFileWriteChannel(writeFd) {
+                // Mirrors the withStdInOut wiring: force-close the connection when the write
+                // side dies so pending receivers complete exceptionally.
+                GlobalScope.launch {
+                    runCatching { connectionReady.await().close() }
+                }
+            }
+
+            val connection = (input to output).asConnection(env)
+            connection.registerDefault(EchoSerializedService(env))
+            connectionReady.complete(connection)
+
+            val request = env.serialization.createCallData(String.serializer(), "hello")
+
+            // The call must terminate (throw) rather than hang. Bound it so a regression surfaces
+            // as a test failure (assertNotNull below) instead of wedging the suite.
+            val outcome = withTimeoutOrNull(5_000) {
+                runCatching {
+                    connection.defaultChannel().call("echo", request, callId = null)
+                }
+            }
+
+            assertNotNull(
+                outcome,
+                "call() did not terminate within 5s after the write side failed — hung (#201)"
+            )
+
+            runCatching { close(readPipeWriteEnd) }
+            runCatching { connection.close() }
+        }
+    }
+
+    private class EchoSerializedService(override val env: KsrpcEnvironment<String>) :
+        SerializedService<String> {
+        override suspend fun call(
+            endpoint: String,
+            input: CallData<String>,
+            callId: RpcCallId?
+        ): CallData<String> = input
+
+        override suspend fun close() = Unit
+
+        override suspend fun onClose(onClose: suspend () -> Unit) = Unit
+    }
+}


### PR DESCRIPTION
## Summary

The Kotlin/Native analog of the #200 JVM pipe fix: a pending `call()` could hang forever when the posix transport's write side failed while the read side stayed open. Two fixes:

- **Write-side (the reported bug):** `posixFileWriteChannel` gains an `onWriteFailure` hook. When the dedicated writer thread aborts on a posix write failure, `withStdInOut` force-closes the connection so a `call()` already awaiting a response wakes and fails fast, instead of hanging. Mirrors the force-close-on-write-failure approach from #200/#202.
- **Read-side:** `posixFileReadChannel` treated `read() == 0` (EOF on a blocking fd) as `continue`, busy-spinning the reader thread forever once the peer closed the write end — which prevented the native process from exiting. Now treats EOF as `break` so the reader terminates cleanly. Folded in here since it's the same "native transport shouldn't hang" theme.

## Verification

- New `CallHangsOnWriteFailureNativeTest` passes **in isolation** (`:ksrpc-test:linuxX64Test --tests "*CallHangsOnWriteFailure*"`) in ~36s with a clean process exit (before the read-side fix it wedged indefinitely).
- `:ksrpc-sockets:apiCheck` green (the `klib.api` is updated for the new defaulted `onWriteFailure` param).
- ktlint + license green.

## Notes

- The **full** `:ksrpc-test:linuxX64Test` suite has a **pre-existing** hang unrelated to this change (in the `ReadWritePacketChannel.close` path) — confirmed by running the suite on a clean `main` (also wedged, SIGKILLed at a 900s bound). Tracked in **#214**. Until that's fixed, run this test via a `--tests` filter. CI has no native-test job, so neither the pre-existing hang nor this test runs in CI.
- The `klib.api` dump was regenerated on Linux (apple targets disabled here), which split `posixFileWriteChannel` into a carried-over param-less `[apple]` entry + the new-param `native` entry. This is a dev-environment artifact; a maintainer building on macOS may want to regenerate the dump to unify it. It is self-consistent for the Linux CI environment (`apiCheck` passes).

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)