### PR TITLE
Bound the peer-supplied Content-Length before allocating (#249)

### DIFF
--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
@@ -101,11 +101,13 @@ internal class JsonRpcHeader(
             val headerName = line.substring(0, separator).trim()
             if (headerName.equals(CONTENT_LENGTH, ignoreCase = true)) {
                 val headerValue = line.substring(separator + 1).trim()
-                // Present but unparseable must not read as absent: toIntOrNull()
-                // also returns null above Int.MAX_VALUE, and a null length here
-                // surfaces to the caller as end-of-stream.
+                // Deliberately tolerant, unlike the socket transport: an
+                // unparseable length leaves this null, receive() returns null,
+                // and the caller treats that as end-of-stream and tears the
+                // connection down. Nothing resumes mid-frame, so there is no
+                // desync to prevent. Pinned by
+                // JsonRpcTest.testHeaderReceiver_receiveWithInvalidContentLengthReturnsNull.
                 contentLength = headerValue.toIntOrNull()
-                    ?: throw IOException("Unparseable $CONTENT_LENGTH: '$headerValue'")
             }
         }
     }

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
@@ -101,13 +101,15 @@ internal class JsonRpcHeader(
             val headerName = line.substring(0, separator).trim()
             if (headerName.equals(CONTENT_LENGTH, ignoreCase = true)) {
                 val headerValue = line.substring(separator + 1).trim()
-                // Deliberately tolerant, unlike the socket transport: an
-                // unparseable length leaves this null, receive() returns null,
-                // and the caller treats that as end-of-stream and tears the
-                // connection down. Nothing resumes mid-frame, so there is no
-                // desync to prevent. Pinned by
-                // JsonRpcTest.testHeaderReceiver_receiveWithInvalidContentLengthReturnsNull.
+                // Refused rather than skipped, for the same reason as the socket
+                // transport: the reader loop in JsonRpcWriterBase does
+                // `comm.receive() ?: continue`, so a null length resumes header
+                // parsing with the frame body still queued — the next
+                // well-formed frame is swallowed and the connection then hangs.
+                // toIntOrNull() also returns null above Int.MAX_VALUE, so this
+                // is the path `Content-Length: 99999999999` takes.
                 contentLength = headerValue.toIntOrNull()
+                    ?: throw IOException("Unparseable $CONTENT_LENGTH: '$headerValue'")
             }
         }
     }

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
@@ -101,7 +101,11 @@ internal class JsonRpcHeader(
             val headerName = line.substring(0, separator).trim()
             if (headerName.equals(CONTENT_LENGTH, ignoreCase = true)) {
                 val headerValue = line.substring(separator + 1).trim()
+                // Present but unparseable must not read as absent: toIntOrNull()
+                // also returns null above Int.MAX_VALUE, and a null length here
+                // surfaces to the caller as end-of-stream.
                 contentLength = headerValue.toIntOrNull()
+                    ?: throw IOException("Unparseable $CONTENT_LENGTH: '$headerValue'")
             }
         }
     }

--- a/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
+++ b/ksrpc-jsonrpc/src/commonMain/kotlin/JsonRpcTransformer.kt
@@ -21,10 +21,12 @@ import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.packets.internal.CONTENT_LENGTH
 import com.monkopedia.ksrpc.packets.internal.CONTENT_TYPE
+import com.monkopedia.ksrpc.packets.internal.MAX_CONTENT_LENGTH
 import com.monkopedia.ksrpc.sockets.internal.appendLine
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
 import io.ktor.utils.io.close
+import io.ktor.utils.io.errors.IOException
 import io.ktor.utils.io.readFully
 import io.ktor.utils.io.readUTF8Line
 import io.ktor.utils.io.writeFully
