### PR TITLE
Subscribe to the source before startCollection returns (#247)

### DIFF
--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/AsKsFlow.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/AsKsFlow.kt
@@ -20,6 +20,7 @@ import com.monkopedia.ksrpc.asString
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -34,6 +35,10 @@ import kotlinx.coroutines.launch
  * [KsFlowCollector]. The returned [KsCollectionToken] can cancel that
  * collection.
  *
+ * The collection is subscribed to this flow before `startCollection` returns,
+ * so a hot source (a `SharedFlow` with no replay, for instance) can emit as
+ * soon as the caller holds the token without those emissions being missed.
+ *
  * The [KsFlowService] does NOT auto-close on collection completion — it
  * stays alive until [KsFlowService.close] is called.
  */
@@ -44,7 +49,10 @@ private class KsFlowServiceImpl<T>(private val source: Flow<T>) : KsFlowService<
 
     override suspend fun startCollection(collector: KsFlowCollector<T>): KsCollectionToken {
         val scope = CoroutineScope(coroutineContext + parentJob)
-        val job = scope.launch {
+        // UNDISPATCHED so the collection subscribes to [source] before this call
+        // returns; a plain launch only schedules the body, and a hot source drops
+        // everything emitted between the token returning and the body running.
+        val job = scope.launch(start = CoroutineStart.UNDISPATCHED) {
             try {
                 source.collect { item ->
                     collector.onItem(item)

--- a/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -236,6 +237,47 @@ class KsFlowServiceTest {
             )
         }
     )
+
+    /**
+     * A hot source must be subscribed by the time `startCollection` returns.
+     * If the collection is only scheduled, everything the source emits between
+     * the token returning and the collection starting is dropped and the
+     * collector waits out its timeout instead (#247).
+     *
+     * Repeated because a scheduled collection can still win the race by luck —
+     * it subscribed in time in roughly 6% of rounds when this was measured, so
+     * a single round would let the regression through about that often.
+     */
+    @Test
+    fun testStartCollectionSubscribesBeforeReturning() = runBlockingUnit {
+        repeat(100) { round ->
+            val source = MutableSharedFlow<String>(replay = 0)
+            val flowService = source.asKsFlow()
+            val received = CompletableDeferred<String>()
+            val collector = object : KsFlowCollector<String> {
+                override suspend fun onItem(item: String) {
+                    received.complete(item)
+                }
+
+                override suspend fun onError(error: RpcFailure) = Unit
+
+                override suspend fun onComplete() = Unit
+
+                override suspend fun close() = Unit
+            }
+            flowService.startCollection(collector)
+            assertEquals(
+                1,
+                source.subscriptionCount.value,
+                "round $round: startCollection returned before subscribing to the source"
+            )
+            source.emit("emitted-right-after-token")
+            withTimeout(5000) {
+                assertEquals("emitted-right-after-token", received.await())
+            }
+            flowService.close()
+        }
+    }
 
     private fun executePipe(
         serviceJob: suspend (Connection<String>) -> Unit,


### PR DESCRIPTION
Fixes #247.

`asKsFlow()` started its server-side collection with a plain `scope.launch`, which only *schedules* the body, and returned the `KsCollectionToken` right away. So `startCollection` could return before the coroutine had subscribed to the source.

A cold source is unaffected — nothing emits until the collection starts. A hot source (a `MutableSharedFlow` with `replay = 0`, or any flow the user shares) drops everything emitted in that window, and the client sees a stalled collection rather than an error. That matters because `startCollection` returning a token is the only "I am subscribed now" signal ksrpc gives a caller, and it did not mean that.

### Fix

`scope.launch(start = CoroutineStart.UNDISPATCHED)`. The body runs on the calling coroutine up to its first real suspension, which for `SharedFlow.collect` is after the subscriber slot is registered — so the token cannot be handed back before the subscription exists.

`onSubscription` is not usable here: it is defined on `SharedFlow`, and `asKsFlow` accepts any `Flow`.

The trade-off is that a cold source's synchronous prologue (the part of a `flow { }` builder before its first suspension) now runs on the caller's dispatcher instead of the launched one. In practice the first `collector.onItem` is a suspending sub-service call, so a source that emits at all suspends almost immediately.

Private implementation detail — no ABI change, `apiCheck` is byte-identical.

### Measurement

2000 rounds in-process on `Dispatchers.Default`, `startCollection(collector)` then `emit` immediately, 200 ms per round:

| variant | drops |
| --- | --- |
| before (`launch { }`) | 1877 / 2000 |
| control: await `subscriptionCount > 0` before emitting | 0 / 2000 |
| after (`launch(start = UNDISPATCHED)`) | 0 / 2000 |

The control isolates the cause to the dispatch gap. In-process the whole window *is* that gap, which is why the rate is so high; over a real connection the trigger costs a wire round trip, so the rate falls but the window does not close, and it widens under dispatcher load.

### Test

`KsFlowServiceTest.testStartCollectionSubscribesBeforeReturning` asserts `subscriptionCount.value == 1` the instant `startCollection` returns, then emits and requires the item to arrive. It asserts the invariant itself rather than sampling for the symptom, so there are no sleeps or timing thresholds.

It repeats 100 rounds, because a scheduled collection can still win the race by luck — it subscribed in time in about 6% of the measured rounds (the 123 of 2000 that did not drop), so a single round would let the regression through about that often. 100 rounds run in ~1.2s. Verified to fail on the unfixed code (`round N: startCollection returned before subscribing to the source expected:<1> but was:<0>`) and pass with the change.

### Verification

`ktlintCheck` (CI's `-x ktlintKotlinScriptCheck` form), `licenseCheckForKotlin`, `apiCheck`, full `jvmTest`, and `:ksrpc-test:linuxX64Test` all green locally on JDK 21.
