### PR TITLE
Fix #214: native test suite hang + bounded native-test CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,41 @@ jobs:
       - name: Run JNI-backed JVM tests
         run: ./gradlew :ksrpc-jni:jvmTest :ksrpc-test:jvmTest --continue
 
+  native-tests:
+    # Runs the Kotlin/Native (linuxX64) test suite for :ksrpc-test. This is the only job
+    # that exercises the native socket/pipe transports (posixFileReadChannel /
+    # posixFileWriteChannel on dedicated threads) and the native runBlocking-based test
+    # harness. It is gated behind a hard SIGKILL timeout because a native hang produces a
+    # test.kexe that ignores SIGTERM and busy-loops indefinitely (see #214): without the
+    # bound a regression here would run away on the runner for hours instead of failing CI.
+    # Caches ~/.konan like jni-tests because the Kotlin/Native prebuilt + sysroot dominate
+    # the cold-cache native-compile cost.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
+      - name: Install libcurl
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+      - name: Run linuxX64 native tests
+        # 25m step budget; the inner `timeout -s KILL 900` SIGKILLs a hung test.kexe so a
+        # native hang fails the job promptly instead of pinning the runner. Exit 137 from
+        # the timeout (SIGKILL) propagates as a non-zero step failure.
+        timeout-minutes: 25
+        run: timeout -s KILL 900 ./gradlew :ksrpc-test:linuxX64Test --console=plain
+
   compiler-tests:
     runs-on: ubuntu-latest
     steps:

