### PR TITLE
Document Result<T> return-type support (#216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ dependencies {
 - **Context propagation** -- Propagate per-call context (auth tokens, trace IDs) across transports with [`@KsContext`](https://monkopedia.github.io/ksrpc/ksrpc-api/com.monkopedia.ksrpc.annotation/-ks-context/index.html). [Guide](https://monkopedia.github.io/ksrpc/)
 - **Introspection** -- Opt in with [`@KsIntrospectable`](https://monkopedia.github.io/ksrpc/ksrpc-introspection/com.monkopedia.ksrpc.annotation/-ks-introspectable/index.html) to expose endpoint metadata and schemas at runtime. [Guide](https://monkopedia.github.io/ksrpc/)
 - **Flow streaming** -- Use `Flow<T>` in method signatures for streaming results over any transport, backed by [`KsFlowService`](https://monkopedia.github.io/ksrpc/ksrpc-flow/com.monkopedia.ksrpc.flow/-ks-flow-service/index.html). [Guide](https://monkopedia.github.io/ksrpc/)
+- **`Result<T>` returns** -- Declare a [`@KsMethod`](https://monkopedia.github.io/ksrpc/ksrpc-api/com.monkopedia.ksrpc.annotation/-ks-method/index.html) returning `Result<O>` to receive failures as `Result.failure` instead of thrown exceptions, with no wire-format change. [Guide](https://monkopedia.github.io/ksrpc/)
 - **JSON-RPC 2.0 notifications** -- Mark methods with [`@KsNotification`](https://monkopedia.github.io/ksrpc/ksrpc-api/com.monkopedia.ksrpc.annotation/-ks-notification/index.html) for fire-and-forget semantics.
 
 ## Why not gRPC?

--- a/dokka/guides/error-handling.md
+++ b/dokka/guides/error-handling.md
@@ -137,6 +137,37 @@ try {
 
 The built-in sentinel codes are always recognized: `ENDPOINT_NOT_FOUND_CODE` (-32601) produces [RpcEndpointException], and `INTERNAL_ERROR_CODE` (-32603) produces [RpcException].
 
+## Result return types
+
+A `@KsMethod` may return `Result<O>` instead of `O`, letting the client receive failures as `Result.failure` rather than thrown exceptions. `@KsError` participates unchanged on such methods:
+
+```kotlin
+@KsService
+interface ParseService : RpcService {
+    @KsMethod("/parse")
+    @KsError(code = 200, type = ParseError::class)
+    suspend fun parse(input: String): Result<Int>
+}
+```
+
+- A failure mapped via `@KsError` -- whether thrown from the handler or returned as `Result.failure(typedError)` -- round-trips into `Result.failure(typedError)` on the client.
+- An unmapped failure becomes a generic `KsrpcException` (`code = -32603`) inside `Result.failure`, the same as the untyped-error path above.
+- `CancellationException` / `TimeoutCancellationException` are not captured into the `Result` -- they propagate.
+
+The stub returns the `Result` and does not throw on failure:
+
+```kotlin
+stub.parse("not-a-number")
+    .onFailure { error ->
+        when (error) {
+            is ParseError -> println("Bad input: ${error.input}")
+            else -> println("RPC error: ${error.message}")
+        }
+    }
+```
+
+The wire format is identical to a plain `O` method with the same `@KsError` bindings -- see [Result return types](service-declaration.md) in the service declaration guide for the full semantics.
+
 ## Wire format by transport
 
 How typed errors appear on the wire depends on the transport:

--- a/dokka/guides/service-declaration.md
+++ b/dokka/guides/service-declaration.md
@@ -178,6 +178,54 @@ interface SlowService : RpcService {
 
 The generated stub wraps the call in `withTimeout`. On transports with cancellation support, the cancellation propagates to the server.
 
+## Result return types
+
+A `@KsMethod` may return `Result<O>`. Such a method is equivalent to a plain `O`-returning method wrapped in `runCatching`-except-cancellation:
+
+```kotlin
+@KsService
+interface ParseService : RpcService {
+    @KsMethod("/parse")
+    @KsError(code = 200, type = ParseError::class)
+    suspend fun parse(input: String): Result<Int>
+}
+```
+
+The server handler returns a `Result`:
+
+```kotlin
+class ParseServiceImpl : ParseService {
+    override suspend fun parse(input: String): Result<Int> =
+        input.toIntOrNull()?.let { Result.success(it) }
+            ?: Result.failure(ParseError(input))
+}
+```
+
+The client stub returns a `Result` and does **not** throw on failure -- handle the outcome with `onSuccess` / `onFailure`, `getOrNull`, `fold`, or any other `Result` API:
+
+```kotlin
+stub.parse("42")
+    .onSuccess { value -> println("Parsed $value") }
+    .onFailure { error -> println("Failed: ${error.message}") }
+```
+
+The semantics are:
+
+- **No wire change.** A `Result<O>` method is byte-for-byte identical to a plain `O` method on the wire. Success serializes the inner `O` exactly as a plain `O` method would; failure uses the existing [`@KsError`](https://monkopedia.github.io/ksrpc/ksrpc-api/com.monkopedia.ksrpc.annotation/-ks-error/index.html) / error envelope. `kotlin.Result` itself is never serialized. A peer written against `Result<O>` and one written against `O` interoperate.
+- **Server.** A returned `Result.success(o)` sends `o`. A returned `Result.failure(e)` is encoded through the same path as a thrown `e`, so it is indistinguishable on the wire from `throw e`. Throwing from the handler also surfaces as `Result.failure` on the client.
+- **Client.** An error response becomes `Result.failure(decoded)`; a success response becomes `Result.success(o)`. The stub never throws except for cancellation.
+- **`@KsError` participates unchanged.** A bound typed error round-trips into `Result.failure(typedError)`; an unmapped failure becomes a generic `KsrpcException` inside `Result.failure`. See [Error Handling](error-handling.md).
+- **Cancellation propagates.** `CancellationException` and `TimeoutCancellationException` are **not** folded into the `Result` -- they propagate on both sides to preserve structured concurrency (this is the "except cancellation" part of `runCatching`-except-cancellation). A `@KsTimeout` firing on a `Result<O>` method throws, it does not return `Result.failure`.
+
+### Unsupported nested shapes
+
+`Result` is supported only as the top-level type wrapping a serializable or binary value. The following shapes are rejected by a compiler (FIR) diagnostic, on both the return type and the parameter type:
+
+- `Result<Flow<…>>`
+- `Flow<Result<…>>` (`Result` cannot be nested inside `Flow`)
+- `Result<SubService>` (a `Result` wrapping a `@KsService` sub-service)
+- `Result<Result<…>>` (nested `Result`)
+
 ## Implementing services
 
 Implement a service by extending the interface:

--- a/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
+++ b/ksrpc-api/src/commonMain/kotlin/com/monkopedia/ksrpc/annotation/KsMethod.kt
@@ -32,9 +32,18 @@ annotation class KsService
  * The [name] must be unique within a [KsService] but need not be unique
  * globally.
  *
+ * A `@KsMethod` may return `Result<O>`. Such a method is equivalent to a plain
+ * `O`-returning method wrapped in `runCatching`-except-cancellation: success
+ * yields `Result.success(o)`, a thrown or returned failure yields
+ * `Result.failure(e)`, and the stub does not throw except for cancellation. The
+ * wire format is unchanged — success serializes the inner `O` and failure uses
+ * the existing [KsError] / error envelope; `kotlin.Result` is never serialized.
+ *
  * @sample com.monkopedia.ksrpc.samples.basicServiceDeclaration
  * @sample com.monkopedia.ksrpc.samples.serializableTypes
  * @sample com.monkopedia.ksrpc.samples.unitInputOutput
+ * @sample com.monkopedia.ksrpc.samples.resultReturnTypeDeclaration
+ * @sample com.monkopedia.ksrpc.samples.consumingResultReturnType
  */
 annotation class KsMethod(val name: String)
 

--- a/ksrpc-samples/src/commonMain/kotlin/com/monkopedia/ksrpc/samples/ResultReturnTypes.kt
+++ b/ksrpc-samples/src/commonMain/kotlin/com/monkopedia/ksrpc/samples/ResultReturnTypes.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("unused", "UNUSED_VARIABLE")
+
+package com.monkopedia.ksrpc.samples
+
+import com.monkopedia.ksrpc.RpcService
+import com.monkopedia.ksrpc.annotation.KsError
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.ksrpcEnvironment
+import com.monkopedia.ksrpc.serialized
+import com.monkopedia.ksrpc.toStub
+import kotlinx.serialization.Serializable
+
+// ---- Error type ----
+
+@Serializable
+data class ParseError(val input: String) : RuntimeException("Could not parse: $input")
+
+// ---- Service with a Result<O> return type ----
+
+@KsService
+interface ParseService : RpcService {
+    @KsMethod("/parse")
+    @KsError(code = 200, type = ParseError::class)
+    suspend fun parse(input: String): Result<Int>
+}
+
+// ---- Sample functions ----
+
+/**
+ * Demonstrates a `@KsMethod` whose return type is `Result<O>`.
+ */
+fun resultReturnTypeDeclaration() {
+    // A Result<O> method is equivalent to a plain O method wrapped in
+    // runCatching-except-cancellation. The wire format is unchanged: success
+    // serializes the inner O, and failure uses the same @KsError / error
+    // envelope as a thrown exception. kotlin.Result is never serialized.
+    val service = object : ParseService {
+        override suspend fun parse(input: String): Result<Int> =
+            input.toIntOrNull()?.let { Result.success(it) }
+                ?: Result.failure(ParseError(input))
+    }
+}
+
+/**
+ * Demonstrates calling a `Result<O>` method and handling the outcome with
+ * `onSuccess` / `onFailure` instead of try/catch.
+ */
+suspend fun consumingResultReturnType() {
+    val service = object : ParseService {
+        override suspend fun parse(input: String): Result<Int> =
+            input.toIntOrNull()?.let { Result.success(it) }
+                ?: Result.failure(ParseError(input))
+    }
+
+    val env = ksrpcEnvironment { }
+    val serialized = service.serialized(env)
+    val stub = serialized.toStub<ParseService, String>()
+
+    // The stub returns a Result and does NOT throw on failure. A failure
+    // mapped via @KsError round-trips as Result.failure(typedError).
+    stub.parse("42")
+        .onSuccess { value -> println("Parsed $value") }
+        .onFailure { error -> println("Failed: ${error.message}") }
+
+    val outcome: Result<Int> = stub.parse("not-a-number")
+    // outcome.isFailure == true; outcome.exceptionOrNull() is a ParseError.
+}


### PR DESCRIPTION
## Summary
Adds user-facing documentation for the `Result<O>` return-type feature on `@KsMethod` (shipped in #213, decided in #133).

- **Guide** — new "Result return types" section in `service-declaration.md` covering declaration, the `runCatching`-except-cancellation equivalence, the no-wire-change guarantee, `@KsError` interaction, cancellation behavior, and the FIR-rejected nested shapes (`Result<Flow<…>>`, `Flow<Result<…>>`, `Result<SubService>`, `Result<Result<…>>`). A tie-in section in `error-handling.md` covers the typed-error round-trip into `Result.failure`.
- **Sample + `@sample`** — new `ksrpc-samples` commonMain file `ResultReturnTypes.kt` with a `Result<Int>`-returning `@KsService` and a client using `.onSuccess`/`.onFailure`; wired via `@sample` tags + KDoc on `@KsMethod`. Dokka resolves and renders both samples.
- **README** — feature bullet for `Result<T>` returns.

Voice is descriptive (no selling/comparative phrasing), matching the existing guide conventions. All claims verified against the merged `ResultTransformer`/`transformOutcome`/`untransformOutcome` in `RpcMethod.kt`, the `UNSUPPORTED_RESULT_SHAPE` FIR diagnostic, and `ResultReturnTypeTest`.

## Test plan
- [x] `:ksrpc-samples:compileKotlinJvm` + `compileKotlinMetadata` — green (exit 0)
- [x] `:ksrpc-samples:ktlintCheck` — green (exit 0)
- [x] `:dokkaGeneratePublicationHtml` — green (exit 0); no unresolved-`@sample` / broken-include warnings; sample code rendered into the generated `@KsMethod` page

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)