### PR TITLE
Send the flow error's message, not the server's stack trace (#250)

### DIFF
--- a/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/AsKsFlow.kt
+++ b/ksrpc-flow/src/commonMain/kotlin/com/monkopedia/ksrpc/flow/AsKsFlow.kt
@@ -16,7 +16,6 @@
 package com.monkopedia.ksrpc.flow
 
 import com.monkopedia.ksrpc.RpcFailure
-import com.monkopedia.ksrpc.asString
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -41,6 +40,10 @@ import kotlinx.coroutines.launch
  *
  * The [KsFlowService] does NOT auto-close on collection completion — it
  * stays alive until [KsFlowService.close] is called.
+ *
+ * If the flow throws, the collector receives the exception's message. The stack
+ * trace is not sent, matching what a `@KsMethod` call does with a server-side
+ * failure.
  */
 fun <T> Flow<T>.asKsFlow(): KsFlowService<T> = KsFlowServiceImpl(this)
 
@@ -62,7 +65,13 @@ private class KsFlowServiceImpl<T>(private val source: Flow<T>) : KsFlowService<
                 // Collection was cancelled — don't send onError for cancellation.
                 throw e
             } catch (e: Throwable) {
-                collector.onError(RpcFailure(e.asString))
+                // Message only, never `asString`: on JVM and Native that is the
+                // full stack trace, and this collector is the remote peer's, so
+                // it would put server file names, line numbers and library
+                // frames on the wire. Matches RpcMethod.encodeError and
+                // HostSerializedServiceImpl, which both send `t.message` and
+                // keep the stack server-side (#250).
+                collector.onError(RpcFailure(e.message ?: e.toString()))
             }
         }
         return object : KsCollectionToken {

--- a/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
+++ b/ksrpc-test/src/commonTest/kotlin/KsFlowServiceTest.kt
@@ -155,6 +155,45 @@ class KsFlowServiceTest {
     )
 
     /**
+     * The client gets the exception's message and NOT the server's stack trace.
+     *
+     * `asString` is the full `printStackTrace` output on JVM and the message
+     * plus frames on Native, and the collector it is handed to belongs to the
+     * remote peer — so using it put server file names, line numbers and library
+     * frames on the wire, while the ordinary `@KsMethod` error path sent only
+     * `t.message` (#250).
+     */
+    @Test
+    fun testErrorDoesNotLeakServerStackTrace() = executePipe(
+        serviceJob = { c ->
+            val flowService = flow<String> {
+                throw RuntimeException("boom-from-server")
+            }.asKsFlow()
+            c.registerDefault(flowService.serialized<KsFlowService<String>, String>(c.env))
+        },
+        clientJob = { c ->
+            val stub = c.defaultChannel().toStub<KsFlowService<String>, String>()
+            val exception = assertFailsWith<RpcException> { stub.toList() }
+            val message = exception.message
+            assertTrue(
+                message.contains("boom-from-server"),
+                "expected the server message to survive; got $message"
+            )
+            // A stack trace names the throwing frame. Asserting on the package
+            // rather than on "at " keeps this from passing for the wrong reason
+            // on a platform whose frames are formatted differently.
+            assertTrue(
+                !message.contains("com.monkopedia.ksrpc.flow"),
+                "server stack frames reached the client: $message"
+            )
+            assertTrue(
+                !message.contains("RuntimeException"),
+                "server exception class reached the client: $message"
+            )
+        }
+    )
+
+    /**
      * Cancellation: client calls `cancelCollection`, server-side collection
      * job is cancelled.
      */


### PR DESCRIPTION
Fixes #250.

`asKsFlow`'s catch sent `RpcFailure(e.asString)` to the collector — and that collector belongs to the **remote peer**. `asString` is:

- `jvmMain/RpcObject.kt:77-80` — `StringWriter().also { printStackTrace(PrintWriter(it)) }.toString()`
- `nativeMain/RpcObject.kt:72-73` — message + `getStackTrace().joinToString("\n")`
- `jsAndWasmJsMain/RpcObject.kt:65-66` — `toString()` (message only; those hosts were unaffected)

So on a JVM or Native host, any exception thrown by a flow a client was collecting sent that client the server's file names, line numbers, and library frames.

Both ordinary error paths already send only `t.message`: `RpcMethod.encodeError` (`RpcMethod.kt:524`) and `HostSerializedServiceImpl` (`:113-118`). The second one states the convention in a comment — *"the full stack is logged server-side … not propagated to the client … so wire frames are consistent regardless of which catch produced them"* — and that claim was false while the flow path existed. This makes it true.

### What is deliberately not in here

The main path also **logs** the full stack server-side via `env.logger` before sending the message. `KsFlowServiceImpl` has no `KsrpcEnvironment` to log through — it is a plain `Flow` extension constructed by `Flow<T>.asKsFlow()`, with no seam to pass one. So this PR stops the disclosure but does not restore the server-side record: a flow that throws now produces no server-side log line at all.

That is a real gap and I would rather state it than let the symmetry claim be overread. Threading an environment into that layer is a bigger change than #250 asked for, and it collides with the fact that `asKsFlow()` is public API with no parameters.

### The test

`testErrorDoesNotLeakServerStackTrace` asserts three things: the server's message survives, no `com.monkopedia.ksrpc.flow` frame reaches the client, and the exception's class name does not either.

It asserts on the package rather than on `"at "` on purpose — a platform whose frames are formatted differently would let an `"at "` check pass for the wrong reason, and this test runs on every platform in `commonTest`.

### Verification status — read this before approving

**Local verification did not run.** The shared build slot was held for a 20-minute job and my queued run was cancelled rather than left waiting. **CI is the verification of record for this PR**, and `jni-tests` runs the full `:ksrpc-test:jvmTest` including the new test.

I am flagging that rather than quietly relying on CI: nothing here has been executed on my machine, and the previous PR in this area needed four rounds because a targeted local run missed a contradicting test. The reviewer should treat the green checks as the evidence, not my say-so.
