### PR TITLE
Remove dead PendingPacket data class (#224)

### DIFF
--- a/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/PacketChannelBase.kt
@@ -614,6 +614,4 @@ abstract class PacketChannelBase<T>(
     suspend fun receive(): Packet<T> = receiveLock.withLock {
         receiveLocked()
     }
-
-    private data class PendingPacket<T>(val receivedAt: Long, val packet: Packet<T>)
 }


### PR DESCRIPTION
Deletes the private nested `PendingPacket` data class in `PacketChannelBase` — declared but never referenced anywhere (confirmed via repo-wide grep: the only hit was the declaration). It's a vestige of an earlier pending-packet-buffering design; live out-of-order buffering now lives in `BinaryChannel.pending`.

Zero behavior change. Removes a misleading vestige (a reader seeing the `receivedAt` field might assume time-based packet bookkeeping that doesn't exist).

Verified: `:ksrpc-packets:compileKotlinJvm` + `ktlintCheck` green.

Closes #224.