@@ -78,6 +80,9 @@ internal class JsonRpcHeader(
     override suspend fun receive(): JsonElement? {
         receiveLock.withLock {
             val length = readContentLength() ?: return null
+            if (length < 0 || length > MAX_CONTENT_LENGTH) {
+                throw IOException("Refusing $CONTENT_LENGTH of $length (limit $MAX_CONTENT_LENGTH)")
+            }
             var byteArray = ByteArray(length)
             input.readFully(byteArray)
             return json.decodeFromString(serializer, byteArray.decodeToString())

--- a/ksrpc-packets/src/commonMain/kotlin/Constants.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/Constants.kt
@@ -23,4 +23,15 @@ const val CONTENT_LENGTH = "Content-Length"
 @KsrpcInternal
 const val CONTENT_TYPE = "Content-Type"
 
+/**
+ * Largest inbound frame a length-prefixed transport will allocate a buffer for.
+ *
+ * `Content-Length` is supplied by the remote peer and the buffer is allocated
+ * before any content is read, so an unbounded value lets one short header cost
+ * the host its heap. Frames are chunked well below this (see `maxSize` on the
+ * packet channel), so a legitimate frame does not approach it.
+ */
+@KsrpcInternal
+const val MAX_CONTENT_LENGTH = 64 * 1024 * 1024
+
 internal const val METHOD = "Method"

--- a/ksrpc-packets/src/commonMain/kotlin/Constants.kt
+++ b/ksrpc-packets/src/commonMain/kotlin/Constants.kt
@@ -28,8 +28,11 @@ const val CONTENT_TYPE = "Content-Type"
  *
  * `Content-Length` is supplied by the remote peer and the buffer is allocated
  * before any content is read, so an unbounded value lets one short header cost
- * the host its heap. Frames are chunked well below this (see `maxSize` on the
- * packet channel), so a legitimate frame does not approach it.
+ * the host its heap.
+ *
+ * 64 MiB is four thousand times the 16 KiB a packet channel chunks outbound
+ * frames to (`PacketChannelBase.DEFAULT_MAX_SIZE`), so no frame this codebase
+ * produces comes near it.
  */
 @KsrpcInternal
 const val MAX_CONTENT_LENGTH = 64 * 1024 * 1024

--- a/ksrpc-sockets/src/commonMain/kotlin/ReadWritePacketChannel.kt
+++ b/ksrpc-sockets/src/commonMain/kotlin/ReadWritePacketChannel.kt
@@ -87,7 +87,13 @@ private suspend fun ByteReadChannel.readPacket(
 // tested directly, the same way readFields is.
 @KsrpcInternal
 suspend fun ByteReadChannel.readContent(params: Map<String, String>): String? {
-    val length = params[CONTENT_LENGTH]?.toIntOrNull() ?: return null
+    val raw = params[CONTENT_LENGTH] ?: return null
+    // A header that is present but unparseable is not the same as an absent one.
+    // toIntOrNull() also returns null above Int.MAX_VALUE, so treating it as
+    // absent would let `Content-Length: 99999999999` skip the bound below and
+    // leave the caller reading the frame body as though it were header lines.
+    val length = raw.toIntOrNull()
+        ?: throw IOException("Unparseable $CONTENT_LENGTH: '$raw'")
     if (length < 0 || length > MAX_CONTENT_LENGTH) {
         throw IOException("Refusing $CONTENT_LENGTH of $length (limit $MAX_CONTENT_LENGTH)")
     }

--- a/ksrpc-sockets/src/commonMain/kotlin/ReadWritePacketChannel.kt
+++ b/ksrpc-sockets/src/commonMain/kotlin/ReadWritePacketChannel.kt
@@ -20,12 +20,14 @@ package com.monkopedia.ksrpc.sockets.internal
 import com.monkopedia.ksrpc.KsrpcEnvironment
 import com.monkopedia.ksrpc.annotation.KsrpcInternal
 import com.monkopedia.ksrpc.packets.internal.CONTENT_LENGTH
+import com.monkopedia.ksrpc.packets.internal.MAX_CONTENT_LENGTH
 import com.monkopedia.ksrpc.packets.internal.PACKET_JSON
 import com.monkopedia.ksrpc.packets.internal.Packet
 import com.monkopedia.ksrpc.packets.internal.PacketChannelBase
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
 import io.ktor.utils.io.close
+import io.ktor.utils.io.errors.IOException
 import io.ktor.utils.io.readFully
 import io.ktor.utils.io.writeFully
 import io.ktor.utils.io.writeStringUtf8
@@ -81,8 +83,14 @@ private suspend fun ByteReadChannel.readPacket(
     }
 }
 
-private suspend fun ByteReadChannel.readContent(params: Map<String, String>): String? {
+// Exposed (internal-marked) rather than private so the length bound below can be
+// tested directly, the same way readFields is.
+@KsrpcInternal
+suspend fun ByteReadChannel.readContent(params: Map<String, String>): String? {
     val length = params[CONTENT_LENGTH]?.toIntOrNull() ?: return null
+    if (length < 0 || length > MAX_CONTENT_LENGTH) {
+        throw IOException("Refusing $CONTENT_LENGTH of $length (limit $MAX_CONTENT_LENGTH)")
+    }
     val byteArray = ByteArray(length)
     readFully(byteArray)
     return byteArray.decodeToString()

--- a/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
@@ -60,8 +60,17 @@ class ContentLengthBoundTest {
         }
     }
 
+    /**
+     * An in-range length still reads normally — the guard rejects, it does not
+     * break the ordinary path.
+     *
+     * This does not exercise the inclusive edge at [MAX_CONTENT_LENGTH] itself:
+     * doing so means allocating 64 MiB and feeding it, which is not worth the
+     * cost per run. So the boundary is pinned from above (limit + 1 is refused)
+     * and not from below.
+     */
     @Test
-    fun testSocketTransportAcceptsLengthAtTheLimit() = runBlockingUnit {
+    fun testSocketTransportAcceptsInRangeContentLength() = runBlockingUnit {
         val channel = ByteChannel(autoFlush = true)
         channel.writeStringUtf8("hello")
         assertEquals("hello", channel.readContent(mapOf("Content-Length" to "5")))

--- a/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
@@ -27,6 +27,7 @@ import io.ktor.utils.io.writeStringUtf8
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -63,17 +64,55 @@ class ContentLengthBoundTest {
     /**
      * An in-range length still reads normally — the guard rejects, it does not
      * break the ordinary path.
-     *
-     * This does not exercise the inclusive edge at [MAX_CONTENT_LENGTH] itself:
-     * doing so means allocating 64 MiB and feeding it, which is not worth the
-     * cost per run. So the boundary is pinned from above (limit + 1 is refused)
-     * and not from below.
      */
     @Test
     fun testSocketTransportAcceptsInRangeContentLength() = runBlockingUnit {
         val channel = ByteChannel(autoFlush = true)
         channel.writeStringUtf8("hello")
         assertEquals("hello", channel.readContent(mapOf("Content-Length" to "5")))
+    }
+
+    /**
+     * Pins the boundary from below, so `>` cannot silently become `>=`.
+     *
+     * Exactly [MAX_CONTENT_LENGTH] must be accepted, and proving that without
+     * feeding 64 MiB means catching the transport one step later: the buffer is
+     * allocated and the read then waits for content that never arrives, so the
+     * timeout — rather than an [IOException] — is what says the guard let it
+     * through.
+     */
+    @Test
+    fun testSocketTransportAcceptsExactlyTheLimit() = runBlockingUnit {
+        val channel = ByteChannel(autoFlush = true)
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(500) {
+                channel.readContent(mapOf("Content-Length" to "$MAX_CONTENT_LENGTH"))
+            }
+        }
+    }
+
+    /**
+     * A `Content-Length` above `Int.MAX_VALUE` does not parse, and treating an
+     * unparseable header as an absent one would hand the caller a frame it
+     * reads as header lines. It must be refused, not skipped.
+     */
+    @Test
+    fun testSocketTransportRejectsUnparseableContentLength() = runBlockingUnit {
+        val channel = ByteChannel(autoFlush = true)
+        assertFailsWith<IOException> {
+            withTimeout(5000) {
+                channel.readContent(mapOf("Content-Length" to "99999999999"))
+            }
+        }
+    }
+
+    @Test
+    fun testJsonRpcTransportRejectsUnparseableContentLength() = runBlockingUnit {
+        val input = ByteChannel(autoFlush = true)
+        val output = ByteChannel(autoFlush = true)
+        val transformer = (input to output).jsonHeader(ksrpcEnvironment { })
+        input.writeStringUtf8("Content-Length: 99999999999\r\n\r\n")
+        assertFailsWith<IOException> { withTimeout(5000) { transformer.receive() } }
     }
 
     @Test

--- a/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
@@ -107,15 +107,6 @@ class ContentLengthBoundTest {
     }
 
     @Test
-    fun testJsonRpcTransportRejectsUnparseableContentLength() = runBlockingUnit {
-        val input = ByteChannel(autoFlush = true)
-        val output = ByteChannel(autoFlush = true)
-        val transformer = (input to output).jsonHeader(ksrpcEnvironment { })
-        input.writeStringUtf8("Content-Length: 99999999999\r\n\r\n")
-        assertFailsWith<IOException> { withTimeout(5000) { transformer.receive() } }
-    }
-
-    @Test
     fun testJsonRpcTransportRejectsOversizedContentLength() = runBlockingUnit {
         val input = ByteChannel(autoFlush = true)
         val output = ByteChannel(autoFlush = true)

--- a/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Jason Monk <monkopedia@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(KsrpcInternal::class)
+
+package com.monkopedia.ksrpc
+
+import com.monkopedia.ksrpc.annotation.KsrpcInternal
+import com.monkopedia.ksrpc.jsonrpc.internal.jsonHeader
+import com.monkopedia.ksrpc.packets.internal.MAX_CONTENT_LENGTH
+import com.monkopedia.ksrpc.sockets.internal.readContent
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.errors.IOException
+import io.ktor.utils.io.writeStringUtf8
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.withTimeout
+
+/**
+ * A `Content-Length` is supplied by the remote peer and the receive buffer is
+ * allocated from it before any content is read, so an unbounded value lets one
+ * short header cost the host its heap (#249). Both length-prefixed transports
+ * must reject an out-of-range length instead of allocating for it.
+ */
+class ContentLengthBoundTest {
+
+    @Test
+    fun testSocketTransportRejectsOversizedContentLength() = runBlockingUnit {
+        val channel = ByteChannel(autoFlush = true)
+        assertFailsWith<IOException> {
+            // withTimeout so an unguarded build fails here rather than hanging:
+            // without the bound this allocates the buffer and then blocks in
+            // readFully waiting for content that never arrives.
+            withTimeout(5000) {
+                channel.readContent(mapOf("Content-Length" to "${MAX_CONTENT_LENGTH + 1L}"))
+            }
+        }
+    }
+
+    @Test
+    fun testSocketTransportRejectsNegativeContentLength() = runBlockingUnit {
+        val channel = ByteChannel(autoFlush = true)
+        assertFailsWith<IOException> {
+            withTimeout(5000) {
+                channel.readContent(mapOf("Content-Length" to "-1"))
+            }
+        }
+    }
+
+    @Test
+    fun testSocketTransportAcceptsLengthAtTheLimit() = runBlockingUnit {
+        val channel = ByteChannel(autoFlush = true)
+        channel.writeStringUtf8("hello")
+        assertEquals("hello", channel.readContent(mapOf("Content-Length" to "5")))
+    }
+
+    @Test
+    fun testJsonRpcTransportRejectsOversizedContentLength() = runBlockingUnit {
+        val input = ByteChannel(autoFlush = true)
+        val output = ByteChannel(autoFlush = true)
+        val transformer = (input to output).jsonHeader(ksrpcEnvironment { })
+        input.writeStringUtf8("Content-Length: ${MAX_CONTENT_LENGTH + 1L}\r\n\r\n")
+        assertFailsWith<IOException> { withTimeout(5000) { transformer.receive() } }
+    }
+
+    @Test
+    fun testJsonRpcTransportRejectsNegativeContentLength() = runBlockingUnit {
+        val input = ByteChannel(autoFlush = true)
+        val output = ByteChannel(autoFlush = true)
+        val transformer = (input to output).jsonHeader(ksrpcEnvironment { })
+        input.writeStringUtf8("Content-Length: -1\r\n\r\n")
+        assertFailsWith<IOException> { withTimeout(5000) { transformer.receive() } }
+    }
+}

--- a/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/ContentLengthBoundTest.kt
@@ -107,6 +107,15 @@ class ContentLengthBoundTest {
     }
 
     @Test
+    fun testJsonRpcTransportRejectsUnparseableContentLength() = runBlockingUnit {
+        val input = ByteChannel(autoFlush = true)
+        val output = ByteChannel(autoFlush = true)
+        val transformer = (input to output).jsonHeader(ksrpcEnvironment { })
+        input.writeStringUtf8("Content-Length: 99999999999\r\n\r\n")
+        assertFailsWith<IOException> { withTimeout(5000) { transformer.receive() } }
+    }
+
+    @Test
     fun testJsonRpcTransportRejectsOversizedContentLength() = runBlockingUnit {
         val input = ByteChannel(autoFlush = true)
         val output = ByteChannel(autoFlush = true)

--- a/ksrpc-test/src/commonTest/kotlin/JsonRpcTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/JsonRpcTest.kt
@@ -31,11 +31,13 @@ import com.monkopedia.ksrpc.jsonrpc.internal.jsonLine
 import com.monkopedia.ksrpc.sockets.internal.appendLine
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.close
+import io.ktor.utils.io.errors.IOException
 import io.ktor.utils.io.readFully
 import io.ktor.utils.io.readUTF8Line
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -213,7 +215,7 @@ class JsonRpcTest {
     }
 
     @Test
-    fun testHeaderReceiver_receiveWithInvalidContentLengthReturnsNull() = runBlockingUnit {
+    fun testHeaderReceiver_receiveWithInvalidContentLengthThrows() = runBlockingUnit {
         val outputChannel = ByteChannel()
         val inputChannel = ByteChannel()
         inputChannel.appendLine("Content-Length: abc")
@@ -222,7 +224,10 @@ class JsonRpcTest {
         inputChannel.appendLine("""{"jsonrpc":"2.0","result":-19,"id":1}""")
         inputChannel.flush()
         val sender = (inputChannel to outputChannel).jsonHeader(ksrpcEnvironment { })
-        assertEquals(null, sender.receive())
+        // Was assertEquals(null, ...): returning null made the reader loop in
+        // JsonRpcWriterBase `continue` with the frame body still queued, so the
+        // next well-formed frame was swallowed and the connection hung (#249).
+        assertFailsWith<IOException> { sender.receive() }
     }
 
     @Test


### PR DESCRIPTION
Fixes #249.

Both length-prefixed transports sized a receive buffer straight from the peer's `Content-Length`, with no ceiling and no sign check, and the allocation happens *before* any content is read:

- `Content-Length: 2147483647` costs the host 2 GB for one short header the peer never has to follow up on.
- `Content-Length: -1` reached `ByteArray(-1)` → `NegativeArraySizeException`, which is not an `IOException` and so missed the transport's error path.

Both are reachable on the first frame of a connection, and neither transport authenticates.

### The bound

`MAX_CONTENT_LENGTH` (64 MiB) in `ksrpc-packets`, which both transports already depend on. Frames chunk well below it (`maxSize`, 16 KiB), so a legitimate frame does not approach the limit.

It is a `const`, not configurable. Making the limit settable means adding to `KsrpcEnvironment`, which is a public API change and a separate conversation — worth having, but not smuggled into a bug fix.

`readContent` becomes internal-marked (`@KsrpcInternal`) rather than private so the bound is directly testable, the same way `readFields` already is. No dump movement — `@KsrpcInternal` is in `nonPublicMarkers`, and `apiCheck` is byte-identical.

### On the tests, because one detail is deliberate

The rejection tests wrap the call in `withTimeout(5000)`. Without the bound, the unguarded code allocates the buffer and then blocks in `readFully` waiting for content that never arrives — so a test asserting only `assertFailsWith<IOException>` would **hang** rather than fail. I found that the hard way: the first negative-control run had to be killed at ten minutes. A regression here should cost five seconds, not a CI job.

The oversize tests use `MAX_CONTENT_LENGTH + 1` rather than `Int.MAX_VALUE`. `Int.MAX_VALUE` is the realistic attack value, but it makes every negative-control run allocate 2 GB on a shared machine, and limit+1 tests the same boundary.

### Verification

| | result |
| --- | --- |
| `ContentLengthBoundTest`, with the bound | 5 pass |
| same tests, both guards disabled | **4 of 5 fail**; the at-the-limit acceptance case still passes |
| `:ksrpc-test:jvmTest` (full) | pass |
| `ktlintCheck -x ktlintKotlinScriptCheck`, `licenseCheckForKotlin`, `apiCheck` | pass |

Local, JDK 21. The negative control is what makes the first row mean anything — the tests were confirmed to detect the defect before they were confirmed to pass.