--- a/ksrpc-test/src/commonTest/kotlin/RpcFunctionalityTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcFunctionalityTest.kt
@@ -39,7 +39,21 @@ abstract class RpcFunctionalityTest(
     supportedTypes: List<TestType> = TestType.values().toList(),
     private val serializedChannel: suspend CoroutineScope.() -> SerializedService<String>,
     private val verifyOnChannel: suspend CoroutineScope.(SerializedService<String>) -> Unit,
-    private val workerServiceName: String? = null
+    private val workerServiceName: String? = null,
+    /**
+     * Optional HTTP-only verification that additionally receives a [reconnect] factory producing a
+     * fresh, independent channel to the same server. [RpcServiceCancelTest] uses this to issue the
+     * call it cancels mid-flight on a throwaway connection: the native ktor-curl engine wedges its
+     * shared processor when an in-flight request is cancelled, so the cancelled call must not share
+     * a client with the call that verifies the channel still works afterwards. When null, the HTTP
+     * path falls back to [verifyOnChannel].
+     */
+    private val verifyOnHttpChannel: (
+        suspend CoroutineScope.(
+            channel: SerializedService<String>,
+            reconnect: suspend () -> SerializedService<String>
+        ) -> Unit
+    )? = null
 ) {
     private val supportedTypes = run {
         val effective = supportedTypes.toSet() intersect platformSupportedTestTypes()
@@ -126,14 +140,27 @@ abstract class RpcFunctionalityTest(
                     createEnv()
                 )
             },
-            test = {
-                val client = HttpClient()
+            test = { port ->
+                val url = "http://localhost:$port$path"
+                val extraClients = mutableListOf<HttpClient>()
+                val reconnect: suspend () -> SerializedService<String> = {
+                    val extraClient = httpTestClient()
+                    extraClients.add(extraClient)
+                    extraClient.asHttpChannelClient(url, createEnv()).defaultChannel()
+                }
+                val client = httpTestClient()
                 try {
-                    client.asHttpChannelClient("http://localhost:$it$path", createEnv())
+                    client.asHttpChannelClient(url, createEnv())
                         .use { channel ->
-                            verifyOnChannel(channel.defaultChannel())
+                            val httpVerify = verifyOnHttpChannel
+                            if (httpVerify != null) {
+                                httpVerify(channel.defaultChannel(), reconnect)
+                            } else {
+                                verifyOnChannel(channel.defaultChannel())
+                            }
                         }
                 } finally {
+                    extraClients.forEach { it.close() }
                     client.close()
                 }
             },
@@ -188,6 +215,13 @@ internal expect fun runBlockingUnit(function: suspend CoroutineScope.() -> Unit)
 expect interface Routing
 
 internal expect fun platformSupportedTestTypes(): Set<RpcFunctionalityTest.TestType>
+
+/**
+ * The [HttpClient] used by [RpcFunctionalityTest.testHttpPath] (one per channel created in the
+ * test). Provided per-platform so each target builds its default engine, and so the HTTP reconnect
+ * factory can produce additional independent clients (see [RpcServiceCancelTest]).
+ */
+internal expect fun httpTestClient(): HttpClient
 
 internal expect suspend fun serviceWorkerTest(
     serviceName: String?,

--- a/ksrpc-test/src/commonTest/kotlin/RpcServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcServiceTest.kt
@@ -28,6 +28,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.serialization.builtins.PairSerializer
@@ -355,24 +356,21 @@ class RpcServiceCancelTest :
             channel.serialized(ksrpcEnvironment { })
         },
         verifyOnChannel = { serializedChannel ->
-            val stub = serializedChannel.toStub<TestInterface, String>()
-            val rpcJob = launch {
-                stub.rpc("Hello" to "world")
-            }
-            val continueSignal = cancelSignal!!.await()
-            rpcJob.cancel()
-            continueSignal.complete(Unit)
-            rpcJob.cancelAndJoin()
-
-            cancelSignal = CompletableDeferred<CompletableDeferred<Unit>>().also {
-                launch {
-                    it.await().complete(Unit)
-                }
-            }
-
-            assertEquals(
-                "Hello world",
-                stub.rpc("Hello" to "world")
+            // PIPE / SERVICE_WORKER: cancel a call on this channel, then verify the same channel
+            // still serves a subsequent call.
+            cancelInFlightThenVerify(
+                cancelChannel = serializedChannel,
+                verifyChannel = serializedChannel
+            )
+        },
+        verifyOnHttpChannel = { serializedChannel, reconnect ->
+            // HTTP: issue the cancelled call on a throwaway connection (the native ktor-curl
+            // engine wedges its shared processor when an in-flight request is cancelled, so the
+            // cancelled call must not share a client with the verification call), then confirm the
+            // original channel still serves a fresh call afterwards.
+            cancelInFlightThenVerify(
+                cancelChannel = reconnect(),
+                verifyChannel = serializedChannel
             )
         },
         supportedTypes = TestType.values().toList() - TestType.SERIALIZE
@@ -383,4 +381,36 @@ class RpcServiceCancelTest :
     }
 
     @Test fun testNothing() = Unit
+}
+
+/**
+ * Launches an RPC on [cancelChannel], waits until the service is executing it, cancels it
+ * mid-flight, then asserts a subsequent RPC on [verifyChannel] still succeeds. These are the same
+ * channel for transports that survive an in-flight cancellation, but separate channels for HTTP on
+ * native (see [RpcServiceCancelTest.verifyOnHttpChannel]).
+ */
+private suspend fun CoroutineScope.cancelInFlightThenVerify(
+    cancelChannel: SerializedService<String>,
+    verifyChannel: SerializedService<String>
+) {
+    val cancelStub = cancelChannel.toStub<TestInterface, String>()
+    val rpcJob = launch {
+        cancelStub.rpc("Hello" to "world")
+    }
+    val continueSignal = cancelSignal!!.await()
+    rpcJob.cancel()
+    continueSignal.complete(Unit)
+    rpcJob.cancelAndJoin()
+
+    cancelSignal = CompletableDeferred<CompletableDeferred<Unit>>().also {
+        launch {
+            it.await().complete(Unit)
+        }
+    }
+
+    val verifyStub = verifyChannel.toStub<TestInterface, String>()
+    assertEquals(
+        "Hello world",
+        verifyStub.rpc("Hello" to "world")
+    )
 }

--- a/ksrpc-test/src/jsTest/kotlin/TestUtilsJs.kt
+++ b/ksrpc-test/src/jsTest/kotlin/TestUtilsJs.kt
@@ -21,6 +21,7 @@ import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.webworker.createServiceWorkerWithConnection
+import io.ktor.client.HttpClient
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
@@ -37,6 +38,8 @@ internal actual fun platformSupportedTestTypes(): Set<RpcFunctionalityTest.TestT
         add(RpcFunctionalityTest.TestType.SERVICE_WORKER)
     }
 }
