### PR TITLE
Upgrade to Kotlin 2.4.0 (compiler-plugin adaptation)

### DIFF
--- a/compiler/gradle/src/main/java/KsrpcGradlePlugin.kt
+++ b/compiler/gradle/src/main/java/KsrpcGradlePlugin.kt
@@ -68,16 +68,12 @@ class KsrpcGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun getCompilerPluginId(): String = BuildConfig.KOTLIN_PLUGIN_ID
 
+    // As of Kotlin 2.4 the Kotlin/Native compiler loads the same plugin artifact as the
+    // JVM/embeddable path, so `KotlinCompilerPluginSupportPlugin.getPluginArtifactForNative()`
+    // was removed from the interface. Native compilations now resolve the artifact below.
     override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
         groupId = BuildConfig.KOTLIN_PLUGIN_GROUP,
         artifactId = BuildConfig.KOTLIN_PLUGIN_NAME,
-        version = BuildConfig.KOTLIN_PLUGIN_VERSION
-    )
-
-    @Deprecated("Deprecated in KotlinCompilerPluginSupportPlugin")
-    override fun getPluginArtifactForNative(): SubpluginArtifact = SubpluginArtifact(
-        groupId = BuildConfig.KOTLIN_PLUGIN_GROUP,
-        artifactId = BuildConfig.KOTLIN_PLUGIN_NAME + "-native",
         version = BuildConfig.KOTLIN_PLUGIN_VERSION
     )
 

--- a/compiler/native/build.gradle.kts
+++ b/compiler/native/build.gradle.kts
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm")
-    alias(libs.plugins.ksp)
     id("org.jetbrains.dokka")
     alias(libs.plugins.vannik.publish)
     `signing`
@@ -37,18 +36,24 @@ java {
 
 dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-compiler")
+}
 
-    ksp(libs.autoservice)
-    compileOnly(libs.autoservice.annotations)
+// The CompilerPluginRegistrar service file is hand-maintained in the plugin module
+// (src/main/resources). The native artifact registers the same registrar class, so it
+// packages the plugin module's resources directly rather than keeping a second copy
+// (syncSource below only mirrors Kotlin sources, not resources).
+sourceSets.main {
+    resources.srcDir(project(":ksrpc-compiler-plugin").file("src/main/resources"))
 }
 
 afterEvaluate {
     tasks.named("compileKotlin") { dependsOn("syncSource") }
-    tasks.named("kspKotlin") { dependsOn("syncSource") }
     tasks.named("sourcesJar") { dependsOn("syncSource") }
 }
 val syncSource = tasks.register<Sync>("syncSource") {
-    from(project(":ksrpc-compiler-plugin").sourceSets.main.get().allSource)
+    from(project(":ksrpc-compiler-plugin").sourceSets.main.get().allSource) {
+        include("**/*.kt")
+    }
     into("src/main/kotlin")
     filter {
         // Replace shadowed imports from plugin module
@@ -95,7 +100,6 @@ tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
         freeCompilerArgs.add("-Xjvm-default=all")
-        freeCompilerArgs.add("-Xcontext-parameters")
     }
 }
 

--- a/compiler/plugin/build.gradle.kts
+++ b/compiler/plugin/build.gradle.kts
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm")
-    alias(libs.plugins.ksp)
     id("com.github.gmazzo.buildconfig")
     alias(libs.plugins.vannik.publish)
     `signing`
@@ -46,9 +45,6 @@ val ksrpcVersion: String = rootDir.resolve("../gradle.properties").readLines()
 
 dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable")
-
-    ksp(libs.autoservice)
-    compileOnly(libs.autoservice.annotations)
 
     // The locally-built jvmJars below contain the current main-build source —
     // the compiler tests need newer APIs (e.g. @KsError #77, the FlowSubservice
@@ -137,10 +133,10 @@ tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
         freeCompilerArgs.add("-Xjvm-default=all")
-        // Required for the FIR-phase `FirDeclarationChecker.check` overrides added
-        // in issue #65 — Kotlin 2.3+ declares `check` with `context(CheckerContext,
-        // DiagnosticReporter)` parameters, which subclasses must match.
-        freeCompilerArgs.add("-Xcontext-parameters")
+        // The FIR-phase `FirDeclarationChecker.check` overrides (issue #65) declare
+        // `context(CheckerContext, DiagnosticReporter)` parameters. Context parameters
+        // are on by default at the Kotlin 2.4 language version, so no opt-in flag is
+        // needed (the former `-Xcontext-parameters` is now redundant).
     }
 }
 
