### PR TITLE
Resolve the js/wasm npm graph in CI (#246)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,13 @@ jobs:
         run: ./gradlew licenseCheckForKotlin --continue
       - name: Check API compatibility
         run: ./gradlew apiCheck
+      # apiCheck compiles the js/wasmJs klibs but never resolves the npm graph,
+      # so a dependency whose `engines` exclude the toolchain's default Node
+      # passes every other check and breaks in a consumer's build instead. That
+      # is what shipped in 1.1.4 (nanoid 6 excludes Node 25) and was reverted in
+      # 1.1.5. This step is the check that would have caught it (#246).
+      - name: Resolve the js/wasm npm graph
+        run: ./gradlew kotlinNpmInstall kotlinWasmNpmInstall
 
   jvm-tests:
     # Pure-JVM modules. The JNI/native-backed jvmTest tasks


### PR DESCRIPTION
Fixes #246.

`apiCheck` compiles the js and wasmJs klibs — which is why CI catches a broken external binding — but **klibs do not npm-link**, so nothing in CI has ever resolved the npm dependency graph. A dependency whose `engines` exclude the toolchain's default Node passes every check this repo has and fails in a consumer's build instead.

Not hypothetical. 1.1.4 bumped npm `nanoid` to 6.0.0, whose `engines.node = "^22 || ^24 || >=26"` **excludes Node 25** — the default managed Node for Kotlin 2.4.10. It shipped green, broke a downstream consumer's wasm build, and was reverted in 1.1.5.

```yaml
- name: Resolve the js/wasm npm graph
  run: ./gradlew kotlinNpmInstall kotlinWasmNpmInstall
```

Placed in the `lint` job beside `apiCheck` rather than in a new job — same class of check, and the runner is already warm.

### The open question in the issue, and why I took this side

#246 asked always-run versus label-gated, to save the Node provision on unrelated PRs. **Always-run**, because the failure it prevents reached a consumer, and because label-gating means it does not run on the PR that bumps the dependency — which is the only PR where it matters. A check that must be remembered on exactly the change it guards is not a check.

### The case against

It adds a Node download and a yarn resolve to a job that currently does no npm work, on every PR including documentation ones. If that turns out to cost real wall-clock, moving it behind a `paths:` filter on the catalog and the js/wasm sources would keep the protection where it matters — that is a smaller and better fallback than a label, and I would rather land this and measure than pre-optimise.

### Verification

**Not verified locally in this session** — the step's own behaviour was confirmed during the 1.1.5 work, where `kotlinWasmNpmInstall` was run against nanoid 5.1.16 on the Node-25 toolchain and passed, and against 6.0.0 where it failed. That is the positive and negative control for this check, from July, on this machine.

What is unverified here is that it works **on a GitHub runner**, which is exactly what the CI run on this PR establishes. If it needs a Node setup step the local box did not, this PR will say so rather than me guessing.
