### PR TITLE
Isolate foreign cancellations from the hosting connection (#228)

### DIFF
--- a/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
+++ b/ksrpc-core/src/commonMain/kotlin/internal/HostSerializedServiceImpl.kt
@@ -34,9 +34,11 @@ import com.monkopedia.ksrpc.channels.RpcCallId
 import com.monkopedia.ksrpc.channels.SerializedChannel
 import com.monkopedia.ksrpc.channels.SerializedService
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.serializer
 
@@ -84,7 +86,20 @@ class HostSerializedChannelImpl<T>(
             }
         }
     } catch (t: CancellationException) {
-        throw t
+        // A CancellationException here is genuine cooperative cancellation ONLY if THIS
+        // coroutine's job was actually cancelled (the caller went away, or an incoming cancel
+        // frame cancelled the handler) — in that case ensureActive() rethrows it and we
+        // propagate as before. Otherwise it is a *foreign* cancellation that leaked out of a
+        // downstream call — e.g. a different connection's MultiChannel.close completing its
+        // pending awaits with CancellationException, surfaced here through a bridging
+        // sub-service. A foreign cancellation must NOT propagate into this connection's
+        // receive loop, where it would close this connection's MultiChannel and take down
+        // every other service multiplexed on it. Treat it like any other dispatch failure:
+        // error-frame this one call so it fails while the connection survives (#228).
+        coroutineContext.ensureActive()
+        env.logger.info("SerializedChannel", "Foreign cancellation during dispatching", t)
+        env.errorListener.onError(t)
+        CallData.Error(KsrpcException.INTERNAL_ERROR_CODE, t.message ?: t.toString())
     } catch (t: Throwable) {
         env.logger.info("SerializedChannel", "Exception thrown during dispatching", t)
         env.errorListener.onError(t)

--- a/ksrpc-test/src/commonTest/kotlin/RpcForeignCancellationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcForeignCancellationTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsMethod
+import com.monkopedia.ksrpc.annotation.KsService
+import com.monkopedia.ksrpc.channels.registerDefault
+import com.monkopedia.ksrpc.sockets.asConnection
+import io.ktor.utils.io.close
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+@KsService
+interface ForeignCancelInterface : RpcService {
+    @KsMethod("/normal")
+    suspend fun normal(input: String): String
+
+    @KsMethod("/foreign_cancel")
+    suspend fun foreignCancel(input: String): String
+}
+
+/**
+ * Regression test for #228: a foreign [CancellationException] thrown by a hosted service method
+ * — modelling a downstream/peer connection dying and surfacing its `MultiChannel.close`
+ * cancellation through a bridging sub-service — must NOT tear down the hosting connection. It
+ * should be isolated to that one call's error response, leaving every other service multiplexed
+ * on the same connection still callable.
+ *
+ * Before the fix, `HostSerializedChannelImpl.call` rethrew every [CancellationException]
+ * (including foreign ones), which propagated into the hosting connection's receive loop and
+ * closed its `MultiChannel` — so the second, unrelated call below failed with
+ * "MultiChannel is closed".
+ */
+class RpcForeignCancellationTest {
+
+    @Test
+    fun foreignCancellationDoesNotTearDownConnection() = runBlockingUnit {
+        if (RpcFunctionalityTest.TestType.PIPE !in RpcFunctionalityTest.TestType.values()) {
+            return@runBlockingUnit
+        }
+        val (output, input) = createPipe()
+        val (so, si) = createPipe()
+        val serviceChannel = (si to output).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { /* expected: the foreign cancellation */ }
+            }
+        )
+        val clientChannel = (input to so).asConnection(
+            ksrpcEnvironment {
+                errorListener = ErrorListener { /* swallow for the test */ }
+            }
+        )
+        val bgJob = GlobalScope.launch(Dispatchers.Default) {
+            serviceChannel.registerDefault<ForeignCancelInterface, String>(
+                object : ForeignCancelInterface {
+                    override suspend fun normal(input: String): String = "ok: $input"
+
+                    override suspend fun foreignCancel(input: String): String =
+                        throw CancellationException("Multi-channel failure")
+                }
+            )
+        }
+        try {
+            withTimeout(30_000) {
+                val service = clientChannel.defaultChannel().toStub<ForeignCancelInterface, String>()
+                // 1. The foreign-cancellation call surfaces as an error to the caller...
+                assertFails { service.foreignCancel("boom") }
+                // 2. ...but the connection survives: an unrelated call still works.
+                assertEquals("ok: hello", service.normal("hello"))
+            }
+        } finally {
+            try {
+                input.cancel(null)
+            } catch (t: Throwable) {
+            }
+            try {
+                si.cancel(null)
+            } catch (t: Throwable) {
+            }
+            output.close(null)
+            so.close(null)
+            bgJob.join()
+        }
+    }
+}

--- a/ksrpc-test/src/commonTest/kotlin/RpcForeignCancellationTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/RpcForeignCancellationTest.kt
@@ -81,7 +81,8 @@ class RpcForeignCancellationTest {
         }
         try {
             withTimeout(30_000) {
-                val service = clientChannel.defaultChannel().toStub<ForeignCancelInterface, String>()
+                val service =
+                    clientChannel.defaultChannel().toStub<ForeignCancelInterface, String>()
                 // 1. The foreign-cancellation call surfaces as an error to the caller...
                 assertFails { service.foreignCancel("boom") }
                 // 2. ...but the connection survives: an unrelated call still works.


### PR DESCRIPTION
## Problem

A `CancellationException` thrown by a hosted service method was unconditionally rethrown by `HostSerializedChannelImpl.call` (`ksrpc-core/.../internal/HostSerializedServiceImpl.kt`). When that exception was a *foreign* cancellation — one that leaked out of a downstream call rather than originating from this call being cancelled — it propagated into the hosting connection's receive loop and closed that connection's `MultiChannel`, taking down every other service multiplexed on the same connection.

This surfaced in a real setup: one connection hosts several services (plus a returned sub-service that bridges to a *second*, independent connection — e.g. a subprocess). When the second connection died, its `MultiChannel.close` completed pending awaits with `CancellationException("Multi-channel failure")`. That cancellation rode back through the bridging sub-service method and tore down the **first** connection, so all unrelated calls on it began failing (or hanging) with `MultiChannel ... is closed`.

## Fix

Distinguish genuine cooperative cancellation from a foreign one. A `CancellationException` caught at the dispatch boundary is real cancellation **only if this coroutine's job was actually cancelled** (the caller went away, or an incoming cancel frame cancelled the handler). `coroutineContext.ensureActive()` rethrows in exactly that case; otherwise the cancellation is foreign and is error-framed like any other dispatch failure, so the single call fails while the connection survives.

Only behavior change: a `CancellationException` thrown while this coroutine's job is still active now becomes a `CallData.Error` response instead of propagating. Genuine cancellation (job cancelled) propagates exactly as before. No public API change (`apiCheck` passes).

## Test

`RpcForeignCancellationTest` hosts a method that throws a foreign `CancellationException`; the test asserts the call surfaces as an error to the caller **and** that an unrelated call on the same connection still succeeds. Before the fix the second call hangs (the hosting connection's receive loop is torn down); after the fix it returns normally.

Verified: new test red→green, full `:ksrpc-test:jvmTest` green, `apiCheck` + license check green.

Closes #228.