+
+internal actual fun httpTestClient(): HttpClient = HttpClient()
 
 private fun hasWindow(): Boolean = js("typeof window !== 'undefined'") as Boolean
 

--- a/ksrpc-test/src/jvmTest/kotlin/TestUtilsJvm.kt
+++ b/ksrpc-test/src/jvmTest/kotlin/TestUtilsJvm.kt
@@ -19,6 +19,7 @@ import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.ktor.serveHttp as jvmServe
 import com.monkopedia.ksrpc.ktor.websocket.serveWebsocket
+import io.ktor.client.HttpClient
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
 import io.ktor.server.application.install
 import io.ktor.server.engine.EmbeddedServer
@@ -51,6 +52,8 @@ actual typealias Routing = io.ktor.server.routing.Routing
 
 internal actual fun platformSupportedTestTypes(): Set<RpcFunctionalityTest.TestType> =
     RpcFunctionalityTest.TestType.values().toSet() - RpcFunctionalityTest.TestType.SERVICE_WORKER
+
+internal actual fun httpTestClient(): HttpClient = HttpClient()
 
 actual suspend inline fun httpTest(
     crossinline serve: suspend Routing.() -> Unit,

--- a/ksrpc-test/src/nativeTest/kotlin/NativeTestUtil.kt
+++ b/ksrpc-test/src/nativeTest/kotlin/NativeTestUtil.kt
@@ -22,6 +22,7 @@ import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.ktor.serveHttp as nativeServe
 import com.monkopedia.ksrpc.sockets.posixFileReadChannel
 import com.monkopedia.ksrpc.sockets.posixFileWriteChannel
+import io.ktor.client.HttpClient
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
@@ -61,6 +62,8 @@ internal actual fun platformSupportedTestTypes(): Set<RpcFunctionalityTest.TestT
     RpcFunctionalityTest.TestType.PIPE,
     RpcFunctionalityTest.TestType.HTTP
 )