@@ -153,5 +149,4 @@ if (signingEnabled) {
 
 afterEvaluate {
     tasks["generateMetadataFileForMavenPublication"].dependsOn("plainJavadocJar")
-    tasks["kspKotlin"].dependsOn("generateBuildConfigClasses")
 }

--- a/compiler/plugin/src/main/java/CompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/CompanionGeneration.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irBranch
 import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irAnnotation
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irElseBranch
 import org.jetbrains.kotlin.ir.builders.irEquals
@@ -42,10 +43,10 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.expressions.IrAnnotation
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -162,13 +163,13 @@ class CompanionGeneration(
         irClass: IrClass,
         rpcObjectKey: IrClassSymbol,
         objectReference: IrClassReference
-    ): IrConstructorCall {
+    ): IrAnnotation {
         val primaryConstructor = rpcObjectKey.constructors.find { it.owner.isPrimary }
             ?: reportInternal(
                 "RpcObjectKey has no primary constructor — ksrpc-core runtime must " +
                     "match the compiler plugin"
             )
-        return context.irBuilder(irClass).irCallConstructor(primaryConstructor, emptyList())
+        return context.irBuilder(irClass).irAnnotation(primaryConstructor, emptyList())
             .apply { putArgs(objectReference) }
     }
 

--- a/compiler/plugin/src/main/java/IrUtils.kt
+++ b/compiler/plugin/src/main/java/IrUtils.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irAnnotation
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irConcat
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
@@ -139,7 +140,7 @@ internal fun IrClass.addKsrpcGeneratedAnnotation(
         ?: reportInternal(
             "@KsrpcGenerated has no constructor — ksrpc-api on the classpath is broken"
         )
-    annotations += context.irBuilder(symbol).irCallConstructor(constructor, emptyList())
+    annotations += context.irBuilder(symbol).irAnnotation(constructor, emptyList())
 }
 
 fun IrClassSymbol.findMethod(name: Name) = functions.find {

--- a/compiler/plugin/src/main/java/KsrpcComponentRegistrar.kt
+++ b/compiler/plugin/src/main/java/KsrpcComponentRegistrar.kt
@@ -15,7 +15,6 @@
  */
 package com.monkopedia.ksrpc.plugin
 
-import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -25,7 +24,6 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 
 @OptIn(ExperimentalCompilerApi::class)
-@AutoService(CompilerPluginRegistrar::class)
 class KsrpcComponentRegistrar : CompilerPluginRegistrar() {
     override val pluginId: String
         get() = "com.monkopedia.ksrpc.plugin"

--- a/compiler/plugin/src/main/java/StubGeneration.kt
+++ b/compiler/plugin/src/main/java/StubGeneration.kt
@@ -36,6 +36,7 @@ import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.builders.declarations.buildReceiverParameter
+import org.jetbrains.kotlin.ir.builders.irAnnotation
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCall
@@ -316,7 +317,7 @@ class StubGeneration(
     }
 
     private fun IrClass.createThreadLocalAnnotation() = context.irBuilder(symbol)
-        .irCallConstructor(env.threadLocal.constructors.single(), listOf())
+        .irAnnotation(env.threadLocal.constructors.single(), listOf())
 
     private fun IrClass.generateCloseMethod(serviceClass: ServiceClass): IrSimpleFunction {
         val close = functions.find { it.name == FqConstants.CLOSE }

--- a/compiler/plugin/src/main/java/SubtypeCompanionGeneration.kt
+++ b/compiler/plugin/src/main/java/SubtypeCompanionGeneration.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.backend.js.utils.isDispatchReceiver
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
+import org.jetbrains.kotlin.ir.builders.irAnnotation
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
@@ -36,9 +37,9 @@ import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.expressions.IrAnnotation
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
@@ -124,13 +125,13 @@ class SubtypeCompanionGeneration(
         irClass: IrClass,
         rpcObjectKey: IrClassSymbol,
         objectReference: IrClassReference
-    ): IrConstructorCall {
+    ): IrAnnotation {
         val primaryConstructor = rpcObjectKey.constructors.find { it.owner.isPrimary }
             ?: reportInternal(
                 "RpcObjectKey has no primary constructor — ksrpc-core runtime must " +
                     "match the compiler plugin"
             )
-        return context.irBuilder(irClass).irCallConstructor(primaryConstructor, emptyList())
+        return context.irBuilder(irClass).irAnnotation(primaryConstructor, emptyList())
             .apply { putArgs(objectReference) }
     }
 

--- a/compiler/plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/compiler/plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,1 @@
+com.monkopedia.ksrpc.plugin.KsrpcComponentRegistrar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,16 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 kotlin-coroutines = "1.10.2"
 kotlin-io = "0.9.0"
 okio = "3.12.0"
 kotlin-serialization = "1.10.0"
-ksp = "2.3.6"
 ktor = "3.4.1"
 slf4j = "2.1.0-alpha1"
 clikt = "5.0.3"
 agp = "9.0.0-rc01"
 dokka = "2.1.0"
 kotlin-atomicfu = "0.31.0"
-kotlin-compiletesting = "0.12.1"
-autoservice = "1.1.1"
-autoservice-ksp = "1.2.0"
+kotlin-compiletesting = "0.13.0"
 jnanoid = "2.0.0"
 nanoid = "5.1.6"
 ksrpctest = "0.11.1"
@@ -29,8 +26,6 @@ kotlinx-benchmark = "0.4.14"
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-autoservice = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "autoservice-ksp" }
-autoservice-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoservice" }
 ksrpctest = { module = "com.monkopedia.ksrpc:ksrpc-core", version.ref = "ksrpctest"}
 kotlin-compiletesting = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlin-compiletesting"}
 ktor-io = { module = "io.ktor:ktor-io", version.ref = "ktor" }
@@ -77,7 +72,6 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 hierynomus-license = { id = "com.github.hierynomus.license", version.ref = "hierynomus" }
 jlleitschuh-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-plugin" }
 gmazzo-buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
 gradle-publish = { id = "com.gradle.plugin-publish", version.ref = "gradleplugin" }
 vannik-publish = { id = "com.vanniktech.maven.publish", version.ref = "vannik" }
 kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }


### PR DESCRIPTION
Upgrades ksrpc to **Kotlin 2.4.0**. The compiler plugin is recompiled against the 2.4.0 compiler API so that projects building on Kotlin 2.4.0 can apply `com.monkopedia.ksrpc.plugin`.

This is not a version-string bump; the compiler-plugin and test toolchain needed real adaptation. Each change below is forced by a concrete 2.4.0 API change.

## Changes

**Kotlin 2.3.20 → 2.4.0** (`gradle/libs.versions.toml`, shared with the `compiler` composite build via the existing symlink).

**Dropped the KSP / `@AutoService` dependency.** There is no KSP release built for Kotlin 2.4.0 yet (latest is 2.3.9, which targets Kotlin 2.3.x), and KSP is hard-locked to the compiler version. KSP was used in exactly one place: `auto-service-ksp` generating the compiler plugin's `META-INF/services/...CompilerPluginRegistrar` registration file from the `@AutoService` annotation on `KsrpcComponentRegistrar`. That file is now hand-maintained (`compiler/plugin/src/main/resources/...`) — deterministic, one line, behavior-identical. The native artifact packages the same resource via its source set. This removes a build-time dependency that was coupled to the Kotlin version.

**IR annotation API (the only compiler-plugin source break).** Kotlin 2.4 represents declaration annotations as the new `IrAnnotation` type rather than raw `IrConstructorCall` (`IrMutableAnnotationContainer.annotations` is now `List<IrAnnotation>`). The four sites that attach synthetic annotations (`@KsrpcGenerated`, `@RpcObjectKey`, `@ThreadLocal`) now build with the new `IrBuilder.irAnnotation(...)` instead of `irCallConstructor(...)`. The generated bytecode is unchanged — `apiCheck` (BCV) passes byte-identical, and the 114-test compiler codegen suite is green.

**`getPluginArtifactForNative()` removed.** Kotlin 2.4 removed this method from `KotlinCompilerPluginSupportPlugin` — the Kotlin/Native compiler now loads the same plugin artifact as the JVM/embeddable path. The override (already `@Deprecated` in 2.3) is gone; native compilations resolve `getPluginArtifact()`. Verified end-to-end: `:ksrpc-test:linuxX64Test` compiles, links, and runs against the embeddable plugin.

**kctfork (kotlin-compile-testing) 0.12.1 → 0.13.0** (test-only). 0.12.1's `commonArguments()` NPEs against the 2.4.0 compiler (`CommonCompilerArguments.setOptIn`); 0.13.0 targets kotlin-compiler-embeddable 2.4.0.

**Removed the now-redundant `-Xcontext-parameters` flag** — context parameters are on by default at the 2.4 language version (the compiler reports the flag as redundant). The FIR checker `check` overrides (#65) still compile.

## Verification (mirrors CI)

- `apiCheck` (BCV): green, generated API byte-identical.
- `ktlintCheck`, `licenseCheckForKotlin`: green.
- compiler plugin suite (`cd compiler && ./gradlew test`): 114 tests, 0 failures.
- `jvmTest` (pure-JVM modules): green.
- JNI + `linuxX64Test` (native transport suite, the #201/#214/#218 hang area): green.

## Notes / follow-ups (not in this PR)

- The `ksrpc-compiler-plugin-native` artifact is now obsolete (Kotlin 2.4 uses one artifact for all targets). It is still built and published here so no published coordinate disappears; removing the `compiler/native` module is a clean follow-up.
- ~15 `referenceClass` / `referenceFunctions` / `referenceProperties` deprecation warnings in the plugin (2.4 prefers `finderForBuiltins()` / `finderForSource(fromFile)`). Left as-is — migrating the symbol-finder API is a semantic change, out of scope for a Kotlin-bump patch.
- `-Xjvm-default=all` is deprecated in favor of the stabilized `-jvm-default` flag; left untouched because the value mapping affects default-method bytecode/ABI and shouldn't change in a no-API-change patch.

