### PR TITLE
SPIKE / DO NOT MERGE: measure the js and wasm suites on a CI runner (#251)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,9 +174,26 @@ jobs:
       - name: Summarise executed counts
         if: always()
         run: |
-          for d in ksrpc-test/build/test-results/*/; do
-            n=$(grep -ho 'tests="[0-9]*"' "$d"*.xml 2>/dev/null | grep -o '[0-9]*' | paste -sd+ | bc || echo 0)
-            f=$(grep -ho 'failures="[0-9]*"' "$d"*.xml 2>/dev/null | grep -o '[0-9]*' | paste -sd+ | bc || echo 0)
+          # An absent results directory and a directory of empty results must not
+          # look the same, and neither may print an empty number: this step exists
+          # to distinguish "ran nothing" from "ran and passed", so it states 0
+          # explicitly and says NO-RESULTS-DIR when there is nothing to read.
+          # Uses sed rather than grep because grep matching nothing exits 1, which
+          # under a stricter shell would redden the job with a misleading message.
+          shopt -s nullglob
+          dirs=(ksrpc-test/build/test-results/*/)
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "NO-RESULTS-DIR — no test task produced results; executed=0"
+            exit 0
+          fi
+          for d in "${dirs[@]}"; do
+            xmls=("$d"*.xml)
+            if [ ${#xmls[@]} -eq 0 ]; then
+              echo "$d executed=0 failures=0 (no XML in directory)"
+              continue
+            fi
+            n=$(sed -n 's/.*tests="\([0-9]*\)".*/\1/p' "${xmls[@]}" | awk '{s+=$1} END {print s+0}')
+            f=$(sed -n 's/.*failures="\([0-9]*\)".*/\1/p' "${xmls[@]}" | awk '{s+=$1} END {print s+0}')
             echo "$d executed=$n failures=$f"
           done
       - name: Upload results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,3 +140,48 @@ jobs:
           :ksrpc-binary-okio:jvmJar
       - name: Run compiler plugin tests
         run: cd compiler && ./gradlew test
+
+  # SPIKE / DO NOT MERGE — measurement job for #251.
+  # The js and wasmJs suites have never run in CI. This job exists to answer
+  # three questions on a clean GitHub runner rather than one developer's box:
+  #   1. does karma find a browser without CHROME_BIN being set by hand?
+  #   2. do the failures match what a local run produced (js 12, wasm ~46)?
+  #   3. what does it cost in wall-clock?
+  # continue-on-error so the measurement cannot block the rest of CI while the
+  # suites are known-failing. That is exactly the shape this repo has no other
+  # instance of, and it must not survive into a real job.
+  js-wasm-tests-measurement:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Report browser availability before running anything
+        run: |
+          echo "CHROME_BIN=${CHROME_BIN:-unset}"
+          which google-chrome chromium chromium-browser || echo "no chrome on PATH"
+      - name: Run js suite
+        run: ./gradlew :ksrpc-test:jsTest --continue
+      - name: Run wasmJs suite
+        if: always()
+        run: ./gradlew :ksrpc-test:wasmJsTest --continue
+      - name: Summarise executed counts
+        if: always()
+        run: |
+          for d in ksrpc-test/build/test-results/*/; do
+            n=$(grep -ho 'tests="[0-9]*"' "$d"*.xml 2>/dev/null | grep -o '[0-9]*' | paste -sd+ | bc || echo 0)
+            f=$(grep -ho 'failures="[0-9]*"' "$d"*.xml 2>/dev/null | grep -o '[0-9]*' | paste -sd+ | bc || echo 0)
+            echo "$d executed=$n failures=$f"
+          done
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-wasm-test-results
+          path: ksrpc-test/build/test-results/

--- a/ksrpc-test/src/wasmJsTest/kotlin/TestUtilsJs.kt
+++ b/ksrpc-test/src/wasmJsTest/kotlin/TestUtilsJs.kt
@@ -96,8 +96,11 @@ actual typealias RunBlockingReturn = Any
 internal actual fun runBlockingUnit(
     function: suspend CoroutineScope.() -> Unit
 ): RunBlockingReturn {
+    // promise's block must produce a JsAny? on wasmJs, so the Unit-returning
+    // test body cannot be the last expression.
     @Suppress("CAST_NEVER_SUCCEEDS")
-    return GlobalScope.promise {
+    return GlobalScope.promise<JsAny?> {
         function()
+        null
     } as RunBlockingReturn
 }


### PR DESCRIPTION
**⚠️ SPIKE — DO NOT MERGE.** This exists to produce a measurement, not to land a change. For #251.

Everything known about ksrpc's js and wasmJs suites comes from **one machine, mine**:

| | js | wasmJs |
| --- | --- | --- |
| run 1 (mine) | 383 tests, 12 failures | 386 tests, 46 failures |
| run 2 (a reviewer's, same code) | — | 385 tests, **47** failures |

The count that moved is `ClosedWriteChannelException`, in race- and teardown-shaped tests. So part of what we "know" about these suites is one sample of a distribution, measured on a loaded developer box running fifteen agents.

### What this job answers that a local run cannot

1. **Does karma find a browser on `ubuntu-latest` without `CHROME_BIN` set by hand?** Locally it does not — the config uses `useChromeHeadless()` and does not locate a browser itself, so I had to point `CHROME_BIN` at `/usr/bin/chromium`. Whether a GitHub image needs the same is a prerequisite for any real job and nobody has checked it. The job prints browser availability *before* running anything, so the answer is visible even if everything after it fails.
2. **Do the failures reproduce on a clean machine, or are some of them mine?** A CI runner is a different scheduler, a different browser build, and no competing load.
3. **What does it cost in wall-clock?** That is the actual input to the always-run vs label-gate decision in #251, and I have been guessing at it from a local 45s.

It also prints **executed test counts per source set**, because a green with zero executions and a green with 383 executions are otherwise indistinguishable — five separate mechanisms for that were found across the fleet this evening.

### Why this must not merge as-is

It carries `continue-on-error: true`. **This repo has no other instance of that flag** — I checked all five workflows during an audit today, precisely because a verification step that cannot fail is a known trap. Here it is deliberate and load-bearing for a measurement (the suites are known-failing; the measurement must not block the rest of CI), and it is exactly the wrong thing to leave in a real job.

So: read the run, take the numbers, close this. The real job belongs in whatever addresses #251, without this flag, and only after #255 / #258 are resolved.

### The case against doing this at all

If the CI numbers come back matching mine, this branch bought a confirmation and cost a workflow file. That is the likely outcome and it is still worth the runner minutes, because the browser-availability question is a genuine unknown that blocks writing the real job — and it is cheaper to learn it here than inside a PR that is trying to fix something.
