### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,6 @@ The 1.1.0 surface — JNI native-host API (#209), `Result<T>` `@KsMethod` return
 (#213), Kotlin/Native posix call-hang fix (#201) — was built up in the 1.1.0-RC1
 cycle; see that entry below for the full feature list.
 
-Validated against downstream consumers:
-
-- **kplusplus** — exercised the JNI host API end-to-end from inside the
-  Kotlin/Native compiler daemon (FIR-checker hosting libclang via a JNI
-  connection); confirms the per-connection model, `runBlocking`-in-FIR
-  ergonomics, and lifecycle.
-- **hauler** — build + test + BCV apiCheck + long-form A/B microbench all
-  clean across all 7 KMP targets (JVM, JS, Wasm, LinuxX64, MingwX64,
-  MacosArm64/X64, IosArm64/X64/SimArm64); perf-neutral vs 1.0.0.
-- **konstructor** — full Playwright e2e suite green; the script-subprocess /
-  ScriptManager teardown WARN-flood pattern from the 1.0.0 cycle is gone.
-- **lsp-kotlin** — `:lsp-ksrpc:build :allTests` green across JVM/JS/Wasm/Linux/
-  Apple including the post-RC3 API-review tests; no regressions.
-
 ## 1.1.0-RC1 (2026-05-27)
 
 First release candidate for 1.1.0. Additive and backward-compatible with 1.0.0 —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.1.0 (2026-05-28)
+
+Identical in library code to 1.1.0-RC1, plus the #220 docs/test polish (JNI
+connection-lifecycle guide section, KGP compiler-plugin classpath `isTransitive`
+note, and a `testCloseIsIdempotent` regression test verifying existing behavior).
+The 1.1.0 surface — JNI native-host API (#209), `Result<T>` `@KsMethod` returns
+(#213), Kotlin/Native posix call-hang fix (#201) — was built up in the 1.1.0-RC1
+cycle; see that entry below for the full feature list.
+
+Validated against downstream consumers:
+
+- **kplusplus** — exercised the JNI host API end-to-end from inside the
+  Kotlin/Native compiler daemon (FIR-checker hosting libclang via a JNI
+  connection); confirms the per-connection model, `runBlocking`-in-FIR
+  ergonomics, and lifecycle.
+- **hauler** — build + test + BCV apiCheck + long-form A/B microbench all
+  clean across all 7 KMP targets (JVM, JS, Wasm, LinuxX64, MingwX64,
+  MacosArm64/X64, IosArm64/X64/SimArm64); perf-neutral vs 1.0.0.
+- **konstructor** — full Playwright e2e suite green; the script-subprocess /
+  ScriptManager teardown WARN-flood pattern from the 1.0.0 cycle is gone.
+- **lsp-kotlin** — `:lsp-ksrpc:build :allTests` green across JVM/JS/Wasm/Linux/
+  Apple including the post-RC3 API-review tests; no regressions.
+
 ## 1.1.0-RC1 (2026-05-27)
 
 First release candidate for 1.1.0. Additive and backward-compatible with 1.0.0 —

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.1.0-RC1
+version=1.1.0
 org.gradle.jvmargs=-Xmx4096m
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.enableKlibsCrossCompilation=false


### PR DESCRIPTION
**1.1.0 final release** — tier-3, your merge.

Bumps `version` 1.1.0-RC1 → 1.1.0 (root `gradle.properties`; `compiler/gradle.properties` is a symlink → follows). Adds the 1.1.0 `CHANGELOG` entry.

Identical in library code to 1.1.0-RC1 plus the #220 polish (JNI connection-lifecycle docs, KGP `isTransitive` note, `testCloseIsIdempotent` regression test). The 1.1.0 surface (JNI native-host API #209, `Result<T>` `@KsMethod` returns #213, Kotlin/Native posix call-hang fix #201, internal/docs/CI #208/#211/#212/#217/#218) was built in the RC1 cycle.

**Downstream validation (all green):**
- kplusplus — JNI host API exercised end-to-end inside the Kotlin/Native compiler daemon (FIR checker → libclang via JNI). Confirms the per-connection model, `runBlocking`-in-FIR, and lifecycle.
- hauler — build + test + BCV + long-form bench clean across all 7 KMP targets; perf-neutral vs 1.0.0.
- konstructor — Playwright e2e green; ScriptManager teardown WARN-flood is gone.
- lsp-kotlin — `:lsp-ksrpc:build :allTests` green across JVM/JS/Wasm/Linux/Apple, no regressions.

After merge, I'll cut the `v1.1.0` GitHub Release (triggers the publish workflow), monitor Maven Central until all modules are live, and ping the four consumers to integrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)