### PR TITLE
Bump version to 1.1.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 1.1.0-RC1 (2026-05-27)
+
+First release candidate for 1.1.0. Additive and backward-compatible with 1.0.0 —
+no breaking changes.
+
+### New features
+
+- **JNI native-host API** (#209): host a ksrpc service inside a Kotlin/Native
+  `.so` and call it from the JVM with `KsrpcNativeHost.connect`. The consumer
+  declares the binding on one of their own classes
+  (`external fun initialize(host: JniHostInit)`) and backs it natively by
+  delegating to `ksrpcHostConnection`; ksrpc owns the JNI export plumbing. Each
+  connection gets its own native environment and service instance(s) — no global
+  state and no `JNI_OnLoad`.
+- **`Result<T>` `@KsMethod` return types** (#213): a `@KsMethod` may return
+  `Result<O>`, equivalent to a plain `O` method wrapped in
+  `runCatching`-except-cancellation, with **no wire-format change** (success
+  serializes `O`; failure uses the existing `@KsError`/error envelope). `@KsError`
+  participates unchanged; `CancellationException`/`TimeoutCancellationException`
+  propagate rather than being captured into the `Result`. Unsupported nested
+  shapes (`Result<Flow<…>>`, `Flow<Result<…>>`, `Result<@KsService>`,
+  `Result<Result<…>>`) are rejected by a FIR diagnostic.
+
+### Bug fixes
+
+- **#201 / PR #215**: the Kotlin/Native POSIX socket transport no longer hangs a
+  pending `call()` when the write side fails silently while the read side stays
+  open (the Kotlin/Native analog of the #200 JVM pipe fix). Also fixes a
+  reader-thread busy-loop on EOF.
+
+### Internal / infrastructure (no consumer-facing API impact)
+
+- **#208**: leaked serialization synthetics (`$serializer` / `$Companion` of
+  `@KsrpcInternal @Serializable` types) are excluded from the BCV API dumps, so
+  the dumps show only genuinely-public surface.
+- **#214 / PR #218**: fixed a hang in the Kotlin/Native test suite and added a
+  bounded `native-tests` CI job so native hangs fail CI fast instead of wedging.
+
+### Documentation
+
+- JNI + service-worker samples (#211); refreshed `ksrpc-jni` / `ksrpc-service-worker`
+  module docs and README transport table (#212); `Result<T>` guide section +
+  sample (#217); `@sample` wiring across public APIs (#207); honest JNI guide for
+  the manual host path, since superseded by #209 (#206).
+
+Downstream consumers (kplusplus, konstructor, lsp-kotlin, hauler) validate against
+this RC.
+
 ## 1.0.0 (2026-05-21)
 
 First stable release. API is now considered stable under semantic versioning —

--- a/compiler/gradle.properties
+++ b/compiler/gradle.properties
@@ -1,1 +1,5 @@
-../gradle.properties
+version=1.1.0-RC1
+org.gradle.jvmargs=-Xmx4096m
+kotlin.mpp.enableCInteropCommonization=true
+kotlin.native.enableKlibsCrossCompilation=false
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/compiler/gradle.properties
+++ b/compiler/gradle.properties
@@ -1,5 +1,1 @@
-version=1.1.0-RC1
-org.gradle.jvmargs=-Xmx4096m
-kotlin.mpp.enableCInteropCommonization=true
-kotlin.native.enableKlibsCrossCompilation=false
-org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+../gradle.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.0
+version=1.1.0-RC1
 org.gradle.jvmargs=-Xmx4096m
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.enableKlibsCrossCompilation=false


### PR DESCRIPTION
First release candidate for the **1.1.0** minor. Additive and backward-compatible with 1.0.0 — no breaking changes.

Bumps `version` 1.0.0 → 1.1.0-RC1 in `gradle.properties` and `compiler/gradle.properties`, and adds the 1.1.0-RC1 `CHANGELOG` entry.

Headline (full `1.0.0..main` delta = PRs #206–#218):
- **JNI native-host API** (#209) — new public capability.
- **`Result<T>` `@KsMethod` returns** (#213) — new public capability.
- **#201 native POSIX call-hang fix** (#215).
- Internal/infra: BCV synthetic exclusions (#208), native-suite hang fix + bounded native-test CI job (#218/#214).
- Docs/samples (#206, #207, #211, #212, #217).

Downstream consumer kplusplus has green-lit the JNI host-API shape and will validate end-to-end against this published RC.

After merge, a `v1.1.0-RC1` GitHub Release will trigger the publish workflow to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)