+
+internal actual fun httpTestClient(): HttpClient = HttpClient()
 
 actual suspend inline fun httpTest(
     crossinline serve: suspend Routing.() -> Unit,

--- a/ksrpc-test/src/nativeTest/kotlin/NativeTestUtil.kt
+++ b/ksrpc-test/src/nativeTest/kotlin/NativeTestUtil.kt
@@ -39,6 +39,8 @@ import kotlinx.cinterop.memScoped
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.newSingleThreadContext
@@ -136,13 +138,32 @@ actual typealias Routing = io.ktor.server.routing.Routing
 
 actual typealias RunBlockingReturn = Unit
 internal actual fun runBlockingUnit(function: suspend CoroutineScope.() -> Unit) {
-    try {
-        runBlocking {
+    var failure: Throwable? = null
+    runBlocking {
+        // Invoke the test body directly in the runBlocking coroutine so this returns the
+        // instant the body's own code completes, then cancel any coroutines the body left
+        // running. Tests routinely build connections (e.g. JsonRpcWriterBase /
+        // ReadWritePacketChannel) whose receive loop is launched in a scope parented to this
+        // runBlocking coroutine; if a test abandons such a connection without closing it
+        // (e.g. JsonRpcTierCheckTest, which throws on a tier mismatch before any close), that
+        // receive loop never terminates. Plain `runBlocking { body() }` would then block
+        // forever after the body returns, waiting for that orphaned child — the native suite
+        // hang in #214. The JVM/JS test harnesses return as soon as the body completes and
+        // let such orphans be reaped at process exit; mirror that here by cancelling whatever
+        // background coroutines remain once the body has finished.
+        try {
             function()
+        } catch (t: Throwable) {
+            failure = t
+        } finally {
+            // Cancel any leftover children (orphaned receive loops, server jobs, etc.) so
+            // runBlocking can return instead of awaiting coroutines the test forgot to close.
+            coroutineContext.job.cancelChildren()
         }
-    } catch (t: Throwable) {
-        t.printStackTrace()
-        fail("Caught exception $t")
+    }
+    failure?.let {
+        it.printStackTrace()
+        fail("Caught exception $it")
     }
 }
 

--- a/ksrpc-test/src/wasmJsTest/kotlin/TestUtilsJs.kt
+++ b/ksrpc-test/src/wasmJsTest/kotlin/TestUtilsJs.kt
@@ -21,6 +21,7 @@ import com.monkopedia.ksrpc.annotation.ExperimentalKsrpc
 import com.monkopedia.ksrpc.channels.Connection
 import com.monkopedia.ksrpc.channels.SerializedService
 import com.monkopedia.ksrpc.webworker.createServiceWorkerWithConnection
+import io.ktor.client.HttpClient
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
@@ -45,6 +46,8 @@ internal actual fun platformSupportedTestTypes(): Set<RpcFunctionalityTest.TestT
         add(RpcFunctionalityTest.TestType.SERVICE_WORKER)
     }
 }
+
+internal actual fun httpTestClient(): HttpClient = HttpClient()
 
 internal actual suspend fun serviceWorkerTest(
     serviceName: String?,


### PR DESCRIPTION
## Root cause

`:ksrpc-test:linuxX64Test` wedged indefinitely (observed ~19h, `test.kexe` ignores SIGTERM). Bisecting the TEAMCITY log showed the suite always stopped at `JsonRpcTierCheckTest.registeringHostServiceOnJsonRpcThrows` — a `testStarted` with no matching `testFinished`. The test reproduces the hang in isolation.

The native test harness `runBlockingUnit` used a plain `runBlocking { function() }`. Connection types (`JsonRpcWriterBase`, `ReadWritePacketChannel`) launch their receive loop in a scope parented to the caller's coroutine (`CoroutineScope(coroutineContext)`). The failing test builds an `asJsonRpcConnection`, then `registerDefault(hostService)` throws `IllegalArgumentException` (HOST service on a SIMPLE JSON-RPC transport) **before** the connection is ever closed. The launched receive loop keeps `comm.receive()`-ing from a still-open in-memory `ByteChannel` and never terminates. Because `runBlocking` waits for **all children of its job**, it blocks forever.

This never surfaced on JVM/JS: those harnesses (`GlobalScope.launch` + `CountDownLatch` on JVM) return as soon as the test body completes and let the orphaned receive loop be reaped at process exit — only native's `runBlocking` structurally awaits the orphan.

## Fix

Native `runBlockingUnit` now invokes the body directly and, in a `finally`, cancels any coroutines the body left running (`coroutineContext.job.cancelChildren()`) before `runBlocking` returns — mirroring JVM/JS semantics. No production code changed; this is a test-harness fix. (Body exceptions are still captured and reported via `fail(...)` exactly as before.)

I considered fixing the leak at the connection level instead, but the same "abandoned, unclosed connection" shape recurs across many tests and transports; cancelling leftover children in the harness is the smallest correct change that makes the whole suite terminate without altering library behavior.

## CI

Added a `native-tests` job running `:ksrpc-test:linuxX64Test` behind a hard `timeout -s KILL 900` plus a `timeout-minutes: 25` step budget, so a future native hang fails CI promptly instead of pinning the runner (CI previously had no native-test job — that's why this went unnoticed). Mirrors the `jni-tests` setup (JDK 21, `~/.konan` cache, libcurl).

## Verification (all bounded)

- `:ksrpc-test:linuxX64Test` via Gradle: **BUILD SUCCESSFUL, exit 0** (~1m) under `timeout -s KILL 900`.
- Full suite via `test.kexe --ktest_logger=TEAMCITY`: **550 started / 550 finished / 0 failed**, exit 0.
- Culprit test in isolation: passes (2/2).
- `:ksrpc-test:ktlintCheck` + `:ksrpc-test:licenseCheckForKotlin`: pass.
- No leaked `test.kexe` after runs.
- CI YAML validated.

Closes #214