### PR TITLE
Fix the wasmJsTest compile break so the suite can run at all (#256)

### DIFF
--- a/ksrpc-test/src/wasmJsTest/kotlin/TestUtilsJs.kt
+++ b/ksrpc-test/src/wasmJsTest/kotlin/TestUtilsJs.kt
@@ -96,8 +96,11 @@ actual typealias RunBlockingReturn = Any
 internal actual fun runBlockingUnit(
     function: suspend CoroutineScope.() -> Unit
 ): RunBlockingReturn {
+    // promise's block must produce a JsAny? on wasmJs, so the Unit-returning
+    // test body cannot be the last expression.
     @Suppress("CAST_NEVER_SUCCEEDS")
-    return GlobalScope.promise {
+    return GlobalScope.promise<JsAny?> {
         function()
+        null
     } as RunBlockingReturn
 }


### PR DESCRIPTION
Fixes #256.

The wasmJs test source set did not compile:

```
e: ksrpc-test/src/wasmJsTest/kotlin/TestUtilsJs.kt:100:24 Cannot infer type for type parameter 'T'.
e: ksrpc-test/src/wasmJsTest/kotlin/TestUtilsJs.kt:101:9 Return type mismatch: expected 'JsAny?', actual 'Unit'.
```

`promise`'s block must yield a `JsAny?` on wasmJs; the test body returns `Unit`, so `T` could not be inferred. The js actual next door is unaffected because it goes through `asDynamic()`.

Nothing in this repo compiles the wasm test sources — `apiCheck` builds `wasmJsMain`, not `wasmJsTest`, and no workflow runs the suite (#251) — so a toolchain tightening broke them and nothing noticed. The nearest candidate is the Kotlin 2.4.0 → 2.4.10 bump in 1.1.4, but I have not bisected it and the break may be older. Same shape as the ksrpc-bench rot in #242: code that nothing compiles rots against the toolchain.

### What this does and does not do

**Does:** make `:ksrpc-test:wasmJsTest` compile and execute. Verified — the suite now runs 386 tests where previously it could not report anything at all.

**Does not:** make it pass. **46 of those 386 fail**, which is #251's problem, not this PR's. Breakdown for whoever picks that up:

| count | signature |
| --- | --- |
| 33 | `IllegalStateException: Can't find rpc companion for class …` |
| 10 | `ClosedWriteChannelException` |
| 2 | karma `Timeout of 2000ms exceeded` |
| 1 | *(was mine — a #254 regression, already reverted there)* |

The 10 + 2 match the js run's signatures exactly (#255), so those two shapes are not wasm-specific. The 33 companion-lookup failures are wasm-only and are the interesting ones.

I am deliberately not bundling any of that here. This PR is the smallest change that turns "we cannot know" into "we know, and it is 46."

**Verification:** `CHROME_BIN=/usr/bin/chromium ./gradlew :ksrpc-test:wasmJsTest` compiles and runs (JDK 21, headless Chromium 150). The suite exits non-zero on those 46 failures, so CI would be red if this were wired in today — which is exactly why #251 stays open rather than being closed by this.
