### PR TITLE
Quiet native write-channel stack trace on teardown (#225)

### DIFF
--- a/ksrpc-sockets/src/nativeMain/kotlin/PosixFileReadChannel.kt
+++ b/ksrpc-sockets/src/nativeMain/kotlin/PosixFileReadChannel.kt
@@ -164,7 +164,12 @@ fun posixFileWriteChannel(fd: Int, onWriteFailure: () -> Unit = {}): ByteWriteCh
                 }
             }
         } catch (cause: Throwable) {
-            cause.printStackTrace()
+            // Don't dump a raw stack trace here: this also fires on normal teardown (the upstream
+            // channel is cancelled/closed and the read throws), which is benign and would print on
+            // every clean native disconnect. The cause is still surfaced — `channel.cancel`
+            // propagates it to readers, and a genuine write failure additionally triggers
+            // `onWriteFailure` below. Matches the quiet teardown handling on the JVM receive path
+            // (#187/#188) and in copyToAndFlush (#169).
             writeFailed = true
             channel.cancel(cause)
         } finally {


### PR DESCRIPTION
`posixFileWriteChannel`'s catch block called `cause.printStackTrace()`, dumping a raw stack trace to stderr on **every** native connection teardown: on a normal disconnect the upstream channel is cancelled/closed and the blocking read throws, landing in the catch. That's benign teardown, not a failure, and the raw trace looks like an error and obscures real ones.

**Fix:** drop the `printStackTrace()`. The cause is still surfaced — `channel.cancel(cause)` propagates it to readers, and a genuine write failure still triggers the `onWriteFailure()` hook (#201) that force-closes the connection. This matches the established quiet-teardown convention on the JVM receive path (#187/#188) and in `copyToAndFlush` (#169).

No API change (`apiCheck` green). Threading a logger to downgrade-to-debug instead would change the public `posixFileWriteChannel` signature; given the consumer blast radius and that the cause already propagates via `cancel`, dropping the raw dump is the minimal correct fix the issue sanctioned.

Verified: `:ksrpc-sockets` linuxX64 compile + ktlint + apiCheck green; native write-failure test (`CallHangsOnWriteFailureNativeTest`) still green.

Closes #